### PR TITLE
Comment Spacing, Indentation, and Capitalization

### DIFF
--- a/config/helperscript.ps1
+++ b/config/helperscript.ps1
@@ -1,4 +1,4 @@
-#This file is meant to assist in building out the json files inside this folder.
+# This file is meant to assist in building out the json files inside this folder.
 
 #===========================================================================
 # applications.json
@@ -35,7 +35,7 @@ Example:
 
 #>
 
-#Modify the variables and run his code. It will import the current file and add your addition. From there you can create a pull request.
+# Modify the variables and run his code. It will import the current file and add your addition. From there you can create a pull request.
 #------Do not delete WPF------
 
 $NameofButton = "WPF" + ""
@@ -45,7 +45,7 @@ $ChocoCommand = ""
 $ButtonToAdd = New-Object psobject
 $jsonfile = Get-Content ./config/applications.json | ConvertFrom-Json
 
-#remove if already exists
+# Remove if already exists
 if($jsonfile.$NameofButton){
     $jsonfile.psobject.Properties.remove($NameofButton)
 }
@@ -88,7 +88,7 @@ Example:
 }    
 #>
 
-#Modify the variables and run his code. It will import the current file and add your addition. From there you can create a pull request.
+# Modify the variables and run his code. It will import the current file and add your addition. From there you can create a pull request.
 
 $NameofButton = ""
 $commands = @(
@@ -97,7 +97,7 @@ $commands = @(
 
 $jsonfile = Get-Content ./config/feature.json | ConvertFrom-Json
 
-#remove if already exists
+# Remove if already exists
 if($jsonfile.$NameofButton){
     $jsonfile.psobject.Properties.remove($NameofButton)
 }
@@ -150,7 +150,7 @@ Example:
 }    
 #>
 
-#Modify the variables and run his code. It will import the current file and add your addition. From there you can create a pull request.
+# Modify the variables and run his code. It will import the current file and add your addition. From there you can create a pull request.
 
 $NameofButton = "WPF" + ""
 $commands = @(
@@ -159,7 +159,7 @@ $commands = @(
 
 $jsonfile = Get-Content ./config/preset.json | ConvertFrom-Json
 
-#remove if already exists
+# Remove if already exists
 if($jsonfile.$NameofButton){
     $jsonfile.psobject.Properties.remove($NameofButton)
 }
@@ -286,11 +286,11 @@ Example:
 
 #>
 
-#Modify the variables and run his code. It will import the current file and add your addition. From there you can create a pull request.
-#Make sure to uncomment the sections you which to add.
+# Modify the variables and run his code. It will import the current file and add your addition. From there you can create a pull request.
+# Make sure to uncomment the sections you which to add.
 
 #$Registry = @(
-#    #to add more repeat this separated by a comma
+#    # To add more repeat this separated by a comma
 #    @{
 #        Path = ""
 #        Name = ""
@@ -301,7 +301,7 @@ Example:
 #)
 
 #$Service = @(
-#    #to add more repeat this separated by a comma
+#    # To add more repeat this separated by a comma
 #    @{
 #        Name = ""
 #        StartupType = ""
@@ -310,7 +310,7 @@ Example:
 #)
 
 #$ScheduledTask = @(
-#    #to add more repeat this separated by a comma
+#    # To add more repeat this separated by a comma
 #    @{
 #        Name = ""
 #        State = ""
@@ -335,7 +335,7 @@ $NameofButton = "WPF" + ""
 $ButtonToAdd = New-Object psobject
 $jsonfile = Get-Content ./config/tweaks.json | ConvertFrom-Json
 
-#remove if already exists
+# Remove if already exists
 if($jsonfile.$NameofButton){
     $jsonfile.psobject.Properties.remove($NameofButton)
 }
@@ -378,7 +378,7 @@ Example:
 }    
 #>
 
-#Modify the variables and run his code. It will import the current file and add your addition. From there you can create a pull request.
+# Modify the variables and run his code. It will import the current file and add your addition. From there you can create a pull request.
 
 $NameofProvider = "" -replace " ","_"
 $IPAddress = @{
@@ -389,7 +389,7 @@ $IPAddress = @{
 $ButtonToAdd = New-Object psobject
 $jsonfile = Get-Content ./config/dns.json | ConvertFrom-Json
 
-#remove if already exists
+# Remove if already exists
 if($jsonfile.$NameofProvider){
     $jsonfile.psobject.Properties.remove($NameofProvider)
 }

--- a/functions/private/Get-WinUtilCheckBoxes.ps1
+++ b/functions/private/Get-WinUtilCheckBoxes.ps1
@@ -2,13 +2,19 @@ Function Get-WinUtilCheckBoxes {
 
     <#
 
-        .DESCRIPTION
-        Function is meant to find all checkboxes that are checked on the specific tab and input them into a script.
+    .SYNOPSIS
+        Finds all checkboxes that are checked on the specific tab and inputs them into a script.
 
-        Outputed data will be the names of the checkboxes that were checked
+    .PARAMETER Group
+        The group of checkboxes to check
 
-        .EXAMPLE
+    .PARAMETER unCheck
+        Whether to uncheck the checkboxes that are checked. Defaults to true
 
+    .OUTPUTS
+        A List containing the name of each checked checkbox
+
+    .EXAMPLE
         Get-WinUtilCheckBoxes "WPFInstall"
 
     #>

--- a/functions/private/Get-WinUtilInstallerProcess.ps1
+++ b/functions/private/Get-WinUtilInstallerProcess.ps1
@@ -1,9 +1,15 @@
 function Get-WinUtilInstallerProcess {
     <#
-    
-        .DESCRIPTION
-        Meant to check for running processes, will return a boolean response
-    
+
+    .SYNOPSIS
+        Checks if the given process is running
+
+    .PARAMETER Process
+        The process to check
+
+    .OUTPUTS
+        Boolean - True if the process is running
+
     #>
 
     param($Process)

--- a/functions/private/Get-WinUtilInstallerProcess.ps1
+++ b/functions/private/Get-WinUtilInstallerProcess.ps1
@@ -2,7 +2,7 @@ function Get-WinUtilInstallerProcess {
     <#
     
         .DESCRIPTION
-        Meant to check for running processes and will return a boolean response
+        Meant to check for running processes, will return a boolean response
     
     #>
 

--- a/functions/private/Get-WinUtilRegistry.ps1
+++ b/functions/private/Get-WinUtilRegistry.ps1
@@ -1,12 +1,12 @@
 function Get-WinUtilRegistry {
     <#
-    
-        .DESCRIPTION
+
+    .SYNOPSIS
         Gets the value of a registry key
 
-        .EXAMPLE
+    .EXAMPLE
         Get-WinUtilRegistry -Name "PublishUserActivities" -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\System" -Type "DWord" -Value "0"
-    
+
     #>    
     param (
         $Name,

--- a/functions/private/Get-WinUtilRegistry.ps1
+++ b/functions/private/Get-WinUtilRegistry.ps1
@@ -2,11 +2,10 @@ function Get-WinUtilRegistry {
     <#
     
         .DESCRIPTION
-        This function will make all modifications to the registry
+        Gets the value of a registry key
 
         .EXAMPLE
-
-        Set-WinUtilRegistry -Name "PublishUserActivities" -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\System" -Type "DWord" -Value "0"
+        Get-WinUtilRegistry -Name "PublishUserActivities" -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\System" -Type "DWord" -Value "0"
     
     #>    
     param (

--- a/functions/private/Get-WinUtilToggleStatus.ps1
+++ b/functions/private/Get-WinUtilToggleStatus.ps1
@@ -1,12 +1,15 @@
 Function Get-WinUtilToggleStatus {
     <#
-    
-        .DESCRIPTION
-        Pulls the registry keys for a toggle switch and returns true or false
 
-        True should mean status is enabled
-        False should mean status is disabled
-    
+    .SYNOPSIS
+        Pulls the registry keys for the given toggle switch and checks whether the toggle should be checked or unchecked
+
+    .PARAMETER ToggleSwitch
+        The name of the toggle to check
+
+    .OUTPUTS
+        Boolean to set the toggle's status to
+
     #>
 
     Param($ToggleSwitch)

--- a/functions/private/Get-WinUtilToggleStatus.ps1
+++ b/functions/private/Get-WinUtilToggleStatus.ps1
@@ -2,7 +2,7 @@ Function Get-WinUtilToggleStatus {
     <#
     
         .DESCRIPTION
-        Meant to pull the registry keys for a toggle switch and returns true or false
+        Pulls the registry keys for a toggle switch and returns true or false
 
         True should mean status is enabled
         False should mean status is disabled

--- a/functions/private/Get-WinUtilVariables.ps1
+++ b/functions/private/Get-WinUtilVariables.ps1
@@ -1,10 +1,13 @@
 function Get-WinUtilVariables {
 
     <#
-    
-        .DESCRIPTION
-        placeholder
-    
+
+    .SYNOPSIS
+        Gets every form object of the provided type
+
+    .OUTPUTS
+        List containing every object that matches the provided type
+
     #>
     param (
         [Parameter()]

--- a/functions/private/Install-WinUtilChoco.ps1
+++ b/functions/private/Install-WinUtilChoco.ps1
@@ -1,10 +1,10 @@
 function Install-WinUtilChoco {
 
     <#
-    
-        .DESCRIPTION
-        Installs Chocolatey if it is not installed
-    
+
+    .SYNOPSIS
+        Installs Chocolatey if it is not already installed
+
     #>
 
     try{

--- a/functions/private/Install-WinUtilChoco.ps1
+++ b/functions/private/Install-WinUtilChoco.ps1
@@ -3,7 +3,7 @@ function Install-WinUtilChoco {
     <#
     
         .DESCRIPTION
-        Function is meant to ensure Choco is installed 
+        Installs Chocolatey if it is not installed
     
     #>
 
@@ -16,7 +16,7 @@ function Install-WinUtilChoco {
         }
     
         Write-Host "Seems Chocolatey is not installed, installing now?"
-        # Let user decide if he wants to install Chocolatey
+        # Let user decide if they want to install Chocolatey
         $confirmation = Read-Host "Are you Sure You Want To Proceed:(y/n)"
         if ($confirmation -eq 'y') {
             Set-ExecutionPolicy Bypass -Scope Process -Force; Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1')) -ErrorAction Stop

--- a/functions/private/Install-WinUtilChoco.ps1
+++ b/functions/private/Install-WinUtilChoco.ps1
@@ -16,7 +16,7 @@ function Install-WinUtilChoco {
         }
     
         Write-Host "Seems Chocolatey is not installed, installing now?"
-        #Let user decide if he wants to install Chocolatey
+        # Let user decide if he wants to install Chocolatey
         $confirmation = Read-Host "Are you Sure You Want To Proceed:(y/n)"
         if ($confirmation -eq 'y') {
             Set-ExecutionPolicy Bypass -Scope Process -Force; Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1')) -ErrorAction Stop

--- a/functions/private/Install-WinUtilProgramWinget.ps1
+++ b/functions/private/Install-WinUtilProgramWinget.ps1
@@ -1,12 +1,19 @@
 Function Install-WinUtilProgramWinget {
 
     <#
-    
-        .DESCRIPTION
-        This will install programs via Winget using a new powershell.exe instance to prevent the GUI from locking up.
 
-        Note the triple quotes are required any time you need a " in a normal script block.
-    
+    .SYNOPSIS
+        Manages the provided programs using Winget
+
+    .PARAMETER ProgramsToInstall
+        A list of programs to manage
+
+    .PARAMETER manage
+        The action to perform on the programs, can be either 'Installing' or 'Uninstalling'
+
+    .NOTES
+        The triple quotes are required any time you need a " in a normal script block.
+
     #>
 
     param(

--- a/functions/private/Install-WinUtilWinget.ps1
+++ b/functions/private/Install-WinUtilWinget.ps1
@@ -8,12 +8,12 @@ function Get-LatestHash {
 }
 
 function Install-WinUtilWinget {
-    
+
     <#
-    
-        .DESCRIPTION
-        Function is meant to ensure winget is installed 
-    
+
+    .SYNOPSIS
+        Installs Winget if it is not already installed
+
     #>
     Try{
         Write-Host "Checking if Winget is Installed..."

--- a/functions/private/Install-WinUtilWinget.ps1
+++ b/functions/private/Install-WinUtilWinget.ps1
@@ -5,7 +5,7 @@ function Get-LatestHash {
     $WebClient.DownloadFile($shaUrl, $shaFile)
   
     Get-Content $shaFile
-  }
+}
 
 function Install-WinUtilWinget {
     

--- a/functions/private/Install-WinUtilWinget.ps1
+++ b/functions/private/Install-WinUtilWinget.ps1
@@ -18,12 +18,12 @@ function Install-WinUtilWinget {
     Try{
         Write-Host "Checking if Winget is Installed..."
         if (Test-WinUtilPackageManager -winget) {
-            #Checks if winget executable exists and if the Windows Version is 1809 or higher
+            # Checks if winget executable exists and if the Windows Version is 1809 or higher
             Write-Host "Winget Already Installed"
             return
         }
 
-        #Gets the computer's information
+        # Gets the computer's information
         if ($null -eq $sync.ComputerInfo){
             $ComputerInfo = Get-ComputerInfo -ErrorAction Stop
         }
@@ -32,7 +32,7 @@ function Install-WinUtilWinget {
         }
 
         if (($ComputerInfo.WindowsVersion) -lt "1809") {
-            #Checks if Windows Version is too old for winget
+            # Checks if Windows Version is too old for winget
             Write-Host "Winget is not supported on this version of Windows (Pre-1809)"
             return
         }

--- a/functions/private/Invoke-WinUtilBingSearch.ps1
+++ b/functions/private/Invoke-WinUtilBingSearch.ps1
@@ -2,7 +2,7 @@ function Invoke-WinUtilBingSearch {
     <#
     
         .DESCRIPTION
-        Sets Bing Search on or off
+        Disables/Enables Bing Search
     
     #>
     Param($Enabled)

--- a/functions/private/Invoke-WinUtilBingSearch.ps1
+++ b/functions/private/Invoke-WinUtilBingSearch.ps1
@@ -1,9 +1,12 @@
 function Invoke-WinUtilBingSearch {
     <#
-    
-        .DESCRIPTION
+
+    .SYNOPSIS
         Disables/Enables Bing Search
-    
+
+    .PARAMETER Enabled
+        Indicates whether to enable or disable Bing Search
+
     #>
     Param($Enabled)
     Try{

--- a/functions/private/Invoke-WinUtilBingSearch.ps1
+++ b/functions/private/Invoke-WinUtilBingSearch.ps1
@@ -1,5 +1,5 @@
 function Invoke-WinUtilBingSearch {
-        <#
+    <#
     
         .DESCRIPTION
         Sets Bing Search on or off

--- a/functions/private/Invoke-WinUtilCurrentSystem.ps1
+++ b/functions/private/Invoke-WinUtilCurrentSystem.ps1
@@ -3,9 +3,7 @@ Function Invoke-WinUtilCurrentSystem {
     <#
 
         .DESCRIPTION
-        Function is meant to read existing system registry and check according configuration.
-
-        Example: Is telemetry enabled? check the box.
+        Checks to see what tweaks have already been applied, and checks the according boxes
 
         .EXAMPLE
 

--- a/functions/private/Invoke-WinUtilCurrentSystem.ps1
+++ b/functions/private/Invoke-WinUtilCurrentSystem.ps1
@@ -2,11 +2,10 @@ Function Invoke-WinUtilCurrentSystem {
 
     <#
 
-        .DESCRIPTION
-        Checks to see what tweaks have already been applied, and checks the according boxes
+    .SYNOPSIS
+        Checks to see what tweaks have already been applied and what programs are installed, and checks the according boxes
 
-        .EXAMPLE
-
+    .EXAMPLE
         Get-WinUtilCheckBoxes "WPFInstall"
 
     #>

--- a/functions/private/Invoke-WinUtilDarkMode.ps1
+++ b/functions/private/Invoke-WinUtilDarkMode.ps1
@@ -1,5 +1,5 @@
 Function Invoke-WinUtilDarkMode {
-        <#
+    <#
     
         .DESCRIPTION
         Sets Dark Mode on or off

--- a/functions/private/Invoke-WinUtilDarkMode.ps1
+++ b/functions/private/Invoke-WinUtilDarkMode.ps1
@@ -2,7 +2,7 @@ Function Invoke-WinUtilDarkMode {
     <#
     
         .DESCRIPTION
-        Sets Dark Mode on or off
+        Enables/Disables Dark Mode
     
     #>
     Param($DarkMoveEnabled)

--- a/functions/private/Invoke-WinUtilDarkMode.ps1
+++ b/functions/private/Invoke-WinUtilDarkMode.ps1
@@ -1,9 +1,12 @@
 Function Invoke-WinUtilDarkMode {
     <#
-    
-        .DESCRIPTION
+
+    .SYNOPSIS
         Enables/Disables Dark Mode
-    
+
+    .PARAMETER DarkMoveEnabled
+        Indicates the current dark mode state
+
     #>
     Param($DarkMoveEnabled)
     Try{

--- a/functions/private/Invoke-WinUtilFeatureInstall.ps1
+++ b/functions/private/Invoke-WinUtilFeatureInstall.ps1
@@ -2,7 +2,7 @@ function Invoke-WinUtilFeatureInstall {
     <#
     
         .DESCRIPTION
-        This function converts all the values from the tweaks.json and routes them to the appropriate function
+        Converts all the values from the tweaks.json and routes them to the appropriate function
     
     #>
 

--- a/functions/private/Invoke-WinUtilFeatureInstall.ps1
+++ b/functions/private/Invoke-WinUtilFeatureInstall.ps1
@@ -1,9 +1,9 @@
 function Invoke-WinUtilFeatureInstall {
     <#
-    
-        .DESCRIPTION
+
+    .SYNOPSIS
         Converts all the values from the tweaks.json and routes them to the appropriate function
-    
+
     #>
 
     param(

--- a/functions/private/Invoke-WinUtilScript.ps1
+++ b/functions/private/Invoke-WinUtilScript.ps1
@@ -1,14 +1,19 @@
 function Invoke-WinUtilScript {
     <#
-    
-        .DESCRIPTION
-        Invokes the provided scriptblock. Intended for things that can't be handled with the other functions
 
-        .EXAMPLE
+    .SYNOPSIS
+        Invokes the provided scriptblock. Intended for things that can't be handled with the other functions.
 
+    .PARAMETER Name
+        The name of the scriptblock being invoked
+
+    .PARAMETER scriptblock
+        The scriptblock to be invoked
+
+    .EXAMPLE
         $Scriptblock = [scriptblock]::Create({"Write-output 'Hello World'"})
         Invoke-WinUtilScript -ScriptBlock $scriptblock -Name "Hello World"
-    
+
     #>
     param (
         $Name,

--- a/functions/private/Invoke-WinUtilScript.ps1
+++ b/functions/private/Invoke-WinUtilScript.ps1
@@ -2,7 +2,7 @@ function Invoke-WinUtilScript {
     <#
     
         .DESCRIPTION
-        This function will run a separate powershell script. Meant for things that can't be handled with the other functions
+        Invokes the provided scriptblock. Intended for things that can't be handled with the other functions
 
         .EXAMPLE
 

--- a/functions/private/Invoke-WinUtilTweaks.ps1
+++ b/functions/private/Invoke-WinUtilTweaks.ps1
@@ -1,9 +1,15 @@
 function Invoke-WinUtilTweaks {
     <#
-    
-        .DESCRIPTION
-        Converts all the values from the tweaks.json and routes them to the appropriate function
-    
+
+    .SYNOPSIS
+        Invokes the function associated with each provided checkbox
+
+    .PARAMETER CheckBox
+        The checkbox to invoke
+
+    .PARAMETER undo
+        Indicates whether to undo the operation contained in the checkbox
+
     #>
 
     param(

--- a/functions/private/Invoke-WinUtilTweaks.ps1
+++ b/functions/private/Invoke-WinUtilTweaks.ps1
@@ -2,7 +2,7 @@ function Invoke-WinUtilTweaks {
     <#
     
         .DESCRIPTION
-        This function converts all the values from the tweaks.json and routes them to the appropriate function
+        Converts all the values from the tweaks.json and routes them to the appropriate function
     
     #>
 

--- a/functions/private/Remove-WinUtilAPPX.ps1
+++ b/functions/private/Remove-WinUtilAPPX.ps1
@@ -2,7 +2,7 @@ function Remove-WinUtilAPPX {
     <#
     
         .DESCRIPTION
-        This function will remove any of the provided APPX names
+        Removes all APPX packages that match the given name
 
         .EXAMPLE
 

--- a/functions/private/Remove-WinUtilAPPX.ps1
+++ b/functions/private/Remove-WinUtilAPPX.ps1
@@ -1,13 +1,15 @@
 function Remove-WinUtilAPPX {
     <#
-    
-        .DESCRIPTION
+
+    .SYNOPSIS
         Removes all APPX packages that match the given name
 
-        .EXAMPLE
+    .PARAMETER Name
+        The name of the APPX package to remove
 
+    .EXAMPLE
         Remove-WinUtilAPPX -Name "Microsoft.Microsoft3DViewer"
-    
+
     #>
     param (
         $Name

--- a/functions/private/Set-WinUtilDNS.ps1
+++ b/functions/private/Set-WinUtilDNS.ps1
@@ -2,7 +2,7 @@ function Set-WinUtilDNS {
     <#
     
         .DESCRIPTION
-        This function will set the DNS of all interfaces that are in the "Up" state. It will lookup the values from the DNS.Json file
+        Sets the DNS of all interfaces that are in the "Up" state. It will lookup the values from the DNS.Json file
 
         .EXAMPLE
 

--- a/functions/private/Set-WinUtilDNS.ps1
+++ b/functions/private/Set-WinUtilDNS.ps1
@@ -1,13 +1,15 @@
 function Set-WinUtilDNS {
     <#
-    
-        .DESCRIPTION
+
+    .SYNOPSIS
         Sets the DNS of all interfaces that are in the "Up" state. It will lookup the values from the DNS.Json file
 
-        .EXAMPLE
+    .PARAMETER DNSProvider
+        The DNS provider to set the DNS server to
 
+    .EXAMPLE
         Set-WinUtilDNS -DNSProvider "google"
-    
+
     #>
     param($DNSProvider)
     if($DNSProvider -eq "Default"){return}

--- a/functions/private/Set-WinUtilRegistry.ps1
+++ b/functions/private/Set-WinUtilRegistry.ps1
@@ -2,7 +2,7 @@ function Set-WinUtilRegistry {
     <#
     
         .DESCRIPTION
-        This function will make all modifications to the registry
+        Modifies the registry based on the given inputs
 
         .EXAMPLE
 

--- a/functions/private/Set-WinUtilRegistry.ps1
+++ b/functions/private/Set-WinUtilRegistry.ps1
@@ -1,14 +1,25 @@
 function Set-WinUtilRegistry {
     <#
-    
-        .DESCRIPTION
+
+    .SYNOPSIS
         Modifies the registry based on the given inputs
 
-        .EXAMPLE
+    .PARAMETER Name
+        The name of the key to modify
 
+    .PARAMETER Path
+        The path to the key
+
+    .PARAMETER Type
+        The type of value to set the key to
+
+    .PARAMETER Value
+        The value to set the key to
+
+    .EXAMPLE
         Set-WinUtilRegistry -Name "PublishUserActivities" -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\System" -Type "DWord" -Value "0"
-    
-    #>    
+
+    #>
     param (
         $Name,
         $Path,

--- a/functions/private/Set-WinUtilRestorePoint.ps1
+++ b/functions/private/Set-WinUtilRestorePoint.ps1
@@ -1,10 +1,10 @@
 function Set-WinUtilRestorePoint {
     <#
-    
-        .DESCRIPTION
+
+    .SYNOPSIS
         Creates a Restore Point
 
-    #>    
+    #>
 
     # Check if the user has administrative privileges
     if (-Not ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {

--- a/functions/private/Set-WinUtilRestorePoint.ps1
+++ b/functions/private/Set-WinUtilRestorePoint.ps1
@@ -2,7 +2,7 @@ function Set-WinUtilRestorePoint {
     <#
     
         .DESCRIPTION
-        This function will make a Restore Point
+        Creates a Restore Point
 
     #>    
 

--- a/functions/private/Set-WinUtilScheduledTask.ps1
+++ b/functions/private/Set-WinUtilScheduledTask.ps1
@@ -2,7 +2,7 @@ function Set-WinUtilScheduledTask {
     <#
     
         .DESCRIPTION
-        This function will enable/disable the provided Scheduled Task
+        Enables/Disables the provided Scheduled Task
 
         .EXAMPLE
 

--- a/functions/private/Set-WinUtilScheduledTask.ps1
+++ b/functions/private/Set-WinUtilScheduledTask.ps1
@@ -1,13 +1,18 @@
 function Set-WinUtilScheduledTask {
     <#
-    
-        .DESCRIPTION
+
+    .SYNOPSIS
         Enables/Disables the provided Scheduled Task
 
-        .EXAMPLE
+    .PARAMETER Name
+        The path to the Scheduled Task
 
+    .PARAMETER State
+        The State to set the Task to
+
+    .EXAMPLE
         Set-WinUtilScheduledTask -Name "Microsoft\Windows\Application Experience\Microsoft Compatibility Appraiser" -State "Disabled"
-    
+
     #>
     param (
         $Name,

--- a/functions/private/Set-WinUtilService.ps1
+++ b/functions/private/Set-WinUtilService.ps1
@@ -2,7 +2,7 @@ Function Set-WinUtilService {
     <#
     
         .DESCRIPTION
-        This function will change the startup type of services and start/stop them as needed
+        Changes the startup type of services and starts/stops them as needed
 
         .EXAMPLE
 

--- a/functions/private/Set-WinUtilService.ps1
+++ b/functions/private/Set-WinUtilService.ps1
@@ -1,14 +1,19 @@
 Function Set-WinUtilService {
     <#
-    
-        .DESCRIPTION
-        Changes the startup type of services and starts/stops them as needed
 
-        .EXAMPLE
+    .SYNOPSIS
+        Changes the startup type of the given service
 
+    .PARAMETER Name
+        The name of the service to modify
+
+    .PARAMETER StartupType
+        The startup type to set the service to
+
+    .EXAMPLE
         Set-WinUtilService -Name "HomeGroupListener" -StartupType "Manual"
-    
-    #>   
+
+    #>
     param (
         $Name,
         $StartupType

--- a/functions/private/Set-WinUtilUiTheme.ps1
+++ b/functions/private/Set-WinUtilUiTheme.ps1
@@ -1,13 +1,18 @@
 function Set-WinUtilUITheme {
     <#
-    
-        .DESCRIPTION
+
+    .SYNOPSIS
         Sets the theme of the XAML file
 
-        .EXAMPLE
+    .PARAMETER inputXML
+        A string representing the XAML object to modify
 
+    .PARAMETER themeName
+        The name of the theme to set the XAML to. Defaults to 'matrix'
+
+    .EXAMPLE
         Set-WinUtilUITheme -inputXAML $inputXAML
-    
+
     #>
     param
     (

--- a/functions/private/Set-WinUtilUiTheme.ps1
+++ b/functions/private/Set-WinUtilUiTheme.ps1
@@ -2,7 +2,7 @@ function Set-WinUtilUITheme {
     <#
     
         .DESCRIPTION
-        This function will set theme to the XAML file
+        Sets the theme of the XAML file
 
         .EXAMPLE
 

--- a/functions/private/Test-WinUtilPackageManager.ps1
+++ b/functions/private/Test-WinUtilPackageManager.ps1
@@ -1,9 +1,15 @@
 function Test-WinUtilPackageManager {
     <#
-    
-        .DESCRIPTION
-        Checks for Winget or Choco depending on the parameter
-    
+
+    .SYNOPSIS
+        Checks if Winget and/or Choco are installed
+
+    .PARAMETER winget
+        Check if Winget is installed
+
+    .PARAMETER choco
+        Check if Chocolatey is installed
+
     #>
 
     Param(

--- a/functions/private/Update-WinUtilProgramWinget.ps1
+++ b/functions/private/Update-WinUtilProgramWinget.ps1
@@ -1,10 +1,10 @@
 Function Update-WinUtilProgramWinget {
 
     <#
-    
-        .DESCRIPTION
-        This will update programs via Winget using a new powershell.exe instance to prevent the GUI from locking up.
-    
+
+    .SYNOPSIS
+        This will update all programs using Winget
+
     #>
 
     [ScriptBlock]$wingetinstall = {

--- a/functions/public/Invoke-WPFButton.ps1
+++ b/functions/public/Invoke-WPFButton.ps1
@@ -1,12 +1,13 @@
 function Invoke-WPFButton {
 
     <#
-    
-        .DESCRIPTION
-        Meant to make creating buttons easier. There is a section below in the gui that will assign this function to every button.
-        This way you can dictate what each button does from this function. 
-    
-        Input will be the name of the button that is clicked. 
+
+    .SYNOPSIS
+        Invokes the function associated with the clicked button
+
+    .PARAMETER Button
+        The name of the button that was clicked
+
     #>
     
     Param ([string]$Button) 

--- a/functions/public/Invoke-WPFButton.ps1
+++ b/functions/public/Invoke-WPFButton.ps1
@@ -11,7 +11,7 @@ function Invoke-WPFButton {
     
     Param ([string]$Button) 
 
-    #Use this to get the name of the button
+    # Use this to get the name of the button
     #[System.Windows.MessageBox]::Show("$Button","Chris Titus Tech's Windows Utility","OK","Info")
 
     Switch -Wildcard ($Button){

--- a/functions/public/Invoke-WPFControlPanel.ps1
+++ b/functions/public/Invoke-WPFControlPanel.ps1
@@ -1,9 +1,12 @@
 function Invoke-WPFControlPanel {
     <#
-    
-        .DESCRIPTION
-        Simple switch for legacy panels
-    
+
+    .SYNOPSIS
+        Opens the requested legacy panel
+
+    .PARAMETER Panel
+        The panel to open
+
     #>
     param($Panel)
 

--- a/functions/public/Invoke-WPFControlPanel.ps1
+++ b/functions/public/Invoke-WPFControlPanel.ps1
@@ -1,5 +1,5 @@
 function Invoke-WPFControlPanel {
-        <#
+    <#
     
         .DESCRIPTION
         Simple Switch for legacy windows

--- a/functions/public/Invoke-WPFControlPanel.ps1
+++ b/functions/public/Invoke-WPFControlPanel.ps1
@@ -2,7 +2,7 @@ function Invoke-WPFControlPanel {
     <#
     
         .DESCRIPTION
-        Simple Switch for legacy windows
+        Simple switch for legacy panels
     
     #>
     param($Panel)

--- a/functions/public/Invoke-WPFFeatureInstall.ps1
+++ b/functions/public/Invoke-WPFFeatureInstall.ps1
@@ -1,5 +1,5 @@
 function Invoke-WPFFeatureInstall {
-        <#
+    <#
     
         .DESCRIPTION
         GUI Function to install Windows Features

--- a/functions/public/Invoke-WPFFeatureInstall.ps1
+++ b/functions/public/Invoke-WPFFeatureInstall.ps1
@@ -1,9 +1,9 @@
 function Invoke-WPFFeatureInstall {
     <#
-    
-        .DESCRIPTION
-        GUI Function to install Windows Features
-    
+
+    .SYNOPSIS
+        Installs selected Windows Features
+
     #>
 
     if($sync.ProcessRunning){

--- a/functions/public/Invoke-WPFFixesNetwork.ps1
+++ b/functions/public/Invoke-WPFFixesNetwork.ps1
@@ -7,8 +7,12 @@ function Invoke-WPFFixesNetwork {
     #>
 
     Write-Host "Resetting Network with netsh"
+
+    # Reset WinSock catalog to a clean state
     Start-Process -NoNewWindow -FilePath "netsh" -ArgumentList "winsock", "reset"
+    # Resets WinHTTP proxy setting to DIRECT
     Start-Process -NoNewWindow -FilePath "netsh" -ArgumentList "winhttp", "reset", "proxy"
+    # Removes all user configured IP settings
     Start-Process -NoNewWindow -FilePath "netsh" -ArgumentList "int", "ip", "reset"
 
     Write-Host "Process complete. Please reboot your computer."

--- a/functions/public/Invoke-WPFFixesNetwork.ps1
+++ b/functions/public/Invoke-WPFFixesNetwork.ps1
@@ -23,7 +23,7 @@ function Invoke-WPFFixesNetwork {
     $MessageIcon = [System.Windows.MessageBoxImage]::Information
 
     [System.Windows.MessageBox]::Show($Messageboxbody, $MessageboxTitle, $ButtonType, $MessageIcon)
-    Write-Host "================================="
-    Write-Host "-- Reset Network Configuration --"
-    Write-Host "================================="
+    Write-Host "=========================================="
+    Write-Host "-- Network Configuration has been Reset --"
+    Write-Host "=========================================="
 }

--- a/functions/public/Invoke-WPFFixesNetwork.ps1
+++ b/functions/public/Invoke-WPFFixesNetwork.ps1
@@ -1,9 +1,9 @@
 function Invoke-WPFFixesNetwork {
     <#
-    
-        .DESCRIPTION
-        PlaceHolder
-    
+
+    .SYNOPSIS
+        Resets various network configurations
+
     #>
 
     Write-Host "Resetting Network with netsh"

--- a/functions/public/Invoke-WPFFixesUpdate.ps1
+++ b/functions/public/Invoke-WPFFixesUpdate.ps1
@@ -7,7 +7,7 @@ function Invoke-WPFFixesUpdate {
     
     #>
 
-    ### Reset Windows Update Script - reregister dlls, services, and remove registry entries.
+    # Reset Windows Update Script - reregister dlls, services, and remove registry entries
 Write-Host "1. Stopping Windows Update Services..."
     Stop-Service -Name BITS
     Stop-Service -Name wuauserv
@@ -83,7 +83,7 @@ Write-Host "12) Forcing discovery..."
     $MessageIcon = [System.Windows.MessageBoxImage]::Information
 
     [System.Windows.MessageBox]::Show($Messageboxbody, $MessageboxTitle, $ButtonType, $MessageIcon)
-    Write-Host "================================="
-    Write-Host "-- Reset ALL Updates to Factory -"
-    Write-Host "================================="
+    Write-Host "==============================================="
+    Write-Host "-- Reset All Windows Update Settings to Stock -"
+    Write-Host "==============================================="
 }

--- a/functions/public/Invoke-WPFFixesUpdate.ps1
+++ b/functions/public/Invoke-WPFFixesUpdate.ps1
@@ -1,10 +1,10 @@
 function Invoke-WPFFixesUpdate {
 
     <#
-    
-        .DESCRIPTION
-        PlaceHolder
-    
+
+    .SYNOPSIS
+        Performs various tasks in an attempt to repair Windows Update
+
     #>
 
     # Reset Windows Update Script - reregister dlls, services, and remove registry entries

--- a/functions/public/Invoke-WPFFormVariables.ps1
+++ b/functions/public/Invoke-WPFFormVariables.ps1
@@ -1,9 +1,9 @@
 Function Invoke-WPFFormVariables {
     <#
-    
-        .DESCRIPTION
-        PlaceHolder
-    
+
+    .SYNOPSIS
+        Prints the logo
+
     #>
     #If ($global:ReadmeDisplay -ne $true) { Write-Host "If you need to reference this display again, run Get-FormVariables" -ForegroundColor Yellow; $global:ReadmeDisplay = $true }
 

--- a/functions/public/Invoke-WPFGetInstalled.ps1
+++ b/functions/public/Invoke-WPFGetInstalled.ps1
@@ -1,8 +1,11 @@
 function Invoke-WPFGetInstalled {
     <#
 
-        .DESCRIPTION
-        placeholder
+    .SYNOPSIS
+        Invokes the function that gets the checkboxes to check in a new runspace
+
+    .PARAMETER checkbox
+        Indicates whether to check for installed 'winget' programs or applied 'tweaks'
 
     #>
     param($checkbox)

--- a/functions/public/Invoke-WPFGetInstalled.ps1
+++ b/functions/public/Invoke-WPFGetInstalled.ps1
@@ -1,8 +1,8 @@
 function Invoke-WPFGetInstalled {
     <#
 
-    .DESCRIPTION
-    placeholder
+        .DESCRIPTION
+        placeholder
 
     #>
     param($checkbox)

--- a/functions/public/Invoke-WPFImpex.ps1
+++ b/functions/public/Invoke-WPFImpex.ps1
@@ -1,13 +1,18 @@
 function Invoke-WPFImpex {
     <#
-    
-        .DESCRIPTION
-        This function handles importing and exporting of the checkboxes checked for the tweaks section
 
-        .EXAMPLE
+    .SYNOPSIS
+        Handles importing and exporting of the checkboxes checked for the tweaks section
 
+    .PARAMETER type
+        Indicates whether to 'import' or 'export'
+
+    .PARAMETER checkbox
+        The checkbox to export to a file or apply the imported file to
+
+    .EXAMPLE
         Invoke-WPFImpex -type "export"
-    
+
     #>
     param(
         $type,

--- a/functions/public/Invoke-WPFInstall.ps1
+++ b/functions/public/Invoke-WPFInstall.ps1
@@ -28,7 +28,7 @@ function Invoke-WPFInstall {
             # Ensure winget is installed
             Install-WinUtilWinget
 
-            # Install all winget programs in new window
+            # Install all selected programs in new window
             Install-WinUtilProgramWinget -ProgramsToInstall $WingetInstall
 
             $ButtonType = [System.Windows.MessageBoxButton]::OK

--- a/functions/public/Invoke-WPFInstall.ps1
+++ b/functions/public/Invoke-WPFInstall.ps1
@@ -1,9 +1,9 @@
 function Invoke-WPFInstall {
     <#
-    
-        .DESCRIPTION
-        PlaceHolder
-    
+
+    .SYNOPSIS
+        Installs the selected programs using winget
+
     #>
 
     if($sync.ProcessRunning){

--- a/functions/public/Invoke-WPFInstallUpgrade.ps1
+++ b/functions/public/Invoke-WPFInstallUpgrade.ps1
@@ -1,9 +1,9 @@
 function Invoke-WPFInstallUpgrade {
     <#
-    
-        .DESCRIPTION
-        PlaceHolder
-    
+
+    .SYNOPSIS
+        Invokes the function that upgrades all installed programs using winget
+
     #>
     if(!(Test-WinUtilPackageManager -winget)){
         Write-Host "==========================================="

--- a/functions/public/Invoke-WPFPanelAutologin.ps1
+++ b/functions/public/Invoke-WPFPanelAutologin.ps1
@@ -1,9 +1,9 @@
 function Invoke-WPFPanelAutologin {
     <#
-    
-        .DESCRIPTION
-        PlaceHolder
-    
+
+    .SYNOPSIS
+        Enables autologin using Sysinternals Autologon.exe
+
     #>
     curl.exe -ss "https://live.sysinternals.com/Autologon.exe" -o $env:temp\autologin.exe # Official Microsoft recommendation https://learn.microsoft.com/en-us/sysinternals/downloads/autologon
     cmd /c $env:temp\autologin.exe /accepteula

--- a/functions/public/Invoke-WPFPanelDISM.ps1
+++ b/functions/public/Invoke-WPFPanelDISM.ps1
@@ -1,9 +1,26 @@
 function Invoke-WPFPanelDISM {
     <#
-    
-        .DESCRIPTION
-        PlaceHolder
-    
+
+    .SYNOPSIS
+        Checks for system corruption using Chkdsk, SFC, and DISM
+
+    .DESCRIPTION
+        1. Chkdsk    - Fixes disk and filesystem corruption
+        2. SFC Run 1 - Fixes system file corruption, and fixes DISM if it was corrupted
+        3. DISM      - Fixes system image corruption, and fixes SFC's system image if it was corrupted
+        4. SFC Run 2 - Fixes system file corruption, this time with an almost guaranteed uncorrupted system image
+
+    .NOTES
+        Command Arguments:
+            1. Chkdsk
+                /Scan - Runs an online scan on the system drive, attempts to fix any corruption, and queues other corruption for fixing on reboot
+            2. SFC
+                /ScanNow - Performs a scan of the system files and fixes any corruption
+            3. DISM      - Fixes system image corruption, and fixes SFC's system image if it was corrupted
+                /Online - Fixes the currently running system image
+                /Cleanup-Image - Performs cleanup operations on the image, could remove some unneeded temporary files
+                /Restorehealth - Performs a scan of the image and fixes any corruption
+
     #>
     Start-Process PowerShell -ArgumentList "Write-Host '(1/4) Chkdsk' -ForegroundColor Green; Chkdsk /scan;
     Write-Host '`n(2/4) SFC - 1st scan' -ForegroundColor Green; sfc /scannow;

--- a/functions/public/Invoke-WPFPresets.ps1
+++ b/functions/public/Invoke-WPFPresets.ps1
@@ -1,8 +1,17 @@
 function Invoke-WPFPresets {
     <#
 
-        .DESCRIPTION
-        Meant to make settings presets easier in the tweaks tab. Will pull the data from config/preset.json
+    .SYNOPSIS
+        Sets the options in the tweaks panel to the given preset
+
+    .PARAMETER preset
+        The preset to set the options to
+
+    .PARAMETER imported
+        If the preset is imported from a file, defaults to false
+
+    .PARAMETER checkbox
+        The checkbox to set the options to, defaults to 'WPFTweaks'
 
     #>
 

--- a/functions/public/Invoke-WPFRunspace.ps1
+++ b/functions/public/Invoke-WPFRunspace.ps1
@@ -23,7 +23,7 @@ function Invoke-WPFRunspace {
         $ArgumentList
     ) 
 
-    # Crate a PowerShell instance.
+    # Create a PowerShell instance
     $script:powershell = [powershell]::Create()
 
     # Add Scriptblock and Arguments to runspace
@@ -31,10 +31,10 @@ function Invoke-WPFRunspace {
     $script:powershell.AddArgument($ArgumentList)
     $script:powershell.RunspacePool = $sync.runspace
     
-    # Run our RunspacePool.
+    # Execute the RunspacePool
     $script:handle = $script:powershell.BeginInvoke()
 
-    # Cleanup our RunspacePool threads when they are complete ie. GC.
+    # Clean up the RunspacePool threads when they are complete, and invoke the garbage collector to clean up the memory
     if ($script:handle.IsCompleted)
     {
         $script:powershell.EndInvoke($script:handle)

--- a/functions/public/Invoke-WPFRunspace.ps1
+++ b/functions/public/Invoke-WPFRunspace.ps1
@@ -23,18 +23,18 @@ function Invoke-WPFRunspace {
         $ArgumentList
     ) 
 
-    #Crate a PowerShell instance.
+    # Crate a PowerShell instance.
     $script:powershell = [powershell]::Create()
 
-    #Add Scriptblock and Arguments to runspace
+    # Add Scriptblock and Arguments to runspace
     $script:powershell.AddScript($ScriptBlock)
     $script:powershell.AddArgument($ArgumentList)
     $script:powershell.RunspacePool = $sync.runspace
     
-    #Run our RunspacePool.
+    # Run our RunspacePool.
     $script:handle = $script:powershell.BeginInvoke()
 
-    #Cleanup our RunspacePool threads when they are complete ie. GC.
+    # Cleanup our RunspacePool threads when they are complete ie. GC.
     if ($script:handle.IsCompleted)
     {
         $script:powershell.EndInvoke($script:handle)

--- a/functions/public/Invoke-WPFRunspace.ps1
+++ b/functions/public/Invoke-WPFRunspace.ps1
@@ -1,20 +1,21 @@
 function Invoke-WPFRunspace {
 
     <#
-    
-        .DESCRIPTION
-        Simple function to make it easier to invoke a runspace from inside the script. 
 
-        .EXAMPLE
+    .SYNOPSIS
+        Creates and invokes a runspace using the given scriptblock and argumentlist
 
-        $params = @{
-            ScriptBlock = $sync.ScriptsInstallPrograms
-            ArgumentList = "Installadvancedip,Installbitwarden"
-            Verbose = $true
-        }
+    .PARAMETER ScriptBlock
+        The scriptblock to invoke in the runspace
 
-        Invoke-WPFRunspace @params
-    
+    .PARAMETER ArgumentList
+        A list of arguments to pass to the runspace
+
+    .EXAMPLE
+        Invoke-WPFRunspace `
+            -ScriptBlock $sync.ScriptsInstallPrograms `
+            -ArgumentList "Installadvancedip,Installbitwarden" `
+
     #>
 
     [CmdletBinding()]

--- a/functions/public/Invoke-WPFShortcut.ps1
+++ b/functions/public/Invoke-WPFShortcut.ps1
@@ -1,8 +1,11 @@
 function Invoke-WPFShortcut {
     <#
 
-        .DESCRIPTION
-        Creates a shortcut
+    .SYNOPSIS
+        Creates a shortcut and prompts for a save location
+
+    .PARAMETER ShortcutToAdd
+        The name of the shortcut to add
 
     #>
     param($ShortcutToAdd)

--- a/functions/public/Invoke-WPFTab.ps1
+++ b/functions/public/Invoke-WPFTab.ps1
@@ -1,10 +1,13 @@
 function Invoke-WPFTab {
 
     <#
-    
-        .DESCRIPTION
-        Sole purpose of this function is to reduce duplicated code for switching between tabs. 
-    
+
+    .SYNOPSIS
+        Sets the selected tab to the tab that was clicked
+
+    .PARAMETER ClickedTab
+        The name of the tab that was clicked
+
     #>
 
     Param ($ClickedTab)

--- a/functions/public/Invoke-WPFToggle.ps1
+++ b/functions/public/Invoke-WPFToggle.ps1
@@ -11,7 +11,7 @@ function Invoke-WPFToggle {
     
     Param ([string]$Button) 
 
-    #Use this to get the name of the button
+    # Use this to get the name of the button
     #[System.Windows.MessageBox]::Show("$Button","Chris Titus Tech's Windows Utility","OK","Info")
 
     Switch -Wildcard ($Button){

--- a/functions/public/Invoke-WPFToggle.ps1
+++ b/functions/public/Invoke-WPFToggle.ps1
@@ -1,12 +1,13 @@
 function Invoke-WPFToggle {
 
     <#
-    
-        .DESCRIPTION
-        Meant to make creating toggle switches easier. There is a section below in the gui that will assign this function to every switch.
-        This way you can dictate what each button does from this function. 
-    
-        Input will be the name of the toggle that is checked. 
+
+    .SYNOPSIS
+        Invokes the scriptblock for the given toggle
+
+    .PARAMETER Button
+        The name of the toggle to invoke
+
     #>
     
     Param ([string]$Button) 

--- a/functions/public/Invoke-WPFUltimatePerformance.ps1
+++ b/functions/public/Invoke-WPFUltimatePerformance.ps1
@@ -9,17 +9,16 @@ Function Invoke-WPFUltimatePerformance {
     Try{
 
         if($state -eq "Enabled"){
-            # Define the name and GUID of the power scheme you want to add
+            # Define the name and GUID of the power scheme
             $powerSchemeName = "Ultimate Performance"
             $powerSchemeGuid = "e9a42b02-d5df-448d-aa00-03f14749eb61"
 
             # Get all power schemes
             $schemes = powercfg /list | Out-String -Stream
 
-            # Find the scheme you want to add
+            # Check if the power scheme already exists
             $ultimateScheme = $schemes | Where-Object { $_ -match $powerSchemeName }
 
-            # If the scheme does not exist, add it
             if ($null -eq $ultimateScheme) {
                 Write-Host "Power scheme '$powerSchemeName' not found. Adding..."
 
@@ -34,13 +33,13 @@ Function Invoke-WPFUltimatePerformance {
             }           
         }
         elseif($state -eq "Disabled"){
-                # Define the name of the power scheme you want to remove
+                # Define the name of the power scheme
                 $powerSchemeName = "Ultimate Performance"
 
                 # Get all power schemes
                 $schemes = powercfg /list | Out-String -Stream
 
-                # Find the scheme you want to remove
+                # Find the scheme to be removed
                 $ultimateScheme = $schemes | Where-Object { $_ -match $powerSchemeName }
 
                 # If the scheme exists, remove it

--- a/functions/public/Invoke-WPFUltimatePerformance.ps1
+++ b/functions/public/Invoke-WPFUltimatePerformance.ps1
@@ -1,9 +1,12 @@
 Function Invoke-WPFUltimatePerformance {
     <#
-    
-        .DESCRIPTION
-        PlaceHolder
-    
+
+    .SYNOPSIS
+        Creates or removes the Ultimate Performance power scheme
+
+    .PARAMETER State
+        Indicates whether to enable or disable the Ultimate Performance power scheme
+
     #>
     param($State)
     Try{

--- a/functions/public/Invoke-WPFUnInstall.ps1
+++ b/functions/public/Invoke-WPFUnInstall.ps1
@@ -7,7 +7,7 @@ function Invoke-WPFUnInstall {
     #>
 
     if($sync.ProcessRunning){
-        $msg = "Install process is currently running."
+        $msg = "Install process is currently running"
         [System.Windows.MessageBox]::Show($msg, "Winutil", [System.Windows.MessageBoxButton]::OK, [System.Windows.MessageBoxImage]::Warning)
         return
     }
@@ -22,7 +22,7 @@ function Invoke-WPFUnInstall {
 
     $ButtonType = [System.Windows.MessageBoxButton]::YesNo
     $MessageboxTitle = "Are you sure?"
-    $Messageboxbody = ("This will uninstall the following applications `n $WingetInstall")
+    $Messageboxbody = ("This will uninstall the following applications: `n $WingetInstall")
     $MessageIcon = [System.Windows.MessageBoxImage]::Information
 
     $confirm = [System.Windows.MessageBox]::Show($Messageboxbody, $MessageboxTitle, $ButtonType, $MessageIcon)
@@ -34,7 +34,7 @@ function Invoke-WPFUnInstall {
         try{
             $sync.ProcessRunning = $true
 
-            # Install all winget programs in new window
+            # Install all selected programs in new window
             Install-WinUtilProgramWinget -ProgramsToInstall $WingetInstall -Manage "Uninstalling"
 
             $ButtonType = [System.Windows.MessageBoxButton]::OK
@@ -45,12 +45,12 @@ function Invoke-WPFUnInstall {
             [System.Windows.MessageBox]::Show($Messageboxbody, $MessageboxTitle, $ButtonType, $MessageIcon)
 
             Write-Host "==========================================="
-            Write-Host "--      Uninstalls have finished          ---"
+            Write-Host "--       Uninstalls have finished       ---"
             Write-Host "==========================================="
         }
         Catch {
             Write-Host "==========================================="
-            Write-Host "--      Winget failed to install        ---"
+            Write-Host "--       Winget failed to install       ---"
             Write-Host "==========================================="
         }
         $sync.ProcessRunning = $False

--- a/functions/public/Invoke-WPFUnInstall.ps1
+++ b/functions/public/Invoke-WPFUnInstall.ps1
@@ -1,9 +1,9 @@
 function Invoke-WPFUnInstall {
     <#
-    
-        .DESCRIPTION
-        PlaceHolder
-    
+
+    .SYNOPSIS
+        Uninstalls the selected programs
+
     #>
 
     if($sync.ProcessRunning){

--- a/functions/public/Invoke-WPFUpdatesdefault.ps1
+++ b/functions/public/Invoke-WPFUpdatesdefault.ps1
@@ -39,7 +39,7 @@ function Invoke-WPFUpdatesdefault {
     Remove-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\WindowsUpdate\UX\Settings" -Name "BranchReadinessLevel" -ErrorAction SilentlyContinue
     Remove-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\WindowsUpdate\UX\Settings" -Name "DeferFeatureUpdatesPeriodInDays" -ErrorAction SilentlyContinue
     Remove-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\WindowsUpdate\UX\Settings" -Name "DeferQualityUpdatesPeriodInDays" -ErrorAction SilentlyContinue
-    Write-Host "================================="
-    Write-Host "---  Updates Set to Default   ---"
-    Write-Host "================================="
+    Write-Host "==================================================="
+    Write-Host "---  Windows Update Settings Reset to Default   ---"
+    Write-Host "==================================================="
 }

--- a/functions/public/Invoke-WPFUpdatesdefault.ps1
+++ b/functions/public/Invoke-WPFUpdatesdefault.ps1
@@ -1,9 +1,9 @@
 function Invoke-WPFUpdatesdefault {
     <#
-    
-        .DESCRIPTION
-        PlaceHolder
-    
+
+    .SYNOPSIS
+        Resets Windows Update settings to default
+
     #>
     If (!(Test-Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU")) {
         New-Item -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" -Force | Out-Null

--- a/functions/public/Invoke-WPFUpdatesdisable.ps1
+++ b/functions/public/Invoke-WPFUpdatesdisable.ps1
@@ -1,9 +1,12 @@
 function Invoke-WPFUpdatesdisable {
     <#
-    
-        .DESCRIPTION
-        PlaceHolder
-    
+
+    .SYNOPSIS
+        Disables Windows Update
+
+    .NOTES
+        Disabling Windows Update is not recommended. This is only for advanced users who know what they are doing.
+
     #>
     If (!(Test-Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU")) {
         New-Item -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU" -Force | Out-Null

--- a/functions/public/Invoke-WPFUpdatesdisable.ps1
+++ b/functions/public/Invoke-WPFUpdatesdisable.ps1
@@ -27,6 +27,6 @@ function Invoke-WPFUpdatesdisable {
         Get-Service -Name $service -ErrorAction SilentlyContinue | Set-Service -StartupType Disabled
     }
     Write-Host "================================="
-    Write-Host "---  Updates ARE DISABLED     ---"
+    Write-Host "---   Updates ARE DISABLED    ---"
     Write-Host "================================="
 }

--- a/functions/public/Invoke-WPFUpdatessecurity.ps1
+++ b/functions/public/Invoke-WPFUpdatessecurity.ps1
@@ -1,9 +1,16 @@
 function Invoke-WPFUpdatessecurity {
     <#
-    
-        .DESCRIPTION
-        PlaceHolder
-    
+
+    .SYNOPSIS
+        Sets Windows Update to recommended settings
+
+    .DESCRIPTION
+        1. Disables driver offering through Windows Update
+        2. Disables Windows Update automatic restart
+        3. Sets Windows Update to Semi-Annual Channel (Targeted)
+        4. Defers feature updates for 365 days
+        5. Defers quality updates for 4 days
+
     #>
     Write-Host "Disabling driver offering through Windows Update..."
         If (!(Test-Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Device Metadata")) {

--- a/functions/public/Invoke-WPFtweaksbutton.ps1
+++ b/functions/public/Invoke-WPFtweaksbutton.ps1
@@ -1,9 +1,9 @@
 function Invoke-WPFtweaksbutton {
   <#
-  
-      .DESCRIPTION
-      PlaceHolder
-  
+
+    .SYNOPSIS
+        Invokes the functions associated with each group of checkboxes
+
   #>
 
   if($sync.ProcessRunning){

--- a/functions/public/Invoke-WPFundoall.ps1
+++ b/functions/public/Invoke-WPFundoall.ps1
@@ -1,9 +1,9 @@
 function Invoke-WPFundoall {
     <#
-    
-        .DESCRIPTION
-        PlaceHolder
-    
+
+    .SYNOPSIS
+        Undoes every selected tweak
+
     #>
 
     if($sync.ProcessRunning){

--- a/pester/configs.Tests.ps1
+++ b/pester/configs.Tests.ps1
@@ -1,10 +1,8 @@
-# Load Variables needed for testing
-
-    # Config Files
-    $global:importedconfigs = @{}
-    Get-ChildItem .\config | Where-Object {$_.Extension -eq ".json"} | ForEach-Object {
-        $global:importedconfigs[$psitem.BaseName] = Get-Content $psitem.FullName | ConvertFrom-Json
-    }
+# Import Config Files
+$global:importedconfigs = @{}
+Get-ChildItem .\config | Where-Object {$_.Extension -eq ".json"} | ForEach-Object {
+    $global:importedconfigs[$psitem.BaseName] = Get-Content $psitem.FullName | ConvertFrom-Json
+}
 
 
 #===========================================================================

--- a/pester/configs.Tests.ps1
+++ b/pester/configs.Tests.ps1
@@ -1,4 +1,4 @@
-#region Load Variables needed for testing
+# Load Variables needed for testing
 
     #Config Files
     $global:importedconfigs = @{}
@@ -7,7 +7,7 @@
     }
 
 
-#endregion Load Variables needed for testing 
+# Load Variables needed for testing 
 
 #===========================================================================
 # Tests - Application Installs

--- a/pester/configs.Tests.ps1
+++ b/pester/configs.Tests.ps1
@@ -1,13 +1,11 @@
 # Load Variables needed for testing
 
-    #Config Files
+    # Config Files
     $global:importedconfigs = @{}
     Get-ChildItem .\config | Where-Object {$_.Extension -eq ".json"} | ForEach-Object {
         $global:importedconfigs[$psitem.BaseName] = Get-Content $psitem.FullName | ConvertFrom-Json
     }
 
-
-# Load Variables needed for testing 
 
 #===========================================================================
 # Tests - Application Installs

--- a/pester/winutil.Tests.ps1
+++ b/pester/winutil.Tests.ps1
@@ -1,4 +1,4 @@
-#region Load Variables needed for testing
+# Load Variables needed for testing
 
     ./Compile.ps1
 
@@ -6,7 +6,7 @@
     $script[0..($script.count - 21)] | Out-File .\pester.ps1    
 
 
-#endregion Load Variables needed for testing 
+# Load Variables needed for testing 
 
 BeforeAll {
    . .\pester.ps1

--- a/pester/winutil.Tests.ps1
+++ b/pester/winutil.Tests.ps1
@@ -6,8 +6,6 @@
     $script[0..($script.count - 21)] | Out-File .\pester.ps1    
 
 
-# Load Variables needed for testing 
-
 BeforeAll {
    . .\pester.ps1
 }

--- a/pester/winutil.Tests.ps1
+++ b/pester/winutil.Tests.ps1
@@ -1,13 +1,15 @@
 # Load Variables needed for testing
 
-    ./Compile.ps1
+./Compile.ps1
 
-    $script = Get-Content .\winutil.ps1
-    $script[0..($script.count - 21)] | Out-File .\pester.ps1    
+$script = Get-Content .\winutil.ps1
+# Remove the part of the script that shows the form, leaving only the variable and function declarations
+$script[0..($script.count - 21)] | Out-File .\pester.ps1    
 
 
 BeforeAll {
-   . .\pester.ps1
+    # Execute the truncated script, bringing the variabes into the current scope
+    . .\pester.ps1
 }
 
 Describe "GUI" {

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -1,16 +1,16 @@
 # SPDX-License-Identifier: MIT
 
-#Configure max thread count for RunspacePool.
+# Configure max thread count for RunspacePool.
 $maxthreads = [int]$env:NUMBER_OF_PROCESSORS
 
-#Create a new session state for parsing variables ie hashtable into our runspace.
+# Create a new session state for parsing variables ie hashtable into our runspace.
 $hashVars = New-object System.Management.Automation.Runspaces.SessionStateVariableEntry -ArgumentList 'sync',$sync,$Null
 $InitialSessionState = [System.Management.Automation.Runspaces.InitialSessionState]::CreateDefault()
 
-#Add the variable to the RunspacePool sessionstate
+# Add the variable to the RunspacePool sessionstate
 $InitialSessionState.Variables.Add($hashVars)
 
-#Add functions
+# Add functions
 $functions = Get-ChildItem function:\ | Where-Object {$_.name -like "*winutil*" -or $_.name -like "*WPF*"}
 foreach ($function in $functions){
     $functionDefinition = Get-Content function:\$($function.name)
@@ -20,13 +20,13 @@ foreach ($function in $functions){
     $initialSessionState.Commands.Add($functionEntry)
 }
 
-#Create our runspace pool. We are entering three parameters here min thread count, max thread count and host machine of where these runspaces should be made.
+# Create our runspace pool. We are entering three parameters here min thread count, max thread count and host machine of where these runspaces should be made.
 $sync.runspace = [runspacefactory]::CreateRunspacePool(1,$maxthreads,$InitialSessionState, $Host)
 
-#Open a RunspacePool instance.
+# Open a RunspacePool instance.
 $sync.runspace.Open()
 
-#region exception classes
+# Exception classes
 
     class WingetFailedInstall : Exception {
         [string] $additionalData
@@ -46,7 +46,6 @@ $sync.runspace.Open()
         GenericException($Message) : base($Message) {}
     }
     
-#endregion exception classes
 
 $inputXML = $inputXML -replace 'mc:Ignorable="d"', '' -replace "x:N", 'N' -replace '^<Win.*', '<Window'
 
@@ -61,7 +60,7 @@ $inputXML = Set-WinUtilUITheme -inputXML $inputXML -themeName $ctttheme
 
 [void][System.Reflection.Assembly]::LoadWithPartialName('presentationframework')
 [xml]$XAML = $inputXML
-#Read XAML
+# Read XAML
 
 $reader = (New-Object System.Xml.XmlNodeReader $xaml)
 try { $sync["Form"] = [Windows.Markup.XamlReader]::Load( $reader ) }
@@ -116,7 +115,7 @@ $sync.keys | ForEach-Object {
 # Setup background config
 #===========================================================================
 
-#Load information in the background
+# Load information in the background
 Invoke-WPFRunspace -ScriptBlock {
     $sync.ConfigLoaded = $False
 

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: MIT
 
-# Configure max thread count for RunspacePool.
+# Configure max thread count for RunspacePool
 $maxthreads = [int]$env:NUMBER_OF_PROCESSORS
 
-# Create a new session state for parsing variables ie hashtable into our runspace.
+# Create a new session state for parsing variables into our runspace
 $hashVars = New-object System.Management.Automation.Runspaces.SessionStateVariableEntry -ArgumentList 'sync',$sync,$Null
 $InitialSessionState = [System.Management.Automation.Runspaces.InitialSessionState]::CreateDefault()
 
@@ -16,12 +16,12 @@ foreach ($function in $functions){
     $functionDefinition = Get-Content function:\$($function.name)
     $functionEntry = New-Object System.Management.Automation.Runspaces.SessionStateFunctionEntry -ArgumentList $($function.name), $functionDefinition
     
-    # And add it to the iss object
+    # Add it to the iss object
     $initialSessionState.Commands.Add($functionEntry)
 }
 
-# Create our runspace pool. We are entering three parameters here min thread count, max thread count and host machine of where these runspaces should be made.
 $sync.runspace = [runspacefactory]::CreateRunspacePool(1,$maxthreads,$InitialSessionState, $Host)
+# Create the runspace pool
 
 # Open a RunspacePool instance.
 $sync.runspace.Open()
@@ -60,8 +60,8 @@ $inputXML = Set-WinUtilUITheme -inputXML $inputXML -themeName $ctttheme
 
 [void][System.Reflection.Assembly]::LoadWithPartialName('presentationframework')
 [xml]$XAML = $inputXML
-# Read XAML
 
+# Read the XAML file
 $reader = (New-Object System.Xml.XmlNodeReader $xaml)
 try { $sync["Form"] = [Windows.Markup.XamlReader]::Load( $reader ) }
 catch [System.Management.Automation.MethodInvocationException] {
@@ -72,7 +72,7 @@ catch [System.Management.Automation.MethodInvocationException] {
     }
 }
 catch {
-    # If it broke some other way <img draggable="false" role="img" class="emoji" alt="😀" src="https://s0.wp.com/wp-content/mu-plugins/wpcom-smileys/twemoji/2/svg/1f600.svg">
+    # If it broke some other way
     Write-Host "Unable to load Windows.Markup.XamlReader. Double-check syntax and ensure .net is installed."
 }
 
@@ -115,7 +115,7 @@ $sync.keys | ForEach-Object {
 # Setup background config
 #===========================================================================
 
-# Load information in the background
+# Load computer information in the background
 Invoke-WPFRunspace -ScriptBlock {
     $sync.ConfigLoaded = $False
 
@@ -125,7 +125,7 @@ Invoke-WPFRunspace -ScriptBlock {
 } | Out-Null
 
 #===========================================================================
-# Shows the form
+# Show the form
 #===========================================================================
 
 Invoke-WPFFormVariables

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -75,11 +75,8 @@ catch [System.Management.Automation.MethodInvocationException] {
         write-warning "Ensure your &lt;button in the `$inputXML does NOT have a Click=ButtonClick property.  PS can't handle this`n`n`n`n"
     }
 }
-catch [System.Management.Automation.RuntimeException] {
-    Write-Host "Unable to load Windows.Markup.XamlReader. Double-check syntax and ensure .net is installed."
-}
 catch {
-    Write-Error "An Error occurred while attempting to load the XAML file: $_"
+    Write-Host "Unable to load Windows.Markup.XamlReader. Double-check syntax and ensure .net is installed."
 }
 
 #===========================================================================

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -7,16 +7,15 @@ $maxthreads = [int]$env:NUMBER_OF_PROCESSORS
 $hashVars = New-object System.Management.Automation.Runspaces.SessionStateVariableEntry -ArgumentList 'sync',$sync,$Null
 $InitialSessionState = [System.Management.Automation.Runspaces.InitialSessionState]::CreateDefault()
 
-# Add the variable to the RunspacePool sessionstate
+# Add the variable to the session state
 $InitialSessionState.Variables.Add($hashVars)
 
-# Add functions
+# Get every private function and add them to the session state
 $functions = Get-ChildItem function:\ | Where-Object {$_.name -like "*winutil*" -or $_.name -like "*WPF*"}
 foreach ($function in $functions){
     $functionDefinition = Get-Content function:\$($function.name)
     $functionEntry = New-Object System.Management.Automation.Runspaces.SessionStateFunctionEntry -ArgumentList $($function.name), $functionDefinition
-    
-    # Add it to the iss object
+
     $initialSessionState.Commands.Add($functionEntry)
 }
 
@@ -28,10 +27,10 @@ $sync.runspace = [runspacefactory]::CreateRunspacePool(
     $Host                   # Machine to create runspaces on
 )
 
-# Open a RunspacePool instance.
+# Open the RunspacePool instance
 $sync.runspace.Open()
 
-# Exception classes
+# Create classes for different exceptions
 
     class WingetFailedInstall : Exception {
         [string] $additionalData
@@ -132,7 +131,7 @@ Invoke-WPFRunspace -ScriptBlock {
 } | Out-Null
 
 #===========================================================================
-# Setup and Show the Window
+# Setup and Show the Form
 #===========================================================================
 
 # Print the logo

--- a/scripts/start.ps1
+++ b/scripts/start.ps1
@@ -8,10 +8,10 @@
 
 Start-Transcript $ENV:TEMP\Winutil.log -Append
 
-#Load DLLs
+# Load DLLs
 Add-Type -AssemblyName System.Windows.Forms
 
-# variable to sync between runspaces
+# Variable to sync between runspaces
 $sync = [Hashtable]::Synchronized(@{})
 $sync.PSScriptRoot = $PSScriptRoot
 $sync.version = "#{replaceme}"


### PR DESCRIPTION
Yes, I'm alive, took a bit of a long break to do more WinFetch shenanigans and to learn Rust. But I've now finally got around with familiarizing myself with the very updated version of this script. And what better way to do that than to improve the grammar/formatting

- Adjusts comments and `Write-Host` statements to be more consistent and readable
  - Capitalizes the first letter
  - Space between `#` and first word
  - Only one `#` in the majority of instances
  - Only use a period if there is more than one sentence
  - Fixed a few typos
  - Sentences are in present tense
  - Text in the large `Write-Host` statements are now centered

- Replaces the Placeholder comments in the functions with full synopses