### PR TITLE
move restore point to runspace

### DIFF
--- a/functions/public/Invoke-WPFtweaksbutton.ps1
+++ b/functions/public/Invoke-WPFtweaksbutton.ps1
@@ -22,12 +22,12 @@ function Invoke-WPFtweaksbutton {
     return
   }
 
-  Set-WinUtilRestorePoint
-
   Invoke-WPFRunspace -ArgumentList $Tweaks -ScriptBlock {
     param($Tweaks)
 
     $sync.ProcessRunning = $true
+
+    Set-WinUtilRestorePoint
 
     Foreach ($tweak in $tweaks){
         Invoke-WinUtilTweaks $tweak


### PR DESCRIPTION
noticed the gui locked up when running tweaks. Moved the restore point to the runspace so it no longer locks up