### PR TITLE
Added snappy driver installer origin 

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -327,6 +327,10 @@
     "winget": "Nilesoft.Shell",
     "choco": "na"
   },
+  "WPFInstallsdio": {
+    "winget": "GlennDelahoy.SnappyDriverInstallerOrigin",
+    "choco": "na"
+  },
   "WPFInstallklite": {
     "winget": "CodecGuide.K-LiteCodecPack.Standard",
     "choco": "k-litecodecpack-standard"

--- a/winutil.ps1
+++ b/winutil.ps1
@@ -10,7 +10,7 @@
     Author         : Chris Titus @christitustech
     Runspace Author: @DeveloperDurp
     GitHub         : https://github.com/ChrisTitusTech
-    Version        : 23.08.03
+    Version        : 23.08.05
 #>
 
 Start-Transcript $ENV:TEMP\Winutil.log -Append
@@ -21,7 +21,7 @@ Add-Type -AssemblyName System.Windows.Forms
 # variable to sync between runspaces
 $sync = [Hashtable]::Synchronized(@{})
 $sync.PSScriptRoot = $PSScriptRoot
-$sync.version = "23.08.03"
+$sync.version = "23.08.05"
 $sync.configs = @{}
 $sync.ProcessRunning = $false
 
@@ -2562,6 +2562,7 @@ $inputXML = '<Window x:Class="WinUtility.MainWindow"
                                 <CheckBox Name="WPFInstallrufus" Content="Rufus Imager" Margin="5,0"/>
                                 <CheckBox Name="WPFInstallsandboxie" Content="Sandboxie Plus" Margin="5,0"/>
                                 <CheckBox Name="WPFInstallshell" Content="Shell (Expanded Context Menu)" Margin="5,0"/>
+                                <CheckBox Name="WPFInstallsdio" Content="Snappy Driver Installer Origin" Margin="5,0"/>
                                 <CheckBox Name="WPFInstallteamviewer" Content="TeamViewer" Margin="5,0"/>
                                 <CheckBox Name="WPFInstallttaskbar" Content="Translucent Taskbar" Margin="5,0"/>
                                 <CheckBox Name="WPFInstalltreesize" Content="TreeSize Free" Margin="5,0"/>
@@ -3062,6 +3063,10 @@ $sync.configs.applications = '{
   },
   "WPFInstallshell": {
     "winget": "Nilesoft.Shell",
+    "choco": "na"
+  },
+  "WPFInstallsdio": {
+    "winget": "GlennDelahoy.SnappyDriverInstallerOrigin",
     "choco": "na"
   },
   "WPFInstallklite": {

--- a/xaml/inputXML.xaml
+++ b/xaml/inputXML.xaml
@@ -403,6 +403,7 @@
                                 <CheckBox Name="WPFInstallrufus" Content="Rufus Imager" Margin="5,0"/>
                                 <CheckBox Name="WPFInstallsandboxie" Content="Sandboxie Plus" Margin="5,0"/>
                                 <CheckBox Name="WPFInstallshell" Content="Shell (Expanded Context Menu)" Margin="5,0"/>
+                                <CheckBox Name="WPFInstallsdio" Content="Snappy Driver Installer Origin" Margin="5,0"/>
                                 <CheckBox Name="WPFInstallteamviewer" Content="TeamViewer" Margin="5,0"/>
                                 <CheckBox Name="WPFInstallttaskbar" Content="Translucent Taskbar" Margin="5,0"/>
                                 <CheckBox Name="WPFInstalltreesize" Content="TreeSize Free" Margin="5,0"/>


### PR DESCRIPTION

- Previous installing snappy driver installer origin with winget gives error : installer hash not matched. and it failed installtion.
- Now i made PR to fix this and upgrade version of sdio on [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs/) with PR : https://github.com/microsoft/winget-pkgs/pull/115287. 
- It fix the issue and now when we install sdio with following command : `winget install GlennDelahoy.SnappyDriverInstallerOrigin` it works fine. after installtion we can run sdio with `sdio` command.

Done FR : #642