### PR TITLE
Add .NET 7.0 Desktop Runtime

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -91,6 +91,10 @@
 		"winget": "Microsoft.DotNet.DesktopRuntime.6",
 		"choco": "dotnet-6.0-runtime"
 	},
+	"WPFInstalldotnet7": {
+		"winget": "Microsoft.DotNet.DesktopRuntime.7",
+		"choco": "dotnet-7.0-runtime"
+	},
 	"WPFInstalleaapp": {
 		"winget": "ElectronicArts.EADesktop",
 		"choco": "ea-app"

--- a/config/applications.json
+++ b/config/applications.json
@@ -559,6 +559,10 @@
 		"winget": "Microsoft.VCRedist.2015+.x64",
 		"choco": "na"
 	},
+	"WPFInstallventoy": {
+		"winget": "na",
+		"choco": "ventoy"
+	},
 	"WPFInstallviber": {
 		"Winget": "Viber.Viber",
 		"choco": "viber"

--- a/xaml/inputXML.xaml
+++ b/xaml/inputXML.xaml
@@ -334,6 +334,7 @@
                                 <CheckBox Name="WPFInstalldotnet3" Content=".NET Desktop Runtime 3.1" Margin="5,0"/>
                                 <CheckBox Name="WPFInstalldotnet5" Content=".NET Desktop Runtime 5" Margin="5,0"/>
                                 <CheckBox Name="WPFInstalldotnet6" Content=".NET Desktop Runtime 6" Margin="5,0"/>
+                                <CheckBox Name="WPFInstalldotnet7" Content=".NET Desktop Runtime 7" Margin="5,0"/>
                                 <CheckBox Name="WPFInstallnuget" Content="Nuget" Margin="5,0"/>
                                 <CheckBox Name="WPFInstallonedrive" Content="OneDrive" Margin="5,0"/>
                                 <CheckBox Name="WPFInstallpowershell" Content="PowerShell" Margin="5,0"/>

--- a/xaml/inputXML.xaml
+++ b/xaml/inputXML.xaml
@@ -418,7 +418,7 @@
                                 <CheckBox Name="WPFInstallsandboxie" Content="Sandboxie Plus" Margin="5,0"/>
                                 <CheckBox Name="WPFInstallshell" Content="Shell (Expanded Context Menu)" Margin="5,0"/>
                                 <CheckBox Name="WPFInstallsdio" Content="Snappy Driver Installer Origin" Margin="5,0"/>
-				                <CheckBox Name="WPFInstallsuperf4" Content="SuperF4" Margin="5,0"/>
+                                <CheckBox Name="WPFInstallsuperf4" Content="SuperF4" Margin="5,0"/>
                                 <CheckBox Name="WPFInstallteamviewer" Content="TeamViewer" Margin="5,0"/>
                                 <CheckBox Name="WPFInstallttaskbar" Content="Translucent Taskbar" Margin="5,0"/>
                                 <CheckBox Name="WPFInstalltreesize" Content="TreeSize Free" Margin="5,0"/>

--- a/xaml/inputXML.xaml
+++ b/xaml/inputXML.xaml
@@ -382,6 +382,7 @@
                                 <CheckBox Name="WPFInstallputty" Content="Putty" Margin="5,0"/>
                                 <CheckBox Name="WPFInstallrustdesk" Content="Rust Remote Desktop (FOSS)" Margin="5,0"/>
                                 <CheckBox Name="WPFInstallsimplewall" Content="SimpleWall" Margin="5,0"/>
+                                <CheckBox Name="WPFInstallventoy" Content="Ventoy" Margin="5,0"/>
                                 <CheckBox Name="WPFInstallwinscp" Content="WinSCP" Margin="5,0"/>
                                 <CheckBox Name="WPFInstallwireshark" Content="WireShark" Margin="5,0"/>
                             </StackPanel>

--- a/xaml/inputXML.xaml
+++ b/xaml/inputXML.xaml
@@ -417,7 +417,7 @@
                                 <CheckBox Name="WPFInstallsandboxie" Content="Sandboxie Plus" Margin="5,0"/>
                                 <CheckBox Name="WPFInstallshell" Content="Shell (Expanded Context Menu)" Margin="5,0"/>
                                 <CheckBox Name="WPFInstallsdio" Content="Snappy Driver Installer Origin" Margin="5,0"/>
-				<CheckBox Name="WPFInstallsuperf4" Content="SuperF4" Margin="5,0"/>
+		                        <CheckBox Name="WPFInstallsuperf4" Content="SuperF4" Margin="5,0"/>
                                 <CheckBox Name="WPFInstallteamviewer" Content="TeamViewer" Margin="5,0"/>
                                 <CheckBox Name="WPFInstallttaskbar" Content="Translucent Taskbar" Margin="5,0"/>
                                 <CheckBox Name="WPFInstalltreesize" Content="TreeSize Free" Margin="5,0"/>


### PR DESCRIPTION
Added .NET Desktop Runtime [Winget](https://learn.microsoft.com/en-us/dotnet/core/install/windows?tabs=net70#install-the-runtime) & [Chocolatey](https://community.chocolatey.org/packages/dotnet-7.0-runtime). Chocolatey package maintained by jberezanski & dotnetcore-chocolateypackages