### PR TITLE
Fix DarkMode

### DIFF
--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -53,6 +53,10 @@ foreach ($button in $buttons){
     })
 }
 
+$WPFToggleDarkMode.Add_Click({    
+  Invoke-WPFDarkMode -DarkMoveEnabled $(Get-WinUtilDarkMode)
+})
+
 $WPFToggleDarkMode.IsChecked = Get-WinUtilDarkMode
 
 #===========================================================================


### PR DESCRIPTION
Noticed darkmode was not toggling, looks like it doesn't get picked up by the following line as the dark mode toggle is considered a checkbox and not a button. Will have to think of a way to pull those in automatically. Easiest way might be using a naming convention to pull all checkboxes that use that style.

https://github.com/ChrisTitusTech/winutil/blob/a1c7501b98d56c5b554f9cfe70cb5a0767385796/scripts/main.ps1#L48