### PR TITLE
Remove Cider Music Player

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -1069,16 +1069,7 @@
 		"content": "Blender (3D Graphics)",
 		"description": "Blender is a powerful open-source 3D creation suite, offering modeling, sculpting, animation, and rendering tools.",
 		"link": "https://www.blender.org/"
-	},
-	"WPFInstallcider": {
-		"winget": "CiderCollective.Cider",
-		"choco": "cider",
-		"category": "Multimedia Tools",
-		"panel": "3",
-		"content": "Cider (FOSS Music Player)",
-		"description": "Cider is a free and open-source music player that focuses on simplicity, providing a clean interface for enjoying your music.",
-		"link": "https://getcider.io/"
-	},
+	}
 	"WPFInstallclementine": {
 		"winget": "Clementine.Clementine",
 		"choco": "clementine",

--- a/winutil.ps1
+++ b/winutil.ps1
@@ -5882,15 +5882,6 @@ $sync.configs.applications = '{
 		"description": "Blender is a powerful open-source 3D creation suite, offering modeling, sculpting, animation, and rendering tools.",
 		"link": "https://www.blender.org/"
 	},
-	"WPFInstallcider": {
-		"winget": "CiderCollective.Cider",
-		"choco": "cider",
-		"category": "Multimedia Tools",
-		"panel": "3",
-		"content": "Cider (FOSS Music Player)",
-		"description": "Cider is a free and open-source music player that focuses on simplicity, providing a clean interface for enjoying your music.",
-		"link": "https://getcider.io/"
-	},
 	"WPFInstallclementine": {
 		"winget": "Clementine.Clementine",
 		"choco": "clementine",


### PR DESCRIPTION
Cider has a new version that is not FOSS anymore and it's a paid program.
This is (or will soon be) deprecated.