### PR TITLE
Add Neovim and Node Version Manager

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -518,5 +518,13 @@
   "WPFInstallwinrar": {
     "winget": "RARLab.WinRar",
     "choco": "winrar"
+  },
+  "WPFInstallneovim": {
+    "winget": "Neovim.Neovim",
+    "choco": "neovim"
+  },
+  "WPFInstallnvm": {
+    "winget": "CoreyButler.NVMforWindows",
+    "choco": "nvm"
   }
 }

--- a/xaml/inputXML.xaml
+++ b/xaml/inputXML.xaml
@@ -146,12 +146,14 @@
                                 <CheckBox Name="Installjetbrains" Content="Jetbrains Toolbox" Margin="5,0"/>
                                 <CheckBox Name="Installnodejs" Content="NodeJS" Margin="5,0"/>
                                 <CheckBox Name="Installnodejslts" Content="NodeJS LTS" Margin="5,0"/>
+                                <CheckBox Name="Installnvm" Content="Node Version Manager" Margin="5,0"/>
                                 <CheckBox Name="Installpython3" Content="Python3" Margin="5,0"/>
                                 <CheckBox Name="Installrustlang" Content="Rust" Margin="5,0"/>
                                 <CheckBox Name="Installgolang" Content="GoLang" Margin="5,0"/>
                                 <CheckBox Name="Installsublime" Content="Sublime" Margin="5,0"/>
                                 <CheckBox Name="Installunity" Content="Unity Game Engine" Margin="5,0"/>
                                 <CheckBox Name="Installvisualstudio" Content="Visual Studio 2022" Margin="5,0"/>
+                                <CheckBox Name="Installneovim" Content="Neovim" Margin="5,0"/>
                                 <CheckBox Name="Installvscode" Content="VS Code" Margin="5,0"/>
                                 <CheckBox Name="Installvscodium" Content="VS Codium" Margin="5,0"/>
 


### PR DESCRIPTION
Issue #690 requested Neovim and Node Version Manager (NVM), so this commit will add those packages as installable programs.

Edited `applications.json`:
     - added the correct package names for em 

Edited `inputXML.xml`:
    - Just added Node Version Manager and Neovim under the Development section
