### PR TITLE
Add Toggle for System Dark Mode

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -217,8 +217,6 @@
 							<CheckBox Name="EssTweaksServices" Content="Set Services to Manual" Margin="5,0" ToolTip="Turns a bunch of system services to manual that don't need to be running all the time. This is pretty harmless as if the service is needed, it will simply start on demand."/>
 							<Label Content="Dark Theme" />
 							<Button Name="EnableDarkMode" Background="AliceBlue" Content="Enable Apps Dark Mode" Margin="60,0" />
-							<Button Name="EnableDarkModeSystem" Background="AliceBlue" Content="Enable System Dark Mode" Margin="60,0" />
-							<Button Name="DisableDarkModeSystem" Background="AliceBlue" Content="Disable System Dark Mode" Margin="60,0"/>
 							<Button Name="DisableDarkMode" Background="AliceBlue" Content="Disable Apps Dark Mode" Margin="60,0"/>
 
 						</StackPanel>

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -216,8 +216,8 @@
 							<CheckBox Name="EssTweaksDVR" Content="Disable GameDVR" Margin="5,0" ToolTip="GameDVR is a Windows App that is a dependancy for some Store Games. I've never met someone that likes it, but it's there for the XBOX crowd."/>
 							<CheckBox Name="EssTweaksServices" Content="Set Services to Manual" Margin="5,0" ToolTip="Turns a bunch of system services to manual that don't need to be running all the time. This is pretty harmless as if the service is needed, it will simply start on demand."/>
 							<Label Content="Dark Theme" />
-							<Button Name="EnableDarkMode" Background="AliceBlue" Content="Enable Apps Dark Mode" Margin="60,0" />
-							<Button Name="DisableDarkMode" Background="AliceBlue" Content="Disable Apps Dark Mode" Margin="60,0"/>
+							<Button Name="EnableDarkMode" Background="AliceBlue" Content="Enable" Margin="60,0" />
+							<Button Name="DisableDarkMode" Background="AliceBlue" Content="Disable" Margin="60,0"/>
 
 						</StackPanel>
 						<StackPanel Background="#777777" SnapsToDevicePixels="True" Grid.Row="2" Grid.Column="1" Margin="10,5">

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -216,8 +216,10 @@
 							<CheckBox Name="EssTweaksDVR" Content="Disable GameDVR" Margin="5,0" ToolTip="GameDVR is a Windows App that is a dependancy for some Store Games. I've never met someone that likes it, but it's there for the XBOX crowd."/>
 							<CheckBox Name="EssTweaksServices" Content="Set Services to Manual" Margin="5,0" ToolTip="Turns a bunch of system services to manual that don't need to be running all the time. This is pretty harmless as if the service is needed, it will simply start on demand."/>
 							<Label Content="Dark Theme" />
-							<Button Name="EnableDarkMode" Background="AliceBlue" Content="Enable" Margin="60,0" />
-							<Button Name="DisableDarkMode" Background="AliceBlue" Content="Disable" Margin="60,0"/>
+							<Button Name="EnableDarkMode" Background="AliceBlue" Content="Enable Apps Dark Mode" Margin="60,0" />
+							<Button Name="EnableDarkModeSystem" Background="AliceBlue" Content="Enable System Dark Mode" Margin="60,0" />
+							<Button Name="DisableDarkModeSystem" Background="AliceBlue" Content="Disable System Dark Mode" Margin="60,0"/>
+							<Button Name="DisableDarkMode" Background="AliceBlue" Content="Disable Apps Dark Mode" Margin="60,0"/>
 
 						</StackPanel>
 						<StackPanel Background="#777777" SnapsToDevicePixels="True" Grid.Row="2" Grid.Column="1" Margin="10,5">

--- a/winutil.ps1
+++ b/winutil.ps1
@@ -1040,23 +1040,8 @@ $WPFEnableDarkMode.Add_Click({
         Write-Host "Enabling Dark Mode"
         $Theme = "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Themes\Personalize"
         Set-ItemProperty $Theme AppsUseLightTheme -Value 0
-        Write-Host "Enabled"
-    }
-)
-
-$WPFEnableDarkModeSystem.Add_Click({
-        Write-Host "Enabling System Dark Mode"
-        $Theme = "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Themes\Personalize"
         Set-ItemProperty $Theme SystemUsesLightTheme -Value 0
         Write-Host "Enabled"
-    }
-)
-    
-$WPFDisableDarkModeSystem.Add_Click({
-        Write-Host "Disabling System Dark Mode"
-        $Theme = "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Themes\Personalize"
-        Set-ItemProperty $Theme SystemUsesLightTheme -Value 1
-        Write-Host "Disabled"
     }
 )
 
@@ -1064,6 +1049,7 @@ $WPFDisableDarkMode.Add_Click({
         Write-Host "Disabling Dark Mode"
         $Theme = "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Themes\Personalize"
         Set-ItemProperty $Theme AppsUseLightTheme -Value 1
+        Set-ItemProperty $Theme SystemUsesLightTheme -Value 1
         Write-Host "Disabled"
     }
 )

--- a/winutil.ps1
+++ b/winutil.ps1
@@ -1035,7 +1035,7 @@ $WPFtweaksbutton.Add_Click({
 
         [System.Windows.MessageBox]::Show($Messageboxbody, $MessageboxTitle, $ButtonType, $MessageIcon)
     })
-
+    
 $WPFEnableDarkMode.Add_Click({
         Write-Host "Enabling Dark Mode"
         $Theme = "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Themes\Personalize"
@@ -1043,7 +1043,23 @@ $WPFEnableDarkMode.Add_Click({
         Write-Host "Enabled"
     }
 )
+
+$WPFEnableDarkModeSystem.Add_Click({
+        Write-Host "Enabling System Dark Mode"
+        $Theme = "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Themes\Personalize"
+        Set-ItemProperty $Theme SystemUsesLightTheme -Value 0
+        Write-Host "Enabled"
+    }
+)
     
+$WPFDisableDarkModeSystem.Add_Click({
+        Write-Host "Disabling System Dark Mode"
+        $Theme = "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Themes\Personalize"
+        Set-ItemProperty $Theme SystemUsesLightTheme -Value 1
+        Write-Host "Disabled"
+    }
+)
+
 $WPFDisableDarkMode.Add_Click({
         Write-Host "Disabling Dark Mode"
         $Theme = "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Themes\Personalize"


### PR DESCRIPTION
Adds toggle for System dark mode as well as App Dark mode to Tweaks. This is to fix issue https://github.com/ChrisTitusTech/winutil/issues/354 . Tested and Working on Windows 10 22H2. Was unable to figure out how to add the functionality to the current buttons so I made new buttons for system and renamed the current buttons to specify App dark mode. Feel free deny merge and do it better if you want as i have no clue how to use github properly and this is my first pull req. Fixed #357 (based on wrong branch sorry)
![000013](https://user-images.githubusercontent.com/27239435/200088489-bc85c9e5-1af3-45e1-9d4b-acb58cf52bf6.png)
