### PR TITLE
Update vcredit package names for winget winutil.ps1

### DIFF
--- a/winutil.ps1
+++ b/winutil.ps1
@@ -2724,11 +2724,11 @@ $sync.configs.applications = '{
     "choco": "dotnet-6.0-runtime"
   },
   "WPFInstallvc2015_64": {
-    "winget": "Microsoft.VC++2015-2022Redist-x64",
+    "winget": "Microsoft.VCRedist.2015+.x64",
     "choco": "na"
   },
   "WPFInstallvc2015_32": {
-    "winget": "Microsoft.VC++2015-2022Redist-x86",
+    "winget": "Microsoft.VCRedist.2015+.x86",
     "choco": "na"
   },
   "WPFInstallfoxpdf": {


### PR DESCRIPTION
Microsoft Visual C++ 2015-2022 Redistributable (32bit, 64bit) package names for winget were incorrect. Due to which, these redistributables were not installing after selection. I have changed them with right names. Please check.... BTW this is a great tool. Keep it up, Titus sir.