### PR TITLE
Runspaces using jobs

### DIFF
--- a/winutil-test.ps1
+++ b/winutil-test.ps1
@@ -767,8 +767,8 @@ $xaml.SelectNodes("//*[@Name]") | ForEach-Object {$global:sync["$("$($_.Name)")"
     }
 
     $undotweaks = {
-        [System.Windows.MessageBox]::Show("UNDOALL THE THINGS",'Tweaks will be undone!',"OK","Info")
-        <#TODO Get this to run in an elevated prompt if not already.
+        #[System.Windows.MessageBox]::Show("UNDOALL THE THINGS",'Tweaks will be undone!',"OK","Info")
+        #TODO Get this to run in an elevated prompt if not already.
 
         Write-Host "Creating Restore Point incase something bad happens"
         Enable-ComputerRestore -Drive "C:\"
@@ -897,8 +897,8 @@ $xaml.SelectNodes("//*[@Name]") | ForEach-Object {$global:sync["$("$($_.Name)")"
         Write-Host "Done - Reverted to Stock Settings"
     
         Write-Host "Essential Undo Completed"
-        #>
-        [System.Windows.MessageBox]::Show("Done",'Undo All',"OK","Info")
+        
+        #[System.Windows.MessageBox]::Show("Done",'Undo All',"OK","Info")
     }
     #===========================================================================
     # Tab 3 - Config Buttons


### PR DESCRIPTION
A possible alternative to #67 as its implementation was running into weird issues

Benefits of using jobs over the other method:
  - More readable code
  - Doesn't have the weird issue causing things to freeze
  - Easier to troubleshoot

To Do:
  - [ ] All scripts working with jobs
    - [x] installPrograms
      - [ ] Make status button work
    - [ ] InstallUpgrade
    - [x] tweaks
    - [x] undotweaks
    - [ ] features
    - [ ] Updatesdefault
    - [ ] Updatesdisable
    - [ ] Updatessecurity
  - [ ] Make sure arguments work
  - [ ] Notify user
    - [ ] Figure out how to print to console
    - [ ] Replace Message Boxes with forms
  - [ ] Remove stuff that doesn't work within a job
  - [ ] Maybe fix function name formatting as it is a bit all over the place