### PR TITLE
replacing the hard-coded paths for windows dir

### DIFF
--- a/functions/public/Invoke-WPFShortcut.ps1
+++ b/functions/public/Invoke-WPFShortcut.ps1
@@ -12,7 +12,7 @@ function Invoke-WPFShortcut {
 
     Switch ($ShortcutToAdd) {
         "WinUtil" {
-            $SourceExe = "C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe"
+            $SourceExe = "$env:SystemRoot\System32\WindowsPowerShell\v1.0\powershell.exe"
             $IRM = 'irm https://christitus.com/win | iex'
             $Powershell = '-ExecutionPolicy Bypass -Command "Start-Process powershell.exe -verb runas -ArgumentList'
             $ArgumentsToSourceExe = "$powershell '$IRM'"

--- a/gpedit-home.ps1
+++ b/gpedit-home.ps1
@@ -1,4 +1,4 @@
 Get-ChildItem @(
-    "C:\Windows\servicing\Packages\Microsoft-Windows-GroupPolicy-ClientTools-Package*.mum",
-    "C:\Windows\servicing\Packages\Microsoft-Windows-GroupPolicy-ClientExtensions-Package*.mum"
+    "$env:SystemRoot\servicing\Packages\Microsoft-Windows-GroupPolicy-ClientTools-Package*.mum",
+    "$env:SystemRoot\servicing\Packages\Microsoft-Windows-GroupPolicy-ClientExtensions-Package*.mum"
 ) | ForEach-Object { dism.exe /online /norestart /add-package:"$_" }

--- a/winutil.ps1
+++ b/winutil.ps1
@@ -1634,7 +1634,7 @@ function Invoke-WPFShortcut {
 
     Switch ($ShortcutToAdd) {
         "WinUtil" {
-            $SourceExe = "C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe"
+            $SourceExe = "$env:SystemRoot\System32\WindowsPowerShell\v1.0\powershell.exe"
             $IRM = 'irm https://christitus.com/win | iex'
             $Powershell = '-ExecutionPolicy Bypass -Command "Start-Process powershell.exe -verb runas -ArgumentList'
             $ArgumentsToSourceExe = "$powershell '$IRM'"


### PR DESCRIPTION
Replaced `C:\Windows`  to environment variable for Windows directory, for compatibility if Windows is installed with a different drive letter.