### PR TITLE
Hotfix fix Get-Checkboxes function

### DIFF
--- a/winutil.ps1
+++ b/winutil.ps1
@@ -120,7 +120,7 @@ Function Get-CheckBoxes {
     if($Group -eq "WPFInstall"){
         Foreach ($CheckBox in $CheckBoxes){
             if($CheckBox.value.ischecked -eq $true){
-                $Configs.applications.install.$($CheckBox.name).winget -split ";" | ForEach-Object {
+                $Configs.applications.$($CheckBox.name).winget -split ";" | ForEach-Object {
                     $Output.Add($psitem)
                 }
                 


### PR DESCRIPTION
@ChrisTitusTech looks like when I updated the applications json for choco the install group got removed and I missed that. Apologies on that. 

Also looks like the pester test got messed up with all the merge requests. I will look into that. 