### PR TITLE
Added Disable UAC

### DIFF
--- a/winutil.ps1
+++ b/winutil.ps1
@@ -539,6 +539,7 @@ $WPFdesktop.Add_Click({
         $WPFMiscTweaksNum.IsChecked = $true
         $WPFMiscTweaksLapPower.IsChecked = $false
         $WPFMiscTweaksLapNum.IsChecked = $false
+        $WPFMiscTweaksDisableUAC.IsChecked = $true
     })
 
 $WPFlaptop.Add_Click({
@@ -559,6 +560,7 @@ $WPFlaptop.Add_Click({
         $WPFMiscTweaksLapNum.IsChecked = $true
         $WPFMiscTweaksPower.IsChecked = $false
         $WPFMiscTweaksNum.IsChecked = $false
+        $WPFMiscTweaksDisableUAC.IsChecked = $true
     })
 
 $WPFminimal.Add_Click({
@@ -579,6 +581,7 @@ $WPFminimal.Add_Click({
         $WPFMiscTweaksNum.IsChecked = $false
         $WPFMiscTweaksLapPower.IsChecked = $false
         $WPFMiscTweaksLapNum.IsChecked = $false
+        $WPFMiscTweaksDisableUAC.IsChecked = $true
     })
 
 $WPFtweaksbutton.Add_Click({
@@ -631,6 +634,17 @@ $WPFtweaksbutton.Add_Click({
             curl.exe -ss "https://dl5.oo-software.com/files/ooshutup10/OOSU10.exe" -o OOSU10.exe
             ./OOSU10.exe ooshutup10.cfg /quiet
             $WPFEssTweaksOO.IsChecked = $false
+        }
+        If ( $WPFMiscTweaksDisableUAC.IsChecked -eq $true) {
+            Write-Host "Disabling UAC..."
+            # This below is the pussy mode which can break some apps. Please. Leave this on 1.
+            # below i will show a way to do it without breaking some Apps that check UAC. U need to be admin tho.
+            # Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System" -Name "EnableLUA" -Type DWord -Value 0
+            Set-ItemProperty -Path HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System -Name ConsentPromptBehaviorAdmin -Type DWord -Value 0 # Default is 5
+            # This will set the GPO Entry in Security so that Admin users elevate without any prompt while normal users still elevate and u can even leave it ennabled.
+            # It will just not bother u anymore
+
+            $WPFMiscTweaksDisableUAC.IsChecked = $false
         }
         If ( $WPFEssTweaksRP.IsChecked -eq $true ) {
             Write-Host "Creating Restore Point in case something bad happens"


### PR DESCRIPTION
Hello Chris,

What did i change?
So instead of using EnableLUA to 0, im using the Method of Disabling the Prompt for Admin Users.
What im doing here is changing HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System to 0 (5 is default)

Why do you ask?
Some tools tend to break or you maybe want someone else to use your PC.
It is annoying to be alerted by certain Programs to ,,Your UAC is turned off,, and this works around that completly.

Tldr
If you find a way to edit Group Policy via Powershell it makes this way Easier.
All im doing is changing this value here.
![image](https://user-images.githubusercontent.com/45071533/190228729-7ccba42a-0231-4dc7-b102-dc0136df853a.png)
