### PR TITLE
Removes ugly blue text when script is running

### DIFF
--- a/functions/private/Install-WinUtilWinget.ps1
+++ b/functions/private/Install-WinUtilWinget.ps1
@@ -1,3 +1,5 @@
+$ProgessStatus="SilentlyContinue"
+
 function Install-WinUtilWinget {
     
     <#


### PR DESCRIPTION
Adding this to all ps1 scripts isn't necessary because not all scripts create the blue text. But, noticed in your live stream that upon first launch of winutil, when it checks/installs winget, the blue texts appears on powershell window. This change is purely aesthetics.