### PR TITLE
Split up AllowGameDVR to fix breaking Xbox Game Bar

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -1268,7 +1268,11 @@
         "Value": "0",
         "OriginalValue": "1",
         "Type": "DWord"
-      },
+      }
+    ]
+  },
+  "WPFDisableGameBar": {
+    "registry": [
       {
         "Path": "HKLM:\\SOFTWARE\\Policies\\Microsoft\\Windows\\GameDVR",
         "Name": "AllowGameDVR",

--- a/winutil.ps1
+++ b/winutil.ps1
@@ -3808,7 +3808,11 @@ $sync.configs.tweaks = '{
         "Value": "0",
         "OriginalValue": "1",
         "Type": "DWord"
-      },
+      }
+    ]
+  },
+  "WPFDisableGameBar": {
+    "registry": [
       {
         "Path": "HKLM:\\SOFTWARE\\Policies\\Microsoft\\Windows\\GameDVR",
         "Name": "AllowGameDVR",

--- a/winutil.ps1
+++ b/winutil.ps1
@@ -3808,11 +3808,7 @@ $sync.configs.tweaks = '{
         "Value": "0",
         "OriginalValue": "1",
         "Type": "DWord"
-      }
-    ]
-  },
-  "WPFDisableGameBar": {
-    "registry": [
+      },
       {
         "Path": "HKLM:\\SOFTWARE\\Policies\\Microsoft\\Windows\\GameDVR",
         "Name": "AllowGameDVR",


### PR DESCRIPTION
The `AllowGameDVR` regkey not only prevents GameDVR, but it also stops the hotkeys for Xbox Game Bar.
Winkey+G and Xbox Controller -> Xbox Button will not work when this key is set to 0.

I propose splitting this key into its own category. By keeping this separate, a user who wants it completely off can still enable this key.

Resolves:
#638
#371
#595

Worth noting to get GameBar working again on machines that already ran the Disable DVR script must:

1. Change the AllowGameDVR regkey to 1:  
`Set-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\GameDVR" -Name "AllowGameDVR" -Type DWord -Value 1`
2. Reboot PC
3. Explicitly Toggle ON the option in Settings -> Gaming -> Xbox Game Bar

--------

This moves the AllowGameDVR reg edit to its own category. 
There is plenty of use cases for Xbox Game Bar (e.x. using as a hotkey for Sound Mixer), where the user would otherwise not care about GameDVR. Most users probably do not use the recording feature but may use Xbox Game Bar for audio management, performance overlay, etc...

Splitting this option apart allows the user to still disable the GameDVR portion while keeping Xbox Game Bar itself functional for other uses.


