### PR TITLE
Fixed Cloudflare Naming

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -334,7 +334,7 @@
 							    <ComboBox Name="changedns"  Height = "20" Width = "150" HorizontalAlignment = "Left" Margin="5,5"> 
 								    <ComboBoxItem IsSelected="True" Content = "Default"/> 
 								    <ComboBoxItem Content = "Google"/> 
-								    <ComboBoxItem Content = "Cloud Flare"/> 
+								    <ComboBoxItem Content = "Cloudflare"/> 
 								    <ComboBoxItem Content = "Level3"/> 
 								    <ComboBoxItem Content = "Open DNS"/> 
 							    </ComboBox> 

--- a/winutil.ps1
+++ b/winutil.ps1
@@ -435,8 +435,8 @@ $WPFtweaksbutton.Add_Click({
             $Interfaces = [System.Management.ManagementClass]::new("Win32_NetworkAdapterConfiguration").GetInstances()
             $Interfaces.SetDNSServerSearchOrder($dns) | Out-Null
         }
-        If ( $WPFchangedns.text -eq 'Cloud Flare' ) {
-            Write-Host "Setting DNS to Cloud Flare for all connections..."
+        If ( $WPFchangedns.text -eq 'Cloudflare' ) {
+            Write-Host "Setting DNS to Cloudflare for all connections..."
             $DC = "1.1.1.1"
             $Internet = "1.0.0.1"
             $dns = "$DC", "$Internet"


### PR DESCRIPTION
Don't close this commit again without properly looking at it. I've corrected your spelling of Cloudflare. In your code you have it spelled as "Cloud Flare" I have changed this to now be "Cloudflare" as seen in the official naming. 

![image](https://user-images.githubusercontent.com/33708767/206404559-9d339294-26d7-4a99-aebb-e5aa44b4b36e.png)
