### PR TITLE
Add CTT YouTube tutorial video to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ If you are still having issues try changing your DNS provider to 1.1.1.1 or 8.8.
 - This project needs a ⭐️ from you. Don't forget to leave a star ⭐️.
 - EXE Wrapper for $10 @ https://www.cttstore.com/windows-toolbox
 
+## Tutorial
+
+[![Watch the video](https://img.youtube.com/vi/6UQZ5oQg8XA/hqdefault.jpg)](https://www.youtube.com/watch?v=6UQZ5oQg8XA)
+
 ## Overview
 
 - Install


### PR DESCRIPTION
I thought that I would add a video you made on your YouTube channel which perfectly explains the usage of your toolbox through your mouth. This could be useful for users who don't want to read the README but still want to set up their system efficiently. The size of the thumbnail can be modified using `default`, `mqdefault`, `hqdefault` or `sddefault` so do let me know if you don't like its size and I can change it.