### PR TITLE
fix tooltip label for Snap Assist Flyout tweak

### DIFF
--- a/xaml/inputXML.xaml
+++ b/xaml/inputXML.xaml
@@ -849,7 +849,7 @@
                             </StackPanel>
 
                             <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
-                                <Label Content="Snap Assist Flyout" Style="{StaticResource labelfortweaks}" ToolTip="If enabled then File extensions (e.g., .txt, .jpg) are visible." />
+                                <Label Content="Snap Assist Flyout" Style="{StaticResource labelfortweaks}" ToolTip="If enabled then Snap preview is disabled when maximize button is hovered." />
                                 <CheckBox Name="WPFToggleSnapFlyout" Style="{StaticResource ColorfulToggleSwitchStyle}" Margin="2.5,0"/>
                             </StackPanel>
 


### PR DESCRIPTION
<Label Content="Snap Assist Flyout" Style="{StaticResource labelfortweaks}" ToolTip="**If enabled then File extensions (e.g., .txt, .jpg) are visible.**" \/>

---

-->

---

<Label Content="Snap Assist Flyout" Style="{StaticResource labelfortweaks}" ToolTip="**If enabled then Snap preview is disabled when maximize button is hovered.**" \/>