### PR TITLE
fix enable numlock after startup

### DIFF
--- a/winutil.ps1
+++ b/winutil.ps1
@@ -771,7 +771,7 @@ $WPFtweaksbutton.Add_Click({
             If (!(Test-Path "HKU:")) {
                 New-PSDrive -Name HKU -PSProvider Registry -Root HKEY_USERS | Out-Null
             }
-            Set-ItemProperty -Path "HKU:\.DEFAULT\Control Panel\Keyboard" -Name "InitialKeyboardIndicators" -Type DWord -Value 2
+            Set-ItemProperty -Path "HKU:\.DEFAULT\Control Panel\Keyboard" -Name "InitialKeyboardIndicators" -Type DWord -Value 80000002
             $WPFMiscTweaksNum.IsChecked = $false
         }
         If ( $WPFMiscTweaksExt.IsChecked -eq $true ) {


### PR DESCRIPTION
the current registry key value doesn't work for me, looking around
https://www.winhelponline.com/blog/enable-numlock-login-screen-default/

> Set it to 2 (for Windows 7)
Set it to 80000002 (for Windows 8 and Windows 10)

using 80000002 did work for me, and since this tool is for windows 10 and 11 I see no point in using the value for win 7