### PR TITLE
Fix multiple winget entry in json file

### DIFF
--- a/pester/winutil.Tests.ps1
+++ b/pester/winutil.Tests.ps1
@@ -193,8 +193,26 @@ Describe "GUI Functions" {
     It "Get-CheckBoxes Install should return data" {
         . .\pester.ps1 
 
-        $WPFInstallvc2015_32.ischecked = $true
-        (Get-CheckBoxes -Group WPFInstall) | should -Not -BeNullOrEmpty
-        $WPFInstallvc2015_32.ischecked | should -be $false
+        $TestCheckBoxes = @(
+            "WPFInstallvc2015_32"
+            "WPFInstallvscode"
+            "WPFInstallgit"
+        )
+        
+        $OutputResult = New-Object System.Collections.Generic.List[System.Object]
+        $TestCheckBoxes | ForEach-Object {
+
+            $global:configs.applications.Install.$psitem.winget -split ";" | ForEach-Object {
+                $OutputResult.Add($psitem)
+            }
+        }
+        $OutputResult = Sort-Object -InputObject $OutputResult
+
+        $TestCheckBoxes | ForEach-Object {(Get-Variable $PSItem).value.ischecked = $true}
+        $Output = Get-CheckBoxes -Group WPFInstall | Sort-Object
+        $Output | should -Not -BeNullOrEmpty -Because "Output did not containe applications to install"
+        $Output | Should -Not -Be $OutputResult -Because "Output contains duplicate values"
+        $Output | Should -Be $($OutputResult | Select-Object -Unique | Sort-Object) -Because "Output doesn't match"
+        $TestCheckBoxes | ForEach-Object {(Get-Variable $PSItem).value.ischecked | should -be $false}
     }
 }

--- a/runspace.ps1
+++ b/runspace.ps1
@@ -1,5 +1,5 @@
 #for CI/CD
-$BranchToUse = 'test'
+$BranchToUse = 'main'
 
 <#
 .NOTES

--- a/runspace.ps1
+++ b/runspace.ps1
@@ -1,5 +1,5 @@
 #for CI/CD
-$BranchToUse = 'main'
+$BranchToUse = 'hotfix/applications'
 
 <#
 .NOTES

--- a/winutil.ps1
+++ b/winutil.ps1
@@ -1,5 +1,5 @@
 #for CI/CD
-$BranchToUse = 'main'
+$BranchToUse = 'hotfix/applications'
 <#
 .NOTES
    Author      : Chris Titus @christitustech

--- a/winutil.ps1
+++ b/winutil.ps1
@@ -1,5 +1,5 @@
 #for CI/CD
-$BranchToUse = 'hotfix/applications'
+$BranchToUse = 'main'
 <#
 .NOTES
    Author      : Chris Titus @christitustech
@@ -117,12 +117,12 @@ Function Get-CheckBoxes {
 
     if($Group -eq "WPFInstall"){
         Foreach ($CheckBox in $CheckBoxes){
-            if($checkbox.value.ischecked -eq $true){
-                $configs.applications.install.$($checkbox.name).winget -split ";" | ForEach-Object {
-                    $output.Add($psitem)
+            if($CheckBox.value.ischecked -eq $true){
+                $Configs.applications.install.$($CheckBox.name).winget -split ";" | ForEach-Object {
+                    $Output.Add($psitem)
                 }
                 
-                $checkbox.value.ischecked = $false
+                $CheckBox.value.ischecked = $false
             }
         }
     }

--- a/winutil.ps1
+++ b/winutil.ps1
@@ -118,13 +118,16 @@ Function Get-CheckBoxes {
     if($Group -eq "WPFInstall"){
         Foreach ($CheckBox in $CheckBoxes){
             if($checkbox.value.ischecked -eq $true){
-                $output.Add("$($configs.applications.install.$($checkbox.name).winget)")
+                $configs.applications.install.$($checkbox.name).winget -split ";" | ForEach-Object {
+                    $output.Add($psitem)
+                }
+                
                 $checkbox.value.ischecked = $false
             }
         }
     }
-
-    Write-Output $Output
+    
+    Write-Output $($Output | Select-Object -Unique)
 }
 
 #===========================================================================

--- a/winutil.ps1
+++ b/winutil.ps1
@@ -1,5 +1,5 @@
 #for CI/CD
-$BranchToUse = 'hotfix/applications'
+$BranchToUse = 'main'
 <#
 .NOTES
    Author      : Chris Titus @christitustech


### PR DESCRIPTION
I updated the logic to split the semi colon as this was missed in the original implementation of the Get-Checkboxes function. I also updated the logic to only pass unique values.

Also updated the unit tests to detect if duplicate values there.

#401 