### PR TITLE
Fix issue in #14

### DIFF
--- a/winutil.ps1
+++ b/winutil.ps1
@@ -1506,7 +1506,8 @@ foreach ($service in $services) {
 	Remove-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\WindowsUpdate\UX\Settings" -Name "BranchReadinessLevel" -ErrorAction SilentlyContinue
 	Remove-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\WindowsUpdate\UX\Settings" -Name "DeferFeatureUpdatesPeriodInDays" -ErrorAction SilentlyContinue
 	Remove-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\WindowsUpdate\UX\Settings" -Name "DeferQualityUpdatesPeriodInDays " -ErrorAction SilentlyContinue
-    
+})
+$WPFFixesUpdate.Add_Click({
     ### Reset Windows Update Script - reregister dlls, services, and remove registry entires.
     Write-Host "1. Stopping Windows Update Services..." 
     Stop-Service -Name BITS 


### PR DESCRIPTION
 - It seems that Chris forgot to add a button for the Repair Windows Update Script and accidentally put it under the Default Windows Update Settings button.
   - Fixed by adding the $WPFFixesUpdate.Add_Click function before the Reset Script
   - Fixes #14