### PR TITLE
Fix #265

### DIFF
--- a/winutil.ps1
+++ b/winutil.ps1
@@ -545,7 +545,17 @@ $WPFinstall.Add_Click({
             Write-Host "Winget Already Installed"
         }
         else {
-            if (((((Get-ComputerInfo).OSName.IndexOf("LTSC")) -ne -1) -or ((Get-ComputerInfo).OSName.IndexOf("Server") -ne -1)) -and (((Get-ComputerInfo).WindowsVersion) -ge "1809")) {
+            #Gets the computer's information
+            $ComputerInfo = Get-ComputerInfo
+
+            #Gets the Windows Edition
+            $OSName = if ($ComputerInfo.OSName) {
+                $ComputerInfo.OSName
+            }else {
+                $ComputerInfo.WindowsProductName
+            }
+
+            if (((($OSName.IndexOf("LTSC")) -ne -1) -or ($OSName.IndexOf("Server") -ne -1)) -and (($ComputerInfo.WindowsVersion) -ge "1809")) {
                 #Checks if Windows edition is LTSC/Server 2019+
                 #Manually Installing Winget
                 Write-Host "Running Alternative Installer for LTSC/Server Editions"


### PR DESCRIPTION
- Closes #265
  - Apparently, sometimes `OSName` in `Get-ComputerInfo` has no value
    - Checks if `OSName` has a value, and if not, uses `WindowsProductName` instead
- Also puts `Get-ComputerInfo` into a variable to prevent it from being called multiple times.