### PR TITLE
Added Winget Check and Install

### DIFF
--- a/winutil.ps1
+++ b/winutil.ps1
@@ -619,6 +619,11 @@ $WPFinstall.Add_Click({
         $WPFInstallzoom.IsChecked = $false
     }    
 
+    # If Winget isn't Installed, Open MS Store Window to Install
+    if (!Get-AppPackage -name 'Microsoft.DesktopAppInstaller') {
+        Start-Process "ms-windows-store://pdp/?ProductId=9NBLGGH4NNS1"
+        $nid = (Get-Process AppInstaller).Id; Wait-Process -Id $nid
+    }
     # Install all winget programs in new window
     $wingetinstall.ToArray()
     # Define Output variable


### PR DESCRIPTION
- Added Winget check that uses ms-windows-store instead of ms-appinstaller because of CVE-2021-43890