### PR TITLE
Changed version of python for winget to 3.12

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -432,7 +432,7 @@
 		"choco": "putty"
 	},
 	"WPFInstallpython3": {
-		"winget": "Python.Python.3.11",
+		"winget": "Python.Python.3.12",
 		"choco": "python"
 	},
 	"WPFInstallqbittorrent": {


### PR DESCRIPTION
Edited application.json to have the version of python updated to the new 3.12 for winget. Choco should work without any changes.