### PR TITLE
fix for bug with selecting presets and toggle switches

### DIFF
--- a/functions/public/Invoke-WPFPresets.ps1
+++ b/functions/public/Invoke-WPFPresets.ps1
@@ -27,7 +27,7 @@ function Invoke-WPFPresets {
         $CheckBoxesToCheck = $sync.configs.preset.$preset
     }
 
-    $CheckBoxes = $sync.GetEnumerator() | Where-Object { $_.Value -is [System.Windows.Controls.CheckBox] -and $_.Name -like "WPFToggle*" }
+    $CheckBoxes = $sync.GetEnumerator() | Where-Object { $_.Value -is [System.Windows.Controls.CheckBox] -and $_.Name -notlike "WPFToggle*" }
     Write-Debug "Getting checkboxes to set $($CheckBoxes.Count)"
 
     $CheckBoxesToCheck | ForEach-Object {

--- a/functions/public/Invoke-WPFPresets.ps1
+++ b/functions/public/Invoke-WPFPresets.ps1
@@ -27,7 +27,7 @@ function Invoke-WPFPresets {
         $CheckBoxesToCheck = $sync.configs.preset.$preset
     }
 
-    $CheckBoxes = $sync.GetEnumerator() | Where-Object { $_.Value -is [System.Windows.Controls.CheckBox] }
+    $CheckBoxes = $sync.GetEnumerator() | Where-Object { $_.Value -is [System.Windows.Controls.CheckBox] -and $_.Name -like "WPFToggle*" }
     Write-Debug "Getting checkboxes to set $($CheckBoxes.Count)"
 
     $CheckBoxesToCheck | ForEach-Object {


### PR DESCRIPTION
When selecting a preset it will also turn off all the sliders in the tweaks tab. Testing a fix for this issue.