### PR TITLE
Fix Winget package for Chromium and add Ungoogled-Chromium

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -92,7 +92,7 @@
 		"choco": "googlechrome"
 	},
 	"WPFInstallchromium": {
-		"winget": "eloston.ungoogled-chromium",
+		"winget": "Hibbiki.Chromium",
 		"choco": "chromium"
 	},
 	"WPFInstallcider": {
@@ -862,6 +862,10 @@
 	"WPFInstallubuntu2204": {
 		"winget": "Canonical.Ubuntu.2204",
 		"choco": "na"
+	},
+	"WPFInstallungoogled": {
+		"winget": "eloston.ungoogled-chromium",
+		"choco": "ungoogled-chromium"
 	},
 	"WPFInstallunity": {
 		"winget": "Unity.UnityHub",

--- a/xaml/inputXML.xaml
+++ b/xaml/inputXML.xaml
@@ -618,6 +618,7 @@
                             <CheckBox Name="WPFInstallfloorp" Content="Floorp" Margin="5,0"/>
                             <CheckBox Name="WPFInstalllibrewolf" Content="LibreWolf" Margin="5,0"/>
                             <CheckBox Name="WPFInstalltor" Content="Tor Browser" Margin="5,0"/>
+                            <CheckBox Name="WPFInstallungoogled" Content="Ungoogled" Margin="5,0"/>
                             <CheckBox Name="WPFInstallvivaldi" Content="Vivaldi" Margin="5,0"/>
                             <CheckBox Name="WPFInstallwaterfox" Content="Waterfox" Margin="5,0"/>
 


### PR DESCRIPTION
The Winget package for Chromium was previously the one for Ungoogled-Chromium, I fixed it and added Ungoogled-Chromium as a separate package instead.