### PR TITLE
Fix and Tweak #19

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -197,6 +197,7 @@
 							<Button Name="FeatureInstall" FontSize="14" Background="AliceBlue" Content="Install Features" Margin="20,5,20,0" Padding="10"/>
 							<Label Content="Fixes" FontSize="16"/>
 							<Button Name="FixesUpdate" FontSize="14" Background="AliceBlue" Content="Reset Windows Update" Margin="20,5,20,0" Padding="10"/>
+							<Button Name="PanelDISM" FontSize="14" Background="AliceBlue" Content="System Corruption Scan" Margin="20,5,20,0" Padding="10"/>
 
 						</StackPanel>
 						<StackPanel Background="#777777" SnapsToDevicePixels="True" Grid.Column="1" Margin="10,5">

--- a/winutil.ps1
+++ b/winutil.ps1
@@ -1200,7 +1200,7 @@ $WPFPanelDISM.Add_Click({
         Write-Host '`n(2/4) SFC - 1st scan' -ForegroundColor Green; sfc /scannow;
         Write-Host '`n(3/4) DISM' -ForegroundColor Green; DISM /Online /Cleanup-Image /Restorehealth; 
         Write-Host '`n(4/4) SFC - 2nd scan' -ForegroundColor Green; sfc /scannow; 
-        Read-Host '`nPress Enter'" -verb runas
+        Read-Host '`nPress Enter to Continue'" -verb runas
     })
 
 $WPFPanelcontrol.Add_Click({

--- a/winutil.ps1
+++ b/winutil.ps1
@@ -1196,11 +1196,11 @@ $WPFFeatureInstall.Add_Click({
     })
 
 $WPFPanelDISM.Add_Click({
-        Start-Process PowerShell -ArgumentList 'Write-Host "Chkdsk" -ForegroundColor Green; Chkdsk; 
-Write-Host "SFC - 1st scan" -ForegroundColor Green; sfc /scannow;
-Write-Host "DISM" -ForegroundColor Green; DISM /Online /Cleanup-Image /Restorehealth; 
-Write-Host "SFC - 2nd scan" -ForegroundColor Green; sfc /scannow; 
-Read-Host "Press Enter"' -verb runas
+        Start-Process PowerShell -ArgumentList "Write-Host '(1/4) Chkdsk' -ForegroundColor Green; Chkdsk /scan; 
+        Write-Host '`n(2/4) SFC - 1st scan' -ForegroundColor Green; sfc /scannow;
+        Write-Host '`n(3/4) DISM' -ForegroundColor Green; DISM /Online /Cleanup-Image /Restorehealth; 
+        Write-Host '`n(4/4) SFC - 2nd scan' -ForegroundColor Green; sfc /scannow; 
+        Read-Host '`nPress Enter'" -verb runas
     })
 
 $WPFPanelcontrol.Add_Click({


### PR DESCRIPTION
- Pull Request #19 didn't add an entry for PanelDISM into MainWindow.xaml, causing an error to be thrown when the script is executed and a button to not be created
  - Fixed by adding an entry into MainWIndow.xaml that creates the needed button under the FixesUpdate button
  - Note: To see the fix, you need to comment line 9 and uncomment line 8 to use the local MainWindow.xaml instead of the one in the Main Branch
- Fixed formatting
- Added /scan to chkdsk so it attempts to fix corruption on online drives
- Tweaked Write-Host's
  - Added newlines (`n) to space out the Statuses
  - Added progress indicators
    - Required "s and 's to be swapped so x/4 does not perform an operation