### PR TITLE
Fix Chocolatey installation detection

### DIFF
--- a/winutil.ps1
+++ b/winutil.ps1
@@ -11,7 +11,8 @@ $inputXML = (new-object Net.WebClient).DownloadString("https://raw.githubusercon
 
 # Choco install 
 $testchoco = powershell choco -v
-if(-not($testchoco)){
+
+if($testchoco.IndexOf("CommandNotFoundException") -eq -1){
     Write-Output "Seems Chocolatey is not installed, installing now"
     Set-ExecutionPolicy Bypass -Scope Process -Force; Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
     powershell choco feature enable -n allowGlobalConfirmation


### PR DESCRIPTION
- Closes #426, Closes #424, and Closes #426
  - Replaces `if(-not($testchoco))` with `if($testchoco.IndexOf("CommandNotFoundException") -eq -1)`