### PR TITLE
Remove hardcoded GUID on services

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -179,12 +179,12 @@
         "OriginalType": "Manual"
       },
       {
-        "Name": "BcastDVRUserService_dc2a4",
+        "Name": "BcastDVRUserService_*",
         "StartupType": "Manual",
         "OriginalType": "Manual"
       },
       {
-        "Name": "BluetoothUserService_dc2a4",
+        "Name": "BluetoothUserService_*",
         "StartupType": "Manual",
         "OriginalType": "Manual"
       },
@@ -214,7 +214,7 @@
         "OriginalType": "Automatic"
       },
       {
-        "Name": "CDPUserSvc_dc2a4",
+        "Name": "CDPUserSvc_*",
         "StartupType": "Automatic",
         "OriginalType": "Automatic"
       },
@@ -224,7 +224,7 @@
         "OriginalType": "Manual"
       },
       {
-        "Name": "CaptureService_dc2a4",
+        "Name": "CaptureService_*",
         "StartupType": "Manual",
         "OriginalType": "Manual"
       },
@@ -239,7 +239,7 @@
         "OriginalType": "Manual"
       },
       {
-        "Name": "ConsentUxUserSvc_dc2a4",
+        "Name": "ConsentUxUserSvc_*",
         "StartupType": "Manual",
         "OriginalType": "Manual"
       },
@@ -249,7 +249,7 @@
         "OriginalType": "Automatic"
       },
       {
-        "Name": "CredentialEnrollmentManagerUserSvc_dc2a4",
+        "Name": "CredentialEnrollmentManagerUserSvc_*",
         "StartupType": "Manual",
         "OriginalType": "Manual"
       },
@@ -284,7 +284,7 @@
         "OriginalType": "Manual"
       },
       {
-        "Name": "DeviceAssociationBrokerSvc_dc2a4",
+        "Name": "DeviceAssociationBrokerSvc_*",
         "StartupType": "Manual",
         "OriginalType": "Manual"
       },
@@ -299,12 +299,12 @@
         "OriginalType": "Manual"
       },
       {
-        "Name": "DevicePickerUserSvc_dc2a4",
+        "Name": "DevicePickerUserSvc_*",
         "StartupType": "Manual",
         "OriginalType": "Manual"
       },
       {
-        "Name": "DevicesFlowUserSvc_dc2a4",
+        "Name": "DevicesFlowUserSvc_*",
         "StartupType": "Manual",
         "OriginalType": "Manual"
       },
@@ -514,7 +514,7 @@
         "OriginalType": "Manual"
       },
       {
-        "Name": "MessagingService_dc2a4",
+        "Name": "MessagingService_*",
         "StartupType": "Manual",
         "OriginalType": "Manual"
       },
@@ -539,7 +539,7 @@
         "OriginalType": "Disabled"
       },
       {
-        "Name": "NPSMSvc_dc2a4",
+        "Name": "NPSMSvc_*",
         "StartupType": "Manual",
         "OriginalType": "Manual"
       },
@@ -599,12 +599,12 @@
         "OriginalType": "Manual"
       },
       {
-        "Name": "OneSyncSvc_dc2a4",
+        "Name": "OneSyncSvc_*",
         "StartupType": "Automatic",
         "OriginalType": "Automatic"
       },
       {
-        "Name": "P9RdrService_dc2a4",
+        "Name": "P9RdrService_*",
         "StartupType": "Manual",
         "OriginalType": "Manual"
       },
@@ -629,7 +629,7 @@
         "OriginalType": "Manual"
       },
       {
-        "Name": "PenService_dc2a4",
+        "Name": "PenService_*",
         "StartupType": "Manual",
         "OriginalType": "Manual"
       },
@@ -644,7 +644,7 @@
         "OriginalType": "Manual"
       },
       {
-        "Name": "PimIndexMaintenanceSvc_dc2a4",
+        "Name": "PimIndexMaintenanceSvc_*",
         "StartupType": "Manual",
         "OriginalType": "Manual"
       },
@@ -669,7 +669,7 @@
         "OriginalType": "Manual"
       },
       {
-        "Name": "PrintWorkflowUserSvc_dc2a4",
+        "Name": "PrintWorkflowUserSvc_*",
         "StartupType": "Manual",
         "OriginalType": "Manual"
       },
@@ -944,7 +944,7 @@
         "OriginalType": "Manual"
       },
       {
-        "Name": "UdkUserSvc_dc2a4",
+        "Name": "UdkUserSvc_*",
         "StartupType": "Manual",
         "OriginalType": "Manual"
       },
@@ -959,12 +959,12 @@
         "OriginalType": "Manual"
       },
       {
-        "Name": "UnistoreSvc_dc2a4",
+        "Name": "UnistoreSvc_*",
         "StartupType": "Manual",
         "OriginalType": "Manual"
       },
       {
-        "Name": "UserDataSvc_dc2a4",
+        "Name": "UserDataSvc_*",
         "StartupType": "Manual",
         "OriginalType": "Manual"
       },
@@ -1144,7 +1144,7 @@
         "OriginalType": "Automatic"
       },
       {
-        "Name": "WpnUserService_dc2a4",
+        "Name": "WpnUserService_*",
         "StartupType": "Automatic",
         "OriginalType": "Automatic"
       },
@@ -1189,7 +1189,7 @@
         "OriginalType": "Manual"
       },
       {
-        "Name": "cbdhsvc_dc2a4",
+        "Name": "cbdhsvc_*",
         "StartupType": "Manual",
         "OriginalType": "Automatic"
       },
@@ -1459,7 +1459,7 @@
         "OriginalType": "Manual"
       },
       {
-        "Name": "webthreatdefusersvc_dc2a4",
+        "Name": "webthreatdefusersvc_*",
         "StartupType": "Automatic",
         "OriginalType": "Automatic"
       },

--- a/functions/private/MicroWin-Helper.ps1
+++ b/functions/private/MicroWin-Helper.ps1
@@ -417,7 +417,7 @@ function New-FirstRun {
 			"BITS",
 			"BrokerInfrastructure",
 			"CDPSvc",
-			"CDPUserSvc_dc2a4",
+			"CDPUserSvc_*",
 			"CoreMessagingRegistrar",
 			"CryptSvc",
 			"DPS",
@@ -435,7 +435,7 @@ function New-FirstRun {
 			"LanmanWorkstation",
 			"MapsBroker",
 			"MpsSvc",
-			"OneSyncSvc_dc2a4",
+			"OneSyncSvc_*",
 			"Power",
 			"ProfSvc",
 			"RpcEptMapper",
@@ -461,8 +461,8 @@ function New-FirstRun {
 			"Winmgmt",
 			"WlanSvc",
 			"WpnService",
-			"WpnUserService_dc2a4",
-			"cbdhsvc_dc2a4",
+			"WpnUserService_*",
+			"cbdhsvc_*",
 			"edgeupdate",
 			"gpsvc",
 			"iphlpsvc",
@@ -471,7 +471,7 @@ function New-FirstRun {
 			"sppsvc",
 			"tiledatamodelsvc",
 			"vm3dservice",
-			"webthreatdefusersvc_dc2a4",
+			"webthreatdefusersvc_*",
 			"wscsvc"
 "@		
 	


### PR DESCRIPTION
- Change to capture unique value per machine, wildcard should suffice (untested)?

#### In reference to:
[Issue#1258](https://github.com/ChrisTitusTech/winutil/issues/1258)

#### Example of the unique GUID per machine (image from the issue above)
- `dc2a4` is the hardcoded value in the current code
![](https://private-user-images.githubusercontent.com/153093868/288439804-d4158b75-e5d0-4840-a68b-0a836c6e6223.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTEiLCJleHAiOjE3MDE4OTMwNjksIm5iZiI6MTcwMTg5Mjc2OSwicGF0aCI6Ii8xNTMwOTM4NjgvMjg4NDM5ODA0LWQ0MTU4Yjc1LWU1ZDAtNDg0MC1hNjhiLTBhODM2YzZlNjIyMy5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBSVdOSllBWDRDU1ZFSDUzQSUyRjIwMjMxMjA2JTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDIzMTIwNlQxOTU5MjlaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT1mMDcyNDk0NTBiNTE5YzJmMzEzNDI5MWQ0ZjhiNzc2MzBkZjc3NzI2NGMwNWE4ZDM2ZDFkYzc1OWM3ZWI4MTdmJlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCZhY3Rvcl9pZD0wJmtleV9pZD0wJnJlcG9faWQ9MCJ9.f-mzjDql7nRaYS1u2O1H7JRo1Wr7mHp0yjJrAPkPJts)

Example(s):
```powershell
      {
        "Name": "BcastDVRUserService_dc2a4",
        "StartupType": "Manual",
        "OriginalType": "Manual"
      },
      {
        "Name": "BluetoothUserService_dc2a4",
        "StartupType": "Manual",
        "OriginalType": "Manual"
      },

```


