### PR TITLE
Add Nahimic Service

### DIFF
--- a/winutil.ps1
+++ b/winutil.ps1
@@ -699,6 +699,7 @@ $WPFtweaksbutton.Add_Click({
                 "MapsBroker"                                   # Downloaded Maps Manager
                 "MicrosoftEdgeElevationService"                # Another Edge Update Service
                 "MSDTC"                                        # Distributed Transaction Coordinator
+                "NahimicService"                               # Nahimic Service
                 #"ndu"                                          # Windows Network Data Usage Monitor (Disabling Breaks Task Manager Per-Process Network Monitoring)
                 "NetTcpPortSharing"                            # Net.Tcp Port Sharing Service
                 "PcaSvc"                                       # Program Compatibility Assistant Service


### PR DESCRIPTION
Added Nahimic Service to list of services to set to manual. Nahimic seems to provide little improvement to audio for some resources consumed and tends to cause issues with specific games. Comes preinstalled on lots of prebuilts and laptops.