### PR TITLE
Removed Duplicate Stop/Disable DiagTrack Service Code

### DIFF
--- a/winutil.ps1
+++ b/winutil.ps1
@@ -634,9 +634,6 @@ $WPFtweaksbutton.Add_Click({
                 New-Item -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\DeliveryOptimization\Config" | Out-Null
             }
             Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\DeliveryOptimization\Config" -Name "DODownloadMode" -Type DWord -Value 1
-            Write-Host "Stopping and disabling Diagnostics Tracking Service..."
-            Stop-Service "DiagTrack" -WarningAction SilentlyContinue
-            Set-Service "DiagTrack" -StartupType Disabled
             Write-Host "Stopping and disabling WAP Push Service..."
             Stop-Service "dmwappushservice" -WarningAction SilentlyContinue
             Set-Service "dmwappushservice" -StartupType Disabled
@@ -728,16 +725,16 @@ $WPFtweaksbutton.Add_Click({
 
             Set-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Policies\Explorer" -Name "HideSCAMeetNow" -Type DWord -Value 1
 
+            Write-Host "Stopping and disabling Diagnostics Tracking Service..."
+            Stop-Service "DiagTrack" -WarningAction SilentlyContinue
+            Set-Service "DiagTrack" -StartupType Disabled
+
             Write-Host "Removing AutoLogger file and restricting directory..."
             $autoLoggerDir = "$env:PROGRAMDATA\Microsoft\Diagnosis\ETLLogs\AutoLogger"
             If (Test-Path "$autoLoggerDir\AutoLogger-Diagtrack-Listener.etl") {
                 Remove-Item "$autoLoggerDir\AutoLogger-Diagtrack-Listener.etl"
             }
             icacls $autoLoggerDir /deny SYSTEM:`(OI`)`(CI`)F | Out-Null
-
-            Write-Host "Stopping and disabling Diagnostics Tracking Service..."
-            Stop-Service "DiagTrack"
-            Set-Service "DiagTrack" -StartupType Disabled
 
             $WPFEssTweaksTele.IsChecked = $false
         }


### PR DESCRIPTION
I moved the "DiagTrack" service code from lines #673-639 down to just before the related "Removing AutoLogger file and restricting directory..." section. Seemed best to stop/disable the service since it messes with the Autologer directory while its running. Lastly, I removed the second stop/disable code on lines #738-740.