### PR TITLE
Fix apps falsely marked as installed

### DIFF
--- a/functions/private/Invoke-WinUtilCurrentSystem.ps1
+++ b/functions/private/Invoke-WinUtilCurrentSystem.ps1
@@ -26,12 +26,10 @@ Function Invoke-WinUtilCurrentSystem {
 
         $filter = Get-WinUtilVariables -Type Checkbox | Where-Object {$psitem -like "WPFInstall*"}
         $sync.GetEnumerator() | Where-Object {$psitem.Key -in $filter} | ForEach-Object {
-            $dependencies = $($sync.configs.applications.$($psitem.Key).winget -split ";")
+            $dependencies = @($sync.configs.applications.$($psitem.Key).winget -split ";")
 
-            Foreach ($dependency in $dependencies) {
-                if($dependency -in $sync.InstalledPrograms.Id){
-                    Write-Output $psitem.name
-                }
+            if ($dependencies[-1] -in $sync.InstalledPrograms.Id) {
+                Write-Output $psitem.name
             }
         }
     }
@@ -51,7 +49,6 @@ Function Invoke-WinUtilCurrentSystem {
         
             if($registryKeys -or $scheduledtaskKeys -or $serviceKeys){
                 $Values = @()
-
 
                 Foreach ($tweaks in $registryKeys){
                     Foreach($tweak in $tweaks){

--- a/winutil.ps1
+++ b/winutil.ps1
@@ -386,12 +386,10 @@ Function Invoke-WinUtilCurrentSystem {
 
         $filter = Get-WinUtilVariables -Type Checkbox | Where-Object {$psitem -like "WPFInstall*"}
         $sync.GetEnumerator() | Where-Object {$psitem.Key -in $filter} | ForEach-Object {
-            $dependencies = $($sync.configs.applications.$($psitem.Key).winget -split ";")
+            $dependencies = @($sync.configs.applications.$($psitem.Key).winget -split ";")
 
-            Foreach ($dependency in $dependencies) {
-                if($dependency -in $sync.InstalledPrograms.Id){
-                    Write-Output $psitem.name
-                }
+            if ($dependencies[-1] -in $sync.InstalledPrograms.Id) {
+                Write-Output $psitem.name
             }
         }
     }
@@ -411,7 +409,6 @@ Function Invoke-WinUtilCurrentSystem {
         
             if($registryKeys -or $scheduledtaskKeys -or $serviceKeys){
                 $Values = @()
-
 
                 Foreach ($tweaks in $registryKeys){
                     Foreach($tweak in $tweaks){


### PR DESCRIPTION
Modify the script to mark an app as installed when the "Get Installed" is pressed only if the last of its dependencies (the actual package) is installed. Currently Github Desktop, VSCode and VSCodium become checked when Git is installed.

- partially fixes #978