### PR TITLE
Fix bug in #39

### DIFF
--- a/winutil.ps1
+++ b/winutil.ps1
@@ -1399,7 +1399,7 @@ $WPFFixesUpdate.Add_Click({
         Get-BitsTransfer | Remove-BitsTransfer 
     
         Write-Host "10) Attempting to install the Windows Update Agent..." 
-        If ($arch -eq 64) { 
+        If (!((wmic OS get OSArchitecture | Out-String).IndexOf("64") -eq -1)) { 
             wusa Windows8-RT-KB2937636-x64 /quiet 
         }
         else { 


### PR DESCRIPTION
- Closes #39
  - $arch is not set to a value in the script; thus it throws an error when the If-Statement is called
    - Fixed by replacing the $arch variable check with a wmic check