### PR TITLE
Add ZeroTier One to utilities menu

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -615,6 +615,10 @@
 		"winget": "subhra74.XtremeDownloadManager",
 		"choco": "xdm"
 	},
+	"WPFInstallzerotierone": {
+    "winget": "ZeroTier.ZeroTierOne",
+    "choco": "zerotier-one"
+  },
 	"WPFInstallzoom": {
 		"winget": "Zoom.Zoom",
 		"choco": "zoom"

--- a/xaml/inputXML.xaml
+++ b/xaml/inputXML.xaml
@@ -426,6 +426,7 @@
                                 <CheckBox Name="WPFInstallwiztree" Content="WizTree" Margin="5,0"/>
                                 <CheckBox Name="WPFInstallwinrar" Content="WinRAR" Margin="5,0"/>
                                 <CheckBox Name="WPFInstallxdm" Content="Xtreme Download Manager" Margin="5,0"/>
+                                <CheckBox Name="WPFInstallzerotierone" Content="ZeroTier One" Margin="5,0"/>
                             </StackPanel>
                         </Grid>
                     </TabItem>


### PR DESCRIPTION
Adds install option for ZeroTier One to Utilities menu. Refer to Issue #1052.

ZeroTier One is a popular, easy to configure VPN utility with an extremely generous free tier.

All compiles, installs & runs OK on my tests.