### PR TITLE
add verbose logon

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -2238,6 +2238,28 @@
       }
     ]
   },
+  "WPFMiscTweaksEnableVerboselogon": {
+    "registry": [
+      {
+        "path": "HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\policies\\system",
+        "OriginalValue": "0",
+        "name": "VerboseStatus",
+        "value": "1",
+        "type": "DWord"
+      }
+    ]
+  },
+  "WPFMiscTweaksDisableVerboselogon": {
+    "registry": [
+      {
+        "path": "HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\policies\\system",
+        "OriginalValue": "1",
+        "name": "VerboseStatus",
+        "value": "0",
+        "type": "DWord"
+      }
+    ]
+  },
   "WPFEssTweaksDeleteTempFiles": {
     "InvokeScript": [
       "Get-ChildItem -Path \"C:\\Windows\\Temp\" *.* -Recurse | Remove-Item -Force -Recurse

--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -2249,17 +2249,6 @@
       }
     ]
   },
-  "WPFMiscTweaksDisableVerboselogon": {
-    "registry": [
-      {
-        "path": "HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\policies\\system",
-        "OriginalValue": "1",
-        "name": "VerboseStatus",
-        "value": "0",
-        "type": "DWord"
-      }
-    ]
-  },
   "WPFEssTweaksDeleteTempFiles": {
     "InvokeScript": [
       "Get-ChildItem -Path \"C:\\Windows\\Temp\" *.* -Recurse | Remove-Item -Force -Recurse

--- a/winutil.ps1
+++ b/winutil.ps1
@@ -10,7 +10,7 @@
     Author         : Chris Titus @christitustech
     Runspace Author: @DeveloperDurp
     GitHub         : https://github.com/ChrisTitusTech
-    Version        : 23.05.17
+    Version        : 23.05.19
 #>
 
 Start-Transcript $ENV:TEMP\Winutil.log -Append
@@ -21,7 +21,7 @@ Add-Type -AssemblyName System.Windows.Forms
 # variable to sync between runspaces
 $sync = [Hashtable]::Synchronized(@{})
 $sync.PSScriptRoot = $PSScriptRoot
-$sync.version = "23.05.17"
+$sync.version = "23.05.19"
 $sync.configs = @{}
 $sync.ProcessRunning = $false
 Function Get-WinUtilCheckBoxes {
@@ -2310,6 +2310,9 @@ $inputXML = '<Window x:Class="WinUtility.MainWindow"
                                 <CheckBox Name="WPFMiscTweaksRightClickMenu" Content="Set Classic Right-Click Menu " Margin="5,0" ToolTip="Great Windows 11 tweak to bring back good context menus when right clicking things in explorer."/>
                                 <CheckBox Name="WPFMiscTweaksDisableMouseAcceleration" Content="Disable Mouse Acceleration" Margin="5,0" ToolTip="Disables Mouse Acceleration."/>
                                 <CheckBox Name="WPFMiscTweaksEnableMouseAcceleration" Content="Enable Mouse Acceleration" Margin="5,0" ToolTip="Enables Mouse Acceleration."/>
+                                <CheckBox Name="WPFMiscTweaksEnableVerboselogon" Content="Enable Verbose logon messages" Margin="5,0" ToolTip="Enable verbose logon messages"/>
+                                <CheckBox Name="WPFMiscTweaksDisableVerboselogon" Content="Disable Verbose logon messages" Margin="5,0" ToolTip="Disable verbose logon messages"/>
+
                                 <Label Content="DNS" />
 							    <ComboBox Name="WPFchangedns"  Height = "20" Width = "160" HorizontalAlignment = "Left" Margin="5,5"> 
 								    <ComboBoxItem IsSelected="True" Content = "Default"/> 
@@ -5287,6 +5290,28 @@ $sync.configs.tweaks = '{
         "name": "MouseThreshold2",
         "value": "10",
         "type": "String"
+      }
+    ]
+  },
+  "WPFMiscTweaksEnableVerboselogon": {
+    "registry": [
+      {
+        "path": "HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\policies\\system",
+        "OriginalValue": "0",
+        "name": "VerboseStatus",
+        "value": "1",
+        "type": "DWord"
+      }
+    ]
+  },
+  "WPFMiscTweaksDisableVerboselogon": {
+    "registry": [
+      {
+        "path": "HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\policies\\system",
+        "OriginalValue": "1",
+        "name": "VerboseStatus",
+        "value": "0",
+        "type": "DWord"
       }
     ]
   },

--- a/winutil.ps1
+++ b/winutil.ps1
@@ -2310,8 +2310,7 @@ $inputXML = '<Window x:Class="WinUtility.MainWindow"
                                 <CheckBox Name="WPFMiscTweaksRightClickMenu" Content="Set Classic Right-Click Menu " Margin="5,0" ToolTip="Great Windows 11 tweak to bring back good context menus when right clicking things in explorer."/>
                                 <CheckBox Name="WPFMiscTweaksDisableMouseAcceleration" Content="Disable Mouse Acceleration" Margin="5,0" ToolTip="Disables Mouse Acceleration."/>
                                 <CheckBox Name="WPFMiscTweaksEnableMouseAcceleration" Content="Enable Mouse Acceleration" Margin="5,0" ToolTip="Enables Mouse Acceleration."/>
-                                <CheckBox Name="WPFMiscTweaksEnableVerboselogon" Content="Enable Verbose logon messages" Margin="5,0" ToolTip="Enable verbose logon messages"/>
-                                <CheckBox Name="WPFMiscTweaksDisableVerboselogon" Content="Disable Verbose logon messages" Margin="5,0" ToolTip="Disable verbose logon messages"/>
+                                <CheckBox Name="WPFMiscTweaksEnableVerboselogon" Content="Enable Verbose logon messages" Margin="5,0" ToolTip="Enables verbose logon messages."/>
 
                                 <Label Content="DNS" />
 							    <ComboBox Name="WPFchangedns"  Height = "20" Width = "160" HorizontalAlignment = "Left" Margin="5,5"> 
@@ -5300,17 +5299,6 @@ $sync.configs.tweaks = '{
         "OriginalValue": "0",
         "name": "VerboseStatus",
         "value": "1",
-        "type": "DWord"
-      }
-    ]
-  },
-  "WPFMiscTweaksDisableVerboselogon": {
-    "registry": [
-      {
-        "path": "HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\policies\\system",
-        "OriginalValue": "1",
-        "name": "VerboseStatus",
-        "value": "0",
         "type": "DWord"
       }
     ]

--- a/xaml/inputXML.xaml
+++ b/xaml/inputXML.xaml
@@ -358,6 +358,9 @@
                                 <CheckBox Name="WPFMiscTweaksRightClickMenu" Content="Set Classic Right-Click Menu " Margin="5,0" ToolTip="Great Windows 11 tweak to bring back good context menus when right clicking things in explorer."/>
                                 <CheckBox Name="WPFMiscTweaksDisableMouseAcceleration" Content="Disable Mouse Acceleration" Margin="5,0" ToolTip="Disables Mouse Acceleration."/>
                                 <CheckBox Name="WPFMiscTweaksEnableMouseAcceleration" Content="Enable Mouse Acceleration" Margin="5,0" ToolTip="Enables Mouse Acceleration."/>
+                                <CheckBox Name="WPFMiscTweaksEnableVerboselogon" Content="Enable Verbose logon messages" Margin="5,0" ToolTip="Enables verbose logon messages"/>
+                                <CheckBox Name="WPFMiscTweaksDisableVerboselogon" Content="Disable Verbose logon messages" Margin="5,0" ToolTip="Disables verbose logon messages"/>
+
                                 <Label Content="DNS" />
 							    <ComboBox Name="WPFchangedns"  Height = "20" Width = "160" HorizontalAlignment = "Left" Margin="5,5"> 
 								    <ComboBoxItem IsSelected="True" Content = "Default"/> 

--- a/xaml/inputXML.xaml
+++ b/xaml/inputXML.xaml
@@ -358,8 +358,7 @@
                                 <CheckBox Name="WPFMiscTweaksRightClickMenu" Content="Set Classic Right-Click Menu " Margin="5,0" ToolTip="Great Windows 11 tweak to bring back good context menus when right clicking things in explorer."/>
                                 <CheckBox Name="WPFMiscTweaksDisableMouseAcceleration" Content="Disable Mouse Acceleration" Margin="5,0" ToolTip="Disables Mouse Acceleration."/>
                                 <CheckBox Name="WPFMiscTweaksEnableMouseAcceleration" Content="Enable Mouse Acceleration" Margin="5,0" ToolTip="Enables Mouse Acceleration."/>
-                                <CheckBox Name="WPFMiscTweaksEnableVerboselogon" Content="Enable Verbose logon messages" Margin="5,0" ToolTip="Enables verbose logon messages"/>
-                                <CheckBox Name="WPFMiscTweaksDisableVerboselogon" Content="Disable Verbose logon messages" Margin="5,0" ToolTip="Disables verbose logon messages"/>
+                                <CheckBox Name="WPFMiscTweaksEnableVerboselogon" Content="Enable Verbose logon messages" Margin="5,0" ToolTip="Enables verbose logon messages."/>
 
                                 <Label Content="DNS" />
 							    <ComboBox Name="WPFchangedns"  Height = "20" Width = "160" HorizontalAlignment = "Left" Margin="5,5"> 


### PR DESCRIPTION
Enable or disable verbose sign in status messages. Verbose status messages may be helpful when you are troubleshooting slow startup, shutdown, logon, or logoff behavior.