### PR TITLE
Add GitHub CLI to applications

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -357,7 +357,7 @@
 		"panel": "1",
 		"content": "GitHub CLI",
 		"link": "https://cli.github.com/",
-		"description": "GitHub CLI is a command-line tool that simplifies working with GitHub directly from the terminal.."
+		"description": "GitHub CLI is a command-line tool that simplifies working with GitHub directly from the terminal."
 	},
 	"WPFInstallgolang": {
 		"winget": "GoLang.Go",

--- a/config/applications.json
+++ b/config/applications.json
@@ -350,6 +350,15 @@
 		"link": "https://desktop.github.com/",
 		"description": "GitHub Desktop is a visual Git client that simplifies collaboration on GitHub repositories with an easy-to-use interface."
 	},
+	"WPFInstallgithubcli": {
+		"winget": "Git.Git;GitHub.cli",
+		"choco": "git;gh",
+		"category": "Development",
+		"panel": "1",
+		"content": "GitHub CLI",
+		"link": "https://cli.github.com/",
+		"description": "GitHub CLI is a command-line tool that simplifies working with GitHub directly from the terminal.."
+	},
 	"WPFInstallgolang": {
 		"winget": "GoLang.Go",
 		"choco": "golang",


### PR DESCRIPTION
GitHub CLI `gh` is the open source command line interface offered by GitHub alongside GitHub Desktop.
For more information and source code see: https://github.com/cli/cli. 
Installation Instructions taken from: https://github.com/cli/cli#windows
Official Site: https://cli.github.com