### PR TITLE
Update pester to remove form completely

### DIFF
--- a/pester/winutil.Tests.ps1
+++ b/pester/winutil.Tests.ps1
@@ -4,7 +4,7 @@
 
 $script = Get-Content .\winutil.ps1 -ErrorAction Stop
 # Remove the part of the script that shows the form, leaving only the variable and function declarations
-$script[0..($script.count - 3)] | Out-File .\pester.ps1 -ErrorAction Stop
+$script[0..($script.count - 206)] | Out-File .\pester.ps1 -ErrorAction Stop
 
 
 BeforeAll {


### PR DESCRIPTION
This made the test pass, although it still shows the same error as before when you dig into the unit test. I'll keep poking at it.

PR opened only for visibility.