### PR TITLE
Incorrect WinGet ID for TCPView.

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -476,7 +476,7 @@
 		"choco": "sumatrapdf"
 	},
 	"WPFInstalltcpview": {
-		"winget": "Microsoft.Sysinternals.Tcpview",
+		"winget": "Microsoft.Sysinternals.TCPView",
 		"choco": "tcpview"
 	},
 	"WPFInstallteams": {


### PR DESCRIPTION
Small issue in the naming of TCPView in the `config/applications.json` winget line which caused the application not to be found when trying to install it. 

The line was `"winget": "Microsoft.Sysinternals.Tcpview",` when it should have been `"winget": "Microsoft.Sysinternals.TCPView",`, small error and an easy fix which I saw while watching the new video.

P.S: *This is my first PR here and I hope I did it correctly*.