### PR TITLE
Fix wrong hash verification for oscdimg

### DIFF
--- a/functions/private/Get-Oscdimg.ps1
+++ b/functions/private/Get-Oscdimg.ps1
@@ -18,7 +18,7 @@ function Get-Oscdimg {
 
     Write-Host "[INFO] oscdimg.exe SHA-256 Hash: $sha256Hash"
 
-    $expectedHash = "F62B91A06F94019A878DD9D1713FFBA2140B863C131EB78A329B4CCD6102960E"  # Replace with the actual expected hash
+    $expectedHash = "AB9E161049D293B544961BFDF2D61244ADE79376D6423DF4F60BF9B147D3C78D"  # Replace with the actual expected hash
     if ($sha256Hash -eq $expectedHash) {
         Write-Host "Hashes match. File is verified."
     } else {

--- a/winutil.ps1
+++ b/winutil.ps1
@@ -10,7 +10,7 @@
     Author         : Chris Titus @christitustech
     Runspace Author: @DeveloperDurp
     GitHub         : https://github.com/ChrisTitusTech
-    Version        : 23.12.19
+    Version        : 23.12.20
 #>
 
 Start-Transcript $ENV:TEMP\Winutil.log -Append
@@ -22,7 +22,7 @@ Add-Type -AssemblyName System.Windows.Forms
 # Variable to sync between runspaces
 $sync = [Hashtable]::Synchronized(@{})
 $sync.PSScriptRoot = $PSScriptRoot
-$sync.version = "23.12.19"
+$sync.version = "23.12.20"
 $sync.configs = @{}
 $sync.ProcessRunning = $false
 
@@ -190,7 +190,7 @@ function Get-Oscdimg {
 
     Write-Host "[INFO] oscdimg.exe SHA-256 Hash: $sha256Hash"
 
-    $expectedHash = "F62B91A06F94019A878DD9D1713FFBA2140B863C131EB78A329B4CCD6102960E"  # Replace with the actual expected hash
+    $expectedHash = "AB9E161049D293B544961BFDF2D61244ADE79376D6423DF4F60BF9B147D3C78D"  # Replace with the actual expected hash
     if ($sha256Hash -eq $expectedHash) {
         Write-Host "Hashes match. File is verified."
     } else {

--- a/winutil.ps1
+++ b/winutil.ps1
@@ -183,8 +183,7 @@ function Get-Oscdimg {
         $oscdimgPath = "$env:TEMP\oscdimg.exe"
     )
     
-    $githubUserName = "ChrisTitusTech"
-    $downloadUrl = "https://github.com/$githubUserName/winutil/releases/oscdimg.exe"
+    $downloadUrl = "https://github.com/ChrisTitusTech/winutil/raw/main/releases/oscdimg.exe"
     Invoke-RestMethod -Uri $downloadUrl -OutFile $oscdimgPath
     $hashResult = Get-FileHash -Path $oscdimgPath -Algorithm SHA256
     $sha256Hash = $hashResult.Hash


### PR DESCRIPTION
The old hash was for other exe, the hash for the new exe is replaced here.