### PR TITLE
[MicroWin] Get-LocalizedYesNo does not work correctly for some localizations

### DIFF
--- a/functions/private/Get-LocalizedYesNo.ps1
+++ b/functions/private/Get-LocalizedYesNo.ps1
@@ -30,7 +30,7 @@ function Get-LocalizedYesNo {
                 break
             }    
         }
-        elseif ($line -match "/D   ") 
+        elseif ($line -match "/D\s+") 
         {
             $found = $true
         }


### PR DESCRIPTION
I tried to use MicroWin to create a compact image, however, I encountered the following error.

![Invoke-WPFMicrowin](https://github.com/ChrisTitusTech/winutil/assets/31767561/d3a22c5a-7aae-423d-a778-f0e519d75576)

I had to do some research, which revealed the problem that on my localization (ru) the help has only 2 spaces instead of 3.

![takeown.exe](https://github.com/ChrisTitusTech/winutil/assets/31767561/50fa0906-7c33-4f2e-ab79-14aa58a6f0db)

This caused an error that did not allow to return values for Yes and No correctly. After replacing the fixed number of spaces with a regular expression, everything worked correctly.  I can assume that this problem occurs not only on my localization.