### PR TITLE
Add a check for $isLinux

### DIFF
--- a/winutil-test.ps1
+++ b/winutil-test.ps1
@@ -5,6 +5,11 @@
    Version 0.0.1
 #>
 
+if ($IsLinux){ # PowerShell on Linux has that read-only bool variable set to $true
+   Write-Host "This utility is exclusively designed for Windows"
+   return
+}
+
 #region Variables
     $global:sync = [Hashtable]::Synchronized(@{})
 


### PR DESCRIPTION
This is a very simple if statement, I don't think there's much to explain

```PowerShell
if ($IsLinux){ # PowerShell on Linux has that read-only bool variable set to $true
   Write-Host "This utility is exclusively designed for Windows"
   return
}
```