### PR TITLE
Arguments

### DIFF
--- a/winutil-test.ps1
+++ b/winutil-test.ps1
@@ -1301,17 +1301,17 @@ $xaml.SelectNodes("//*[@Name]") | ForEach-Object {$global:sync["$("$($_.Name)")"
 # Arguments
 If($env:args){
     Write-Host "Arguments Detected, Running Args"
-    If($env:args -match '\bInstallUpgrade\b'){Invoke-Runspace $InstallUpgrade}
-    If($env:args -match '\bUndoTweaks\b'){Invoke-Runspace $undotweaks}
+    If($env:args -match '\bInstallUpgrade\b'){Invoke-Command -scriptblock $InstallUpgrade}
+    If($env:args -match '\bUndoTweaks\b'){Invoke-Command -scriptblock $undotweaks}
     If($env:args -match '\bPanelControl\b'){cmd /c control}
     If($env:args -match '\bPanelNetwork\b'){cmd /c ncpa.cpl}
     If($env:args -match '\bPanelPower\b'){cmd /c powercfg.cpl}
     If($env:args -match '\bPanelSound\b'){cmd /c mmsys.cpl}
     If($env:args -match '\bPanelSystem\b'){cmd /c sysdm.cpl}
     If($env:args -match '\bPanelUser\b'){cmd /c "control userpasswords2"}
-    If($env:args -match '\bDefaultUpdates\b'){Invoke-Runspace $Updatesdefault}
-    If($env:args -match '\bDisableUpdates\b'){Invoke-Runspace $Updatesdisable}
-    If($env:args -match '\bEnableSecurity\b'){Invoke-Runspace $Updatessecurity}
+    If($env:args -match '\bDefaultUpdates\b'){Invoke-Command -scriptblock $Updatesdefault}
+    If($env:args -match '\bDisableUpdates\b'){Invoke-Command -scriptblock $Updatesdisable}
+    If($env:args -match '\bEnableSecurity\b'){Invoke-Command -scriptblock $Updatessecurity}
     If($env:args -match '\bQuitAfter\b'){Break}
 }
 

--- a/winutil-test.ps1
+++ b/winutil-test.ps1
@@ -1300,7 +1300,7 @@ $xaml.SelectNodes("//*[@Name]") | ForEach-Object {$global:sync["$("$($_.Name)")"
 
 # Arguments
 If($env:args){
-    Write-Host "Arguments Detected, Running Args"
+    Write-Verbose "Arguments Detected, Running Args"
     If($env:args -match '\bInstallUpgrade\b'){Invoke-Command -scriptblock $InstallUpgrade}
     If($env:args -match '\bUndoTweaks\b'){Invoke-Command -scriptblock $undotweaks}
     If($env:args -match '\bPanelControl\b'){cmd /c control}
@@ -1313,6 +1313,11 @@ If($env:args){
     If($env:args -match '\bDisableUpdates\b'){Invoke-Command -scriptblock $Updatesdisable}
     If($env:args -match '\bEnableSecurity\b'){Invoke-Command -scriptblock $Updatessecurity}
     If($env:args -match '\bQuitAfter\b'){Break}
+    If($env:args -match '\bInstall\b'){
+        $ProgramstoInstall = (($env:args-split " " | Where-Object {$_ -like "install*"} ) -split ":")[1]
+        Write-Verbose "Installing $ProgramstoInstall."
+        Invoke-Command -scriptblock  $sync.ScriptsInstallPrograms -ArgumentList $ProgramstoInstall
+    }
 }
 
 # Create Form

--- a/winutil-test.ps1
+++ b/winutil-test.ps1
@@ -26,7 +26,22 @@
         $inputXML = (new-object Net.WebClient).DownloadString("https://raw.githubusercontent.com/ChrisTitusTech/winutil/main/MainWindow.xaml")
         $global:sync["applications"] = Invoke-RestMethod "https://raw.githubusercontent.com/ChrisTitusTech/winutil/test/applications.json"
     }
-        
+
+    If($env:args){Write-Host "Arguments Detected, Running Args";
+        If($env:args -match "InstallUpgrade"){Invoke-Runspace $InstallUpgrade}
+        If($env:args -match "UndoTweaks"){Invoke-Runspace $undotweaks}
+        If($env:args -match "PanelControl"){cmd /c control}
+        If($env:args -match "PanelNetwork"){cmd /c ncpa.cpl}
+        If($env:args -match "PanelPower"){cmd /c powercfg.cpl}
+        If($env:args -match "PanelSound"){cmd /c mmsys.cpl}
+        If($env:args -match "PanelSystem"){cmd /c sysdm.cpl}
+        If($env:args -match "PanelUser"){cmd /c "control userpasswords2"}
+        If($env:args -match "DefaultUpdates"){Invoke-Runspace $Updatesdefault}
+        If($env:args -match "DisableUpdates"){Invoke-Runspace $Updatesdisable}
+        If($env:args -match "EnableSecurity"){Invoke-Runspace $Updatessecurity}
+        If($env:args -match "QuitAfter"){Break}
+    }
+
     $inputXML = $inputXML -replace 'mc:Ignorable="d"','' -replace "x:N",'N' -replace '^<Win.*', '<Window'
     [xml]$XAML = $inputXML
     $reader=(New-Object System.Xml.XmlNodeReader $xaml) 

--- a/winutil-test.ps1
+++ b/winutil-test.ps1
@@ -27,21 +27,6 @@
         $global:sync["applications"] = Invoke-RestMethod "https://raw.githubusercontent.com/ChrisTitusTech/winutil/test/applications.json"
     }
 
-    If($env:args){Write-Host "Arguments Detected, Running Args";
-        If($env:args -match '\bInstallUpgrade\b'){Invoke-Runspace $InstallUpgrade}
-        If($env:args -match '\bUndoTweaks\b'){Invoke-Runspace $undotweaks}
-        If($env:args -match '\bPanelControl\b'){cmd /c control}
-        If($env:args -match '\bPanelNetwork\b'){cmd /c ncpa.cpl}
-        If($env:args -match '\bPanelPower\b'){cmd /c powercfg.cpl}
-        If($env:args -match '\bPanelSound\b'){cmd /c mmsys.cpl}
-        If($env:args -match '\bPanelSystem\b'){cmd /c sysdm.cpl}
-        If($env:args -match '\bPanelUser\b'){cmd /c "control userpasswords2"}
-        If($env:args -match '\bDefaultUpdates\b'){Invoke-Runspace $Updatesdefault}
-        If($env:args -match '\bDisableUpdates\b'){Invoke-Runspace $Updatesdisable}
-        If($env:args -match '\bEnableSecurity\b'){Invoke-Runspace $Updatessecurity}
-        If($env:args -match '\bQuitAfter\b'){Break}
-    }
-
     $inputXML = $inputXML -replace 'mc:Ignorable="d"','' -replace "x:N",'N' -replace '^<Win.*', '<Window'
     [xml]$XAML = $inputXML
     $reader=(New-Object System.Xml.XmlNodeReader $xaml) 
@@ -1313,4 +1298,22 @@ $xaml.SelectNodes("//*[@Name]") | ForEach-Object {$global:sync["$("$($_.Name)")"
 
 #endregion scripts
 
+# Arguments
+If($env:args){
+    Write-Host "Arguments Detected, Running Args"
+    If($env:args -match '\bInstallUpgrade\b'){Invoke-Runspace $InstallUpgrade}
+    If($env:args -match '\bUndoTweaks\b'){Invoke-Runspace $undotweaks}
+    If($env:args -match '\bPanelControl\b'){cmd /c control}
+    If($env:args -match '\bPanelNetwork\b'){cmd /c ncpa.cpl}
+    If($env:args -match '\bPanelPower\b'){cmd /c powercfg.cpl}
+    If($env:args -match '\bPanelSound\b'){cmd /c mmsys.cpl}
+    If($env:args -match '\bPanelSystem\b'){cmd /c sysdm.cpl}
+    If($env:args -match '\bPanelUser\b'){cmd /c "control userpasswords2"}
+    If($env:args -match '\bDefaultUpdates\b'){Invoke-Runspace $Updatesdefault}
+    If($env:args -match '\bDisableUpdates\b'){Invoke-Runspace $Updatesdisable}
+    If($env:args -match '\bEnableSecurity\b'){Invoke-Runspace $Updatessecurity}
+    If($env:args -match '\bQuitAfter\b'){Break}
+}
+
+# Create Form
 $global:sync["Form"].ShowDialog() | out-null

--- a/winutil-test.ps1
+++ b/winutil-test.ps1
@@ -28,18 +28,18 @@
     }
 
     If($env:args){Write-Host "Arguments Detected, Running Args";
-        If($env:args -match "InstallUpgrade"){Invoke-Runspace $InstallUpgrade}
-        If($env:args -match "UndoTweaks"){Invoke-Runspace $undotweaks}
-        If($env:args -match "PanelControl"){cmd /c control}
-        If($env:args -match "PanelNetwork"){cmd /c ncpa.cpl}
-        If($env:args -match "PanelPower"){cmd /c powercfg.cpl}
-        If($env:args -match "PanelSound"){cmd /c mmsys.cpl}
-        If($env:args -match "PanelSystem"){cmd /c sysdm.cpl}
-        If($env:args -match "PanelUser"){cmd /c "control userpasswords2"}
-        If($env:args -match "DefaultUpdates"){Invoke-Runspace $Updatesdefault}
-        If($env:args -match "DisableUpdates"){Invoke-Runspace $Updatesdisable}
-        If($env:args -match "EnableSecurity"){Invoke-Runspace $Updatessecurity}
-        If($env:args -match "QuitAfter"){Break}
+        If($env:args -match '\bInstallUpgrade\b'){Invoke-Runspace $InstallUpgrade}
+        If($env:args -match '\bUndoTweaks\b'){Invoke-Runspace $undotweaks}
+        If($env:args -match '\bPanelControl\b'){cmd /c control}
+        If($env:args -match '\bPanelNetwork\b'){cmd /c ncpa.cpl}
+        If($env:args -match '\bPanelPower\b'){cmd /c powercfg.cpl}
+        If($env:args -match '\bPanelSound\b'){cmd /c mmsys.cpl}
+        If($env:args -match '\bPanelSystem\b'){cmd /c sysdm.cpl}
+        If($env:args -match '\bPanelUser\b'){cmd /c "control userpasswords2"}
+        If($env:args -match '\bDefaultUpdates\b'){Invoke-Runspace $Updatesdefault}
+        If($env:args -match '\bDisableUpdates\b'){Invoke-Runspace $Updatesdisable}
+        If($env:args -match '\bEnableSecurity\b'){Invoke-Runspace $Updatessecurity}
+        If($env:args -match '\bQuitAfter\b'){Break}
     }
 
     $inputXML = $inputXML -replace 'mc:Ignorable="d"','' -replace "x:N",'N' -replace '^<Win.*', '<Window'


### PR DESCRIPTION
- Closes #51
- Depends on #67
- Using $env:args, the script scans for arguments; then if found, Invokes the codeblock associated with said arg.
  - \b is to prevent mutual words from causing issues (Ex: Install and InstallUpgrade would conflict without \b)

This will be expanded for the rest of the script as the script restructure for runspaces is finished.