### PR TITLE
Translucenttb Installation fixed

### DIFF
--- a/winutil.ps1
+++ b/winutil.ps1
@@ -203,7 +203,7 @@ $WPFinstall.Add_Click({
             $WPFInstallterminal.IsChecked = $false
         }
         If ( $WPFInstallttaskbar.IsChecked -eq $true ) { 
-            $wingetinstall.Add("TranslucentTB.TranslucentTB")
+            $wingetinstall.Add("Translucenttb.Translucenttb")
             $WPFInstallttaskbar.IsChecked = $false
         }
         If ( $WPFInstallvlc.IsChecked -eq $true ) { 


### PR DESCRIPTION
I found out the 'TB' at the end should be in small letter s or else winget dosent install it. 