### PR TITLE
Added new toggle tweak button

### DIFF
--- a/functions/private/Get-WinUtilToggleStatus.ps1
+++ b/functions/private/Get-WinUtilToggleStatus.ps1
@@ -59,6 +59,15 @@ Function Get-WinUtilToggleStatus {
             return $false
         }
     }    
+    if($ToggleSwitch -eq "WPFToggleSnapFlyout"){
+        $hidesnap = (Get-ItemProperty -path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced').EnableSnapAssistFlyout
+        if($hidesnap -eq 0){
+            return $false
+        }
+        else{
+            return $true
+        }
+    }    
     if($ToggleSwitch -eq "WPFToggleMouseAcceleration"){
         $MouseSpeed = (Get-ItemProperty -path 'HKCU:\Control Panel\Mouse').MouseSpeed
         $MouseThreshold1 = (Get-ItemProperty -path 'HKCU:\Control Panel\Mouse').MouseThreshold1

--- a/functions/private/Invoke-WinUtilSnapFlyout.ps1
+++ b/functions/private/Invoke-WinUtilSnapFlyout.ps1
@@ -1,0 +1,34 @@
+function Invoke-WinUtilSnapFlyout {
+    <#
+    .SYNOPSIS
+        Disables/Enables Snap Assist Flyout on startup
+    .PARAMETER Enabled
+        Indicates whether to enable or disable Snap Assist Flyout on startup
+    #>
+    Param($Enabled)
+    Try{
+        if ($Enabled -eq $false){
+            Write-Host "Enabling Snap Assist Flyout On startup"
+            $value = 1
+        }
+        else {
+            Write-Host "Disabling Snap Assist Flyout On startup"
+            $value = 0
+        }
+        # taskkill.exe /F /IM "explorer.exe"
+        $Path = "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced"
+        taskkill.exe /F /IM "explorer.exe"
+        Set-ItemProperty -Path $Path -Name EnableSnapAssistFlyout -Value $value
+        Start-Process "explorer.exe"
+    }
+    Catch [System.Security.SecurityException] {
+        Write-Warning "Unable to set $Path\$Name to $Value due to a Security Exception"
+    }
+    Catch [System.Management.Automation.ItemNotFoundException] {
+        Write-Warning $psitem.Exception.ErrorRecord
+    }
+    Catch{
+        Write-Warning "Unable to set $Name due to unhandled exception"
+        Write-Warning $psitem.Exception.StackTrace
+    }
+}

--- a/functions/public/Invoke-WPFToggle.ps1
+++ b/functions/public/Invoke-WPFToggle.ps1
@@ -22,6 +22,7 @@ function Invoke-WPFToggle {
         "WPFToggleNumLock" {Invoke-WinUtilNumLock $(Get-WinUtilToggleStatus WPFToggleNumLock)}
         "WPFToggleVerboseLogon" {Invoke-WinUtilVerboseLogon $(Get-WinUtilToggleStatus WPFToggleVerboseLogon)}
         "WPFToggleShowExt" {Invoke-WinUtilShowExt $(Get-WinUtilToggleStatus WPFToggleShowExt)}
+        "WPFToggleSnapFlyout" {Invoke-WinUtilSnapFlyout $(Get-WinUtilToggleStatus WPFToggleSnapFlyout)}
         "WPFToggleMouseAcceleration" {Invoke-WinUtilMouseAcceleration $(Get-WinUtilToggleStatus WPFToggleMouseAcceleration)}
     }
 }

--- a/xaml/inputXML.xaml
+++ b/xaml/inputXML.xaml
@@ -849,6 +849,11 @@
                             </StackPanel>
 
                             <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
+                                <Label Content="Snap Assist Flyout" Style="{StaticResource labelfortweaks}" ToolTip="If enabled then File extensions (e.g., .txt, .jpg) are visible." />
+                                <CheckBox Name="WPFToggleSnapFlyout" Style="{StaticResource ColorfulToggleSwitchStyle}" Margin="2.5,0"/>
+                            </StackPanel>
+
+                            <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
                                 <Label Content="Mouse Acceleration" Style="{StaticResource labelfortweaks}" ToolTip="If Enabled then Cursor movement is affected by the speed of your physical mouse movements."/>
                                 <CheckBox Name="WPFToggleMouseAcceleration" Style="{StaticResource ColorfulToggleSwitchStyle}" Margin="2.5,0"/>
                             </StackPanel>


### PR DESCRIPTION
- Added new tweak **"Snap Assist Flyout"** that I think is useful for many people who do not like new feature that **MS** added when hover over **maximize** button.
- When **Disable/Enable** tweak, it will restart **explorer.exe** to take effect and set registry value **0/1** to **EnableSnapAssistFlyout**  
- <i>This will disable **ONLY** snap preview when hover **Maximize** button **NOT** snap preview when is **window** dragged to the edge of the screen.<i>