### PR TITLE
Add Toggle for System Dark Mode

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,24 @@
+name: Pester
+
+on: [push]
+
+jobs:
+  test:
+    runs-on: windows-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }}
+      - name: pester_tests
+        id: pester_tests
+        uses: zyborg/pester-tests-report@v1
+        with:
+          include_paths: pester
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: dump test results
+        shell: pwsh
+        run: |
+          Write-Host 'Total Tests Executed...:  ${{ steps.pester_tests.outputs.total_count }}'
+          Write-Host 'Total Tests PASSED.....:  ${{ steps.pester_tests.outputs.passed_count }}'
+          Write-Host 'Total Tests FAILED.....:  ${{ steps.pester_tests.outputs.failed_count }}'

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ winutil.pdb
 *.zip
 .vs/
 *.psd*
+pester.ps1

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -204,11 +204,11 @@
 							<Label FontSize="16" Content="Essential Tweaks"/>
 							<CheckBox Name="EssTweaksRP" Content="Create Restore Point" Margin="5,0" ToolTip="Creates a Windows Restore point before modifying system. Can use Windows System Restore to rollback to before tweaks were applied"/>
 							<CheckBox Name="EssTweaksOO" Content="Run OO Shutup" Margin="5,0" ToolTip="Runs OO Shutup from https://www.oo-software.com/en/shutup10"/>
-							<CheckBox Name="EssTweaksTele" Content="Disable Telemetry" Margin="5,0" ToolTip="Disables Microsoft Telemetry. Note: This will lock many Edge Browser settings. Microsoft spys heavily on you when using the Edge browser."/>
-							<CheckBox Name="EssTweaksWifi" Content="Disable Wifi-Sense" Margin="5,0" ToolTip="Wifi Sense is a spying service that phones home all nearby scaned wifi networks and your current geo location."/>
+							<CheckBox Name="EssTweaksTele" Content="Disable Telemetry" Margin="5,0" ToolTip="Disables Microsoft Telemetry. Note: This will lock many Edge Browser settings. Microsoft spies heavily on you when using the Edge browser."/>
+							<CheckBox Name="EssTweaksWifi" Content="Disable Wifi-Sense" Margin="5,0" ToolTip="Wifi Sense is a spying service that phones home all nearby scanned wifi networks and your current geo location."/>
 							<CheckBox Name="EssTweaksAH" Content="Disable Activity History" Margin="5,0" ToolTip="This erases recent docs, clipboard, and run history."/>
 							<CheckBox Name="EssTweaksDeleteTempFiles" Content="Delete Temporary Files" Margin="5,0" ToolTip="Erases TEMP Folders"/>
-							<CheckBox Name="EssTweaksDiskCleanup" Content="Run Disk Cleanup" Margin="5,0" ToolTip="Runs Disk Cleanup on Drive C: and removes old Windows Updates."/>
+							<CheckBox Name="EssTweaksDiskCleanup" Content="Run Disk Cleanup" Margin="5,0" ToolTip="Runs Disk Cleanup on Drive C: and removes old Windows updates."/>
 							<CheckBox Name="EssTweaksLoc" Content="Disable Location Tracking" Margin="5,0" ToolTip="Disables Location Tracking...DUH!"/>
 							<CheckBox Name="EssTweaksHome" Content="Disable Homegroup" Margin="5,0" ToolTip="Disables HomeGroup - Windows 11 doesn't have this, it was awful."/>
 							<CheckBox Name="EssTweaksStorage" Content="Disable Storage Sense" Margin="5,0" ToolTip="Storage Sense is supposed to delete temp files automatically, but can run at active times and mostly doesn't do much. Although when it was introduced in Win 10 (1809 Version) it deleted people's documents... So there is that."/>

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -216,8 +216,10 @@
 							<CheckBox Name="EssTweaksDVR" Content="Disable GameDVR" Margin="5,0" ToolTip="GameDVR is a Windows App that is a dependancy for some Store Games. I've never met someone that likes it, but it's there for the XBOX crowd."/>
 							<CheckBox Name="EssTweaksServices" Content="Set Services to Manual" Margin="5,0" ToolTip="Turns a bunch of system services to manual that don't need to be running all the time. This is pretty harmless as if the service is needed, it will simply start on demand."/>
 							<Label Content="Dark Theme" />
-							<Button Name="EnableDarkMode" Background="AliceBlue" Content="Enable" Margin="60,0" />
-							<Button Name="DisableDarkMode" Background="AliceBlue" Content="Disable" Margin="60,0"/>
+							<Button Name="EnableDarkMode" Background="AliceBlue" Content="Enable Apps Dark Mode" Margin="60,0" />
+							<Button Name="EnableDarkModeSystem" Background="AliceBlue" Content="Enable System Dark Mode" Margin="60,0" />
+							<Button Name="DisableDarkModeSystem" Background="AliceBlue" Content="Disable System Dark Mode" Margin="60,0"/>
+							<Button Name="DisableDarkMode" Background="AliceBlue" Content="Disable Apps Dark Mode" Margin="60,0"/>
 
 						</StackPanel>
 						<StackPanel Background="#777777" SnapsToDevicePixels="True" Grid.Row="2" Grid.Column="1" Margin="10,5">

--- a/config/applications.json
+++ b/config/applications.json
@@ -168,9 +168,6 @@
     "Installslack": {
       "winget": "SlackTechnologies.Slack"
     },
-    "Installspotify": {
-      "winget": "Spotify.Spotify"
-    },
     "Installsteam": {
       "winget": "Valve.Steam"
     },
@@ -287,6 +284,39 @@
     },
     "Installjdownloader": {
       "winget": "AppWork.JDownloader"
-    }        
+    },
+    "Installsimplewall": {
+      "Winget": "Henry++.simplewall"
+    },
+    "Installrustlang": {
+      "Winget": "Rustlang.Rust.MSVC"
+    },
+    "Installalacritty": {
+      "Winget": "Alacritty.Alacritty"
+    },
+    "Installkdenlive": {
+      "Winget": "KDE.Kdenlive"
+    },
+    "Installglaryutilities": {
+      "Winget": "Glarysoft.GlaryUtilities"
+    },
+    "Installtwinkletray": {
+      "Winget": "xanderfrangos.twinkletray"
+    },
+    "Installidm": {
+      "Winget": "Tonec.InternetDownloadManager"
+    },
+    "Installviber": {
+      "Winget": "Viber.Viber"
+    },
+    "Installgit": {
+      "Winget": "Git.Git"
+    },
+    "Installwiztree": {
+      "Winget": "AntibodySoftware.WizTree"
+    },
+    "Installtor": {
+      "Winget": "TorProject.TorBrowser"
+    }
   }
 }

--- a/pester/winutil.Tests.ps1
+++ b/pester/winutil.Tests.ps1
@@ -1,0 +1,203 @@
+#region Configurable Variables
+
+    <#
+        .NOTES
+        Use this section to configure testing variables. IE if the number of tabs change in the GUI update that variable here.
+        All variables need to be global to be passed between contexts
+
+    #>
+
+    $global:FormName = "Chris Titus Tech's Windows Utility"
+
+#endregion Configurable Variables
+
+#region Load Variables needed for testing
+
+    #Config Files
+    $global:application = get-content ./config/applications.json | ConvertFrom-Json 
+    $global:preset = get-content ./config/preset.json | ConvertFrom-Json 
+    $global:feature = get-content ./config/feature.json | ConvertFrom-Json 
+    $global:tweaks = get-content ./config/tweaks.json | ConvertFrom-Json 
+
+    #GUI
+    $global:sync = [Hashtable]::Synchronized(@{})
+    $global:inputXML = get-content MainWindow.xaml
+    $global:inputXML = $global:inputXML -replace 'mc:Ignorable="d"', '' -replace "x:N", 'N' -replace '^<Win.*', '<Window'
+    [xml]$global:XAML = $global:inputXML
+    [void][System.Reflection.Assembly]::LoadWithPartialName('presentationframework')
+    $global:reader = (New-Object System.Xml.XmlNodeReader $global:xaml) 
+    $global:sync["Form"] = [Windows.Markup.XamlReader]::Load( $global:reader )
+    $global:xaml.SelectNodes("//*[@Name]") | ForEach-Object {$sync["$("$($psitem.Name)")"] = $sync["Form"].FindName($psitem.Name)}
+
+    #Variables to compare GUI to config files
+    $Global:GUIFeatureCount = ($global:feature.psobject.members | Where-Object {$psitem.MemberType -eq "NoteProperty"}).count
+    $Global:GUITabCount = ($global:sync["TabNav"].Items.name).count
+    $Global:GUIApplicationCount = ($global:application.install.psobject.members | Where-Object {$psitem.MemberType -eq "NoteProperty"}).count
+    $Global:GUITweaksCount = ($global:tweaks.psobject.members | Where-Object {$psitem.MemberType -eq "NoteProperty"}).count
+
+    #dotsource original script to pull in all variables and ensure no errors
+    $script = Get-Content .\winutil.ps1
+    $output = $script[0..($script.count - 2)] | Out-File .\pester.ps1    
+
+#endregion Load Variables needed for testing 
+
+#===========================================================================
+# Tests - Json
+#===========================================================================
+
+Describe "Json Files" {
+    Context "Application installs" {
+        It "Imports with no errors" {
+            $global:application | should -Not -BeNullOrEmpty
+        }
+        It "Json should be in correct format" {
+            $winget = $global:application.install.psobject.members | Where-Object {$psitem.MemberType -eq "NoteProperty"} | Select-Object Name,Value
+            $winget.name | should -BeLike "*Install*"
+            $winget.winget | should -Not -BeNullOrEmpty
+        }
+    } 
+
+    Context "Preset" {
+        It "Imports with no errors" {
+            $global:preset | should -Not -BeNullOrEmpty
+        }
+        It "Json should be in correct format" {
+            $preset = $global:preset.psobject.members | Where-Object {$psitem.MemberType -eq "NoteProperty"} | Select-Object Name,Value
+            $preset.name | should -Not -BeNullOrEmpty
+            $preset.Value | should -BeLike "*Tweaks*"
+        }
+    } 
+
+    Context "feature" {
+        It "Imports with no errors" {
+            $global:feature | should -Not -BeNullOrEmpty
+        }
+        It "Json should be in correct format" {
+            $feature = $global:feature.psobject.members | Where-Object {$psitem.MemberType -eq "NoteProperty"} | Select-Object Name,Value
+            $feature.name | should -BeLike "*Feature*"
+            $feature.Value | should -Not -BeNullOrEmpty
+        }
+    } 
+    
+    Context "tweaks" {
+        It "Imports with no errors" {
+            $global:tweaks | should -Not -BeNullOrEmpty
+        }
+        It "Json should be in correct format" {
+            $tweaks = $global:tweaks.psobject.members | Where-Object {$psitem.MemberType -eq "NoteProperty"} | Select-Object Name,Value
+            $tweaks.name | should -BeLike "*Tweaks*"
+            $tweaks.Value.registry | should -Not -BeNullOrEmpty
+            $tweaks.Value.Service | should -Not -BeNullOrEmpty
+            $tweaks.Value.ScheduledTask | should -Not -BeNullOrEmpty
+            $tweaks.Value.Appx | should -Not -BeNullOrEmpty
+            $tweaks.Value.InvokeScript | should -Not -BeNullOrEmpty
+        }
+        It "Original Values should be set" {
+            $tweaks = $global:tweaks.psobject.members | Where-Object {$psitem.MemberType -eq "NoteProperty"} | Select-Object Name,Value
+
+            Foreach($tweak in $tweaks){
+                if($tweak.value.registry){
+
+                    $values = $tweak.value | Select-Object -ExpandProperty registry
+
+                    Foreach ($value in $values){
+                        $value.OriginalValue | should -Not -BeNullOrEmpty
+                    }  
+                }
+                if($tweak.value.Service){
+
+                    $values = $tweak.value | Select-Object -ExpandProperty Service
+
+                    Foreach ($value in $values){
+                        $value.OriginalType | should -Not -BeNullOrEmpty
+                    }  
+                }
+                if($tweak.value.ScheduledTask){
+
+                    $values = $tweak.value | Select-Object -ExpandProperty ScheduledTask
+
+                    Foreach ($value in $values){
+                        $value.OriginalState | should -Not -BeNullOrEmpty
+                    }  
+                }
+            }
+        }
+    } 
+}
+
+#===========================================================================
+# Tests - GUI
+#===========================================================================
+
+Describe "GUI" {
+
+    Context "XML" {
+        It "Imports with no errors" {
+            $global:XAML | should -Not -BeNullOrEmpty
+        }
+        It "Title should be $global:FormName" {
+            $global:XAML.window.Title | should -Be $global:FormName
+        }
+    }
+
+    Context "Form" {
+        It "Imports with no errors" {
+            $global:sync["Form"] | should -Not -BeNullOrEmpty
+        }
+        It "Title should match XML" {
+            $global:sync["Form"].title | should -Be $global:XAML.window.Title
+        }
+        It "Tabs should be $Global:GUITabCount" {
+            ($global:sync.keys | Where-Object {$psitem -like "Tab?"}).count | should -Be $Global:GUITabCount
+        }
+        It "Features should be $Global:GUIFeatureCount" {
+            ($global:sync.keys | Where-Object {
+                $psitem -like "*feature*" -and 
+                $psitem -notlike "FeatureInstall"
+            }).count | should -Be $Global:GUIFeatureCount
+        }
+        It "Applications should be $Global:GUIApplicationCount" {
+            ($global:sync.keys | Where-Object {
+                $psitem -like "*Install*" -and 
+                $psitem -notlike "Install" -and
+                $psitem -notlike "InstallUpgrade" -and
+                $psitem -notlike "featureInstall"
+            }).count | should -Be $Global:GUIApplicationCount
+        }
+        It "Tweaks should be $Global:GUITweaksCount" {
+            ($global:sync.keys | Where-Object {
+                $psitem -like "*tweaks*" -and 
+                $psitem -notlike "tweaksbutton" 
+            }).count | should -Be $Global:GUITweaksCount
+        }
+    } 
+}
+
+#===========================================================================
+# Tests - GUI
+#===========================================================================
+
+Describe "GUI Functions" {
+
+    It "GUI should load with no errors" {
+        . .\pester.ps1 
+        $WPFTab1BT | should -Not -BeNullOrEmpty
+        $WPFundoall | should -Not -BeNullOrEmpty
+        $WPFPanelDISM | should -Not -BeNullOrEmpty
+        $WPFPanelAutologin | should -Not -BeNullOrEmpty
+        $WPFUpdatesdefault | should -Not -BeNullOrEmpty
+        $WPFFixesUpdate | should -Not -BeNullOrEmpty
+        $WPFUpdatesdisable | should -Not -BeNullOrEmpty
+        $WPFUpdatessecurity | should -Not -BeNullOrEmpty
+        $WPFFeatureInstall | should -Not -BeNullOrEmpty
+        $WPFundoall | should -Not -BeNullOrEmpty
+        $WPFDisableDarkMode | should -Not -BeNullOrEmpty
+        $WPFEnableDarkMode | should -Not -BeNullOrEmpty
+        $WPFtweaksbutton | should -Not -BeNullOrEmpty
+        $WPFminimal | should -Not -BeNullOrEmpty
+        $WPFlaptop | should -Not -BeNullOrEmpty
+        $WPFdesktop | should -Not -BeNullOrEmpty
+        $WPFInstallUpgrade | should -Not -BeNullOrEmpty
+        $WPFinstall | should -Not -BeNullOrEmpty
+    }
+}

--- a/runspace.ps1
+++ b/runspace.ps1
@@ -1,5 +1,5 @@
 #for CI/CD
-$BranchToUse = 'main'
+$BranchToUse = 'hotfix/fixapplications'
 
 <#
 .NOTES

--- a/runspace.ps1
+++ b/runspace.ps1
@@ -1,5 +1,5 @@
 #for CI/CD
-$BranchToUse = 'main'
+$BranchToUse = 'feature/pester'
 
 <#
 .NOTES
@@ -1344,37 +1344,37 @@ write-host "====Chris Titus Tech====="
 write-host "=====Windows Toolbox====="
 
 if($gui -eq $true){
-$inputXML = $inputXML -replace 'mc:Ignorable="d"','' -replace "x:N",'N' -replace '^<Win.*', '<Window'
-[xml]$XAML = $inputXML
-$reader=(New-Object System.Xml.XmlNodeReader $xaml) 
+    $inputXML = $inputXML -replace 'mc:Ignorable="d"','' -replace "x:N",'N' -replace '^<Win.*', '<Window'
+    [xml]$XAML = $inputXML
+    $reader=(New-Object System.Xml.XmlNodeReader $xaml) 
 
-try{$sync["Form"]=[Windows.Markup.XamlReader]::Load( $reader )}
-catch [System.Management.Automation.MethodInvocationException] {
-    Write-Warning "We ran into a problem with the XAML code.  Check the syntax for this control..."
-    write-host $error[0].Exception.Message -ForegroundColor Red
-    if ($error[0].Exception.Message -like "*button*"){
-        write-warning "Ensure your &lt;button in the `$inputXML does NOT have a Click=ButtonClick property.  PS can't handle this`n`n`n`n"}
-}
-catch{#if it broke some other way <img draggable="false" role="img" class="emoji" alt="ðŸ˜€" src="https://s0.wp.com/wp-content/mu-plugins/wpcom-smileys/twemoji/2/svg/1f600.svg">
-    Write-Host "Unable to load Windows.Markup.XamlReader. Double-check syntax and ensure .net is installed."
-}
+    try{$sync["Form"]=[Windows.Markup.XamlReader]::Load( $reader )}
+    catch [System.Management.Automation.MethodInvocationException] {
+        Write-Warning "We ran into a problem with the XAML code.  Check the syntax for this control..."
+        write-host $error[0].Exception.Message -ForegroundColor Red
+        if ($error[0].Exception.Message -like "*button*"){
+            write-warning "Ensure your &lt;button in the `$inputXML does NOT have a Click=ButtonClick property.  PS can't handle this`n`n`n`n"}
+    }
+    catch{#if it broke some other way <img draggable="false" role="img" class="emoji" alt="ðŸ˜€" src="https://s0.wp.com/wp-content/mu-plugins/wpcom-smileys/twemoji/2/svg/1f600.svg">
+        Write-Host "Unable to load Windows.Markup.XamlReader. Double-check syntax and ensure .net is installed."
+    }
 
-# Store Form Objects In PowerShell
-$xaml.SelectNodes("//*[@Name]") | ForEach-Object {$sync["$("$($psitem.Name)")"] = $sync["Form"].FindName($psitem.Name)}
+    # Store Form Objects In PowerShell
+    $xaml.SelectNodes("//*[@Name]") | ForEach-Object {$sync["$("$($psitem.Name)")"] = $sync["Form"].FindName($psitem.Name)}
 
-#Gives every button the invoke-button function
-$sync.keys | ForEach-Object {
-    if($sync.$psitem){
-        if($($sync["$psitem"].GetType() | Select-Object -ExpandProperty Name) -eq "Button"){
-            $sync["$psitem"].Add_Click({
-                [System.Object]$Sender = $args[0]
-                Invoke-Button $Sender.name
-            })
+    #Gives every button the invoke-button function
+    $sync.keys | ForEach-Object {
+        if($sync.$psitem){
+            if($($sync["$psitem"].GetType() | Select-Object -ExpandProperty Name) -eq "Button"){
+                $sync["$psitem"].Add_Click({
+                    [System.Object]$Sender = $args[0]
+                    Invoke-Button $Sender.name
+                })
+            }
         }
     }
-}
 
-$sync["Form"].ShowDialog() | out-null
+    $sync["Form"].ShowDialog() | out-null
 }
 
 <#

--- a/runspace.ps1
+++ b/runspace.ps1
@@ -1,5 +1,5 @@
 #for CI/CD
-$BranchToUse = 'hotfix/fixapplications'
+$BranchToUse = 'main'
 
 <#
 .NOTES

--- a/runspace.ps1
+++ b/runspace.ps1
@@ -1,5 +1,5 @@
 #for CI/CD
-$BranchToUse = 'feature/pester'
+$BranchToUse = 'main'
 
 <#
 .NOTES

--- a/winutil.ps1
+++ b/winutil.ps1
@@ -1,5 +1,5 @@
 #for CI/CD
-$BranchToUse = 'main'
+$BranchToUse = 'patch-1'
 <#
 .NOTES
    Author      : Chris Titus @christitustech
@@ -7,7 +7,7 @@ $BranchToUse = 'main'
     Version 0.0.1
 #>
 
-$inputXML = (new-object Net.WebClient).DownloadString("https://raw.githubusercontent.com/ChrisTitusTech/winutil/$BranchToUse/MainWindow.xaml") #uncomment for Production
+$inputXML = (new-object Net.WebClient).DownloadString("https://raw.githubusercontent.com/lavavex/winutil/patch-1/MainWindow.xaml") #uncomment for Production
 
 $inputXML = $inputXML -replace 'mc:Ignorable="d"', '' -replace "x:N", 'N' -replace '^<Win.*', '<Window'
 [void][System.Reflection.Assembly]::LoadWithPartialName('presentationframework')

--- a/winutil.ps1
+++ b/winutil.ps1
@@ -1396,7 +1396,7 @@ $WPFEnableDarkMode.Add_Click({
 $WPFEnableDarkModeSystem.Add_Click({
         Write-Host "Enabling System Dark Mode"
         $Theme = "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Themes\Personalize"
-        Set-ItemProperty $Theme SystemUseLightTheme -Value 0
+        Set-ItemProperty $Theme SystemUsesLightTheme -Value 0
         Write-Host "Enabled"
     }
 )
@@ -1404,7 +1404,7 @@ $WPFEnableDarkModeSystem.Add_Click({
 $WPFDisableDarkModeSystem.Add_Click({
         Write-Host "Disabling System Dark Mode"
         $Theme = "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Themes\Personalize"
-        Set-ItemProperty $Theme SystemUseLightTheme -Value 1
+        Set-ItemProperty $Theme SystemUsesLightTheme -Value 1
         Write-Host "Disabled"
     }
 )

--- a/winutil.ps1
+++ b/winutil.ps1
@@ -7,7 +7,7 @@ $BranchToUse = 'main'
     Version 0.0.1
 #>
 
-$inputXML = (new-object Net.WebClient).DownloadString("https://raw.githubusercontent.com/lavavex/winutil/$BranchToUse/MainWindow.xaml") #uncomment for Production
+$inputXML = (new-object Net.WebClient).DownloadString("https://raw.githubusercontent.com/ChrisTitusTech/winutil/$BranchToUse/MainWindow.xaml") #uncomment for Production
 
 $inputXML = $inputXML -replace 'mc:Ignorable="d"', '' -replace "x:N", 'N' -replace '^<Win.*', '<Window'
 [void][System.Reflection.Assembly]::LoadWithPartialName('presentationframework')
@@ -63,7 +63,7 @@ Function Get-FormVariables {
     #====DEBUG GUI Elements====
 
     #write-host "Found the following interactable elements from our form" -ForegroundColor Cyan
-    get-variable WPF*
+    #get-variable WPF*
 }
  
 Get-FormVariables

--- a/winutil.ps1
+++ b/winutil.ps1
@@ -63,7 +63,7 @@ Function Get-FormVariables {
     #====DEBUG GUI Elements====
 
     #write-host "Found the following interactable elements from our form" -ForegroundColor Cyan
-    #get-variable WPF*
+    get-variable WPF*
 }
  
 Get-FormVariables

--- a/winutil.ps1
+++ b/winutil.ps1
@@ -1,5 +1,5 @@
 #for CI/CD
-$BranchToUse = 'patch-1'
+$BranchToUse = 'main'
 <#
 .NOTES
    Author      : Chris Titus @christitustech
@@ -7,7 +7,7 @@ $BranchToUse = 'patch-1'
     Version 0.0.1
 #>
 
-$inputXML = (new-object Net.WebClient).DownloadString("https://raw.githubusercontent.com/lavavex/winutil/patch-1/MainWindow.xaml") #uncomment for Production
+$inputXML = (new-object Net.WebClient).DownloadString("https://raw.githubusercontent.com/lavavex/winutil/$BranchToUse/MainWindow.xaml") #uncomment for Production
 
 $inputXML = $inputXML -replace 'mc:Ignorable="d"', '' -replace "x:N", 'N' -replace '^<Win.*', '<Window'
 [void][System.Reflection.Assembly]::LoadWithPartialName('presentationframework')
@@ -1392,7 +1392,23 @@ $WPFEnableDarkMode.Add_Click({
         Write-Host "Enabled"
     }
 )
+
+$WPFEnableDarkModeSystem.Add_Click({
+        Write-Host "Enabling System Dark Mode"
+        $Theme = "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Themes\Personalize"
+        Set-ItemProperty $Theme SystemUseLightTheme -Value 0
+        Write-Host "Enabled"
+    }
+)
     
+$WPFDisableDarkModeSystem.Add_Click({
+        Write-Host "Disabling System Dark Mode"
+        $Theme = "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Themes\Personalize"
+        Set-ItemProperty $Theme SystemUseLightTheme -Value 1
+        Write-Host "Disabled"
+    }
+)
+
 $WPFDisableDarkMode.Add_Click({
         Write-Host "Disabling Dark Mode"
         $Theme = "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Themes\Personalize"

--- a/winutil.ps1
+++ b/winutil.ps1
@@ -274,9 +274,9 @@ $WPFinstall.Add_Click({
             $wingetinstall.Add("VSCodium.VSCodium")
             $WPFInstallvscodium.IsChecked = $false
         }
-        If ( $WPFInstallwinscp.IsChecked -eq $true ) { 
+        If ( $WPFInstallscp.IsChecked -eq $true ) { 
             $wingetinstall.Add("WinSCP.WinSCP")
-            $WPFInstallputty.IsChecked = $false
+            $WPFInstallscp.IsChecked = $false
         }
         If ( $WPFInstallanydesk.IsChecked -eq $true ) { 
             $wingetinstall.Add("AnyDeskSoftwareGmbH.AnyDesk")
@@ -527,9 +527,9 @@ $WPFinstall.Add_Click({
             $wingetinstall.Add("Apache.OpenOffice")
             $WPFInstallopenoffice.IsChecked = $false
         }
-        If ( $WPFInstallruskdesk.IsChecked -eq $true ) { 
+        If ( $WPFInstallrustdesk.IsChecked -eq $true ) { 
             $wingetinstall.Add("RustDesk.RustDesk")
-            $WPFInstallruskdesk.IsChecked = $false
+            $WPFInstallrustdesk.IsChecked = $false
         }
         If ( $WPFInstalljami.IsChecked -eq $true ) { 
             $wingetinstall.Add("SFLinux.Jami")


### PR DESCRIPTION
Adds toggle for System dark mode as well as App Dark mode to Tweaks. This is to fix issue #354 . Tested and Working on Windows 10 22H2. Was unable to figure out how to add the functionality to the current buttons so I made new buttons for system and renamed the current buttons to specify App dark mode. Feel free deny merge and do it better if you want as i have no clue how to use github properly and this is my first pull req. This was originally forked from main and it seems that some confilcts with main and test are present... The only edits i actually made were lines 219-222 in winutil.ps1 and lines 1395-1411 in MainWindow.xaml (sorry)
![000013](https://user-images.githubusercontent.com/27239435/200083359-4a175581-5234-423c-8703-43f056570625.png)
