### PR TITLE
adding the code from asheroto to install winget

### DIFF
--- a/functions/private/Install-WinUtilWinget.ps1
+++ b/functions/private/Install-WinUtilWinget.ps1
@@ -41,6 +41,8 @@ function Install-WinUtilWinget {
 
             # Switching to winget-install from PSGallery from asheroto
             # Source: https://github.com/asheroto/winget-installer
+            echo "a" | Install-Script -Name winget-install
+            echo "a" | winget-install
 
             Start-Process powershell.exe -Verb RunAs -ArgumentList "-command irm https://raw.githubusercontent.com/ChrisTitusTech/winutil/$BranchToUse/winget.ps1 | iex | Out-Host" -WindowStyle Normal -ErrorAction Stop
 


### PR DESCRIPTION
with Server versions of Windows, that come without winget , the script seems unable to install it and then refuses to install any programs. so by adding two lines of code (hopefully) you can include the installation of winget and then fulfill the requirement and let the program run and do all the cool things. to my limited understanding, the echo command should forward the accept button and run the two commands that are in the asheroto repo.