### PR TITLE
Fix data type of MouseHoverTime

### DIFF
--- a/winutil.ps1
+++ b/winutil.ps1
@@ -867,7 +867,7 @@ $WPFtweaksbutton.Add_Click({
             Set-ItemProperty -Path "HKCU:\Control Panel\Desktop" -Name "MenuShowDelay" -Type DWord -Value 1
             Set-ItemProperty -Path "HKCU:\Control Panel\Desktop" -Name "AutoEndTasks" -Type DWord -Value 1
             Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management" -Name "ClearPageFileAtShutdown" -Type DWord -Value 0
-            Set-ItemProperty -Path "HKCU:\Control Panel\Mouse" -Name "MouseHoverTime" -Type DWord -Value 400
+            Set-ItemProperty -Path "HKCU:\Control Panel\Mouse" -Name "MouseHoverTime" -Type String -Value 400
 
             ## Timeout Tweaks cause flickering on Windows now
             Remove-ItemProperty -Path "HKCU:\Control Panel\Desktop" -Name "WaitToKillAppTimeout" -ErrorAction SilentlyContinue


### PR DESCRIPTION
Setting Computer\HKEY_CURRENT_USER\Control Panel\Mouse\MouseHoverTime needs to be REG_SZ instead of REG_DWORD as suggested by [meky84](https://github.com/meky84) in issue #516. With the wrong type the Taskbar and the Start Menu become hard to use because everything pops up instantly, probably because it's then treated as a 0 ms delay.
This fixes issue #516. 