### PR TITLE
Add Session messenger to the applications list.

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -463,6 +463,10 @@
 		"winget": "GlennDelahoy.SnappyDriverInstallerOrigin",
 		"choco": "sdio"
 	},
+	"WPFInstallsession": {
+		"winget": "Oxen.Session",
+		"choco": "session"
+	},
 	"WPFInstallsharex": {
 		"winget": "ShareX.ShareX",
 		"choco": "sharex"

--- a/xaml/inputXML.xaml
+++ b/xaml/inputXML.xaml
@@ -272,6 +272,7 @@
                                 <CheckBox Name="WPFInstallhexchat" Content="Hexchat" Margin="5,0"/>
                                 <CheckBox Name="WPFInstalljami" Content="Jami" Margin="5,0"/>
                                 <CheckBox Name="WPFInstallmatrix" Content="Matrix" Margin="5,0"/>
+				<CheckBox Name="WPFInstallsession" Content="Session" Margin="5,0"/>
                                 <CheckBox Name="WPFInstallsignal" Content="Signal" Margin="5,0"/>
                                 <CheckBox Name="WPFInstallskype" Content="Skype" Margin="5,0"/>
                                 <CheckBox Name="WPFInstallslack" Content="Slack" Margin="5,0"/>


### PR DESCRIPTION
Hello!
I'd like to suggest adding Session messenger as an install option.
Session (https://getsession.org/ )is an open source messenger app that:
- uses onion routing for messages
- does not require phone number to use it
- have similair features to Signal
- is secure and private 