### PR TITLE
Fixes, Changes & Features Added (Broken links & Comments)

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -1603,7 +1603,7 @@
 	},
 	"WPFInstallPortmaster": {
 		"winget": "Safing.Portmaster",
-		"choco": "na",
+		"choco": "portmaster",
 		"category": "Pro Tools",
 		"panel": "3",
 		"content": "Portmaster",

--- a/config/applications.json
+++ b/config/applications.json
@@ -639,7 +639,7 @@
 		"description": "Anaconda is a distribution of the Python and R programming languages for scientific computing."
     },
 	"WPFInstallThonny": {
-		"winget": "na",
+		"winget": "AivarAnnamaa.Thonny",
 		"choco": "thonny",
 		"category": "Development",
 		"panel": "1",

--- a/config/applications.json
+++ b/config/applications.json
@@ -854,6 +854,15 @@
 		"link": "https://www.zotero.org/",
 		"description": "Zotero is a free, easy-to-use tool to help you collect, organize, cite, and share your research materials."
 	},
+	"WPFInstallATLauncher": {
+		"winget": "ATLauncher.ATLauncher",
+		"choco": "na",
+		"category": "Games",
+		"panel": "3",
+		"content": "ATLauncher",
+		"link": "https://github.com/ATLauncher/ATLauncher",
+		"description": "ATLauncher is a Launcher for Minecraft which integrates multiple different ModPacks to allow you to download and install ModPacks easily and quickly."
+	},
 	"WPFInstallbluestacks": {
 		"winget": "BlueStack.BlueStacks",
 		"choco": "bluestacks",
@@ -997,6 +1006,15 @@
 		"content": "Sunshine/GameStream Server",
 		"description": "Sunshine is a GameStream server that allows you to remotely play PC games on Android devices, offering low-latency streaming.",
 		"link": "https://github.com/LoLBoy25/Sunshine"
+	},
+	"WPFInstallTcNoAccSwitcher": {
+		"winget": "TechNobo.TcNoAccountSwitcher",
+		"choco": "tcno-acc-switcher",
+		"category": "Games",
+		"panel": "3",
+		"content": "TCNO Account Switcher",
+		"link": "https://github.com/TCNOco/TcNo-Acc-Switcher",
+		"description": "A Super-fast account switcher for Steam, Battle.net, Epic Games, Origin, Riot, Ubisoft and many others!"
 	},
 	"WPFInstallubisoft": {
 		"winget": "Ubisoft.Connect",
@@ -1961,6 +1979,15 @@
 		"link": "https://www.monitorian.com/",
 		"description": "Monitorian is a utility for adjusting monitor brightness and contrast on Windows."
 	},
+	"WPFInstallMotrix": {
+		"winget": "na",
+		"choco": "motrix",
+		"category": "Utilities",
+		"panel": "5",
+		"content": "Motrix Download Manager",
+		"link": "https://github.com/agalwood/Motrix",
+		"description": "A full-featured download manager."
+	},
 	"WPFInstallmsiafterburner": {
 		"winget": "Guru3D.Afterburner",
 		"choco": "msiafterburner",
@@ -2050,6 +2077,15 @@
 		"content": "ownCloud Desktop",
 		"link": "https://owncloud.com/desktop-app/",
 		"description": "ownCloud Desktop is the official desktop client for the ownCloud file synchronization and sharing platform."
+	},
+	"WPFInstallOPAutoClicker": {
+		"winget": "OPAutoClicker.OPAutoClicker",
+		"choco": "autoclicker",
+		"category": "Utilities",
+		"panel": "5",
+		"content": "OPAutoClicker",
+		"link": "https://www.opautoclicker.com",
+		"description": "ATLauncher is a Launcher for Minecraft which integrates multiple different ModPacks to allow you to download and install ModPacks easily and quickly."
 	},
 	"WPFInstallparsec": {
 		"winget": "Parsec.parsec",

--- a/config/applications.json
+++ b/config/applications.json
@@ -1601,14 +1601,14 @@
 		"link": "https://openvpn.net/",
 		"description": "OpenVPN Connect is an open-source VPN client that allows you to connect securely to a VPN server. It provides a secure and encrypted connection for protecting your online privacy."
 	},
-	"WPFInstallportmaster": {
-		"winget": "portmaster",
-		"choco": "portmaster",
+	"WPFInstallPortmaster": {
+		"winget": "Safing.Portmaster",
+		"choco": "na",
 		"category": "Pro Tools",
 		"panel": "3",
 		"content": "Portmaster",
-		"link": "https://github.com/freebsd/portmaster",
-		"description": "Portmaster is a FreeBSD package management tool. It simplifies the process of managing software packages and dependencies on FreeBSD systems."
+		"link": "https://github.com/safing/portmaster",
+		"description": "Portmaster is a free and open-source application that puts you back in charge over all your computers network connections."
 	},
 	"WPFInstallputty": {
 		"winget": "PuTTY.PuTTY",

--- a/config/applications.json
+++ b/config/applications.json
@@ -1989,7 +1989,7 @@
 		"description": "Monitorian is a utility for adjusting monitor brightness and contrast on Windows."
 	},
 	"WPFInstallMotrix": {
-		"winget": "na",
+		"winget": "agalwood.Motrix",
 		"choco": "motrix",
 		"category": "Utilities",
 		"panel": "4",
@@ -2094,7 +2094,7 @@
 		"panel": "5",
 		"content": "OPAutoClicker",
 		"link": "https://www.opautoclicker.com",
-		"description": "ATLauncher is a Launcher for Minecraft which integrates multiple different ModPacks to allow you to download and install ModPacks easily and quickly."
+		"description": "A full-fledged autoclicker with two modes of autoclicking, at your dynamic cursor location or at a prespecified location."
 	},
 	"WPFInstallparsec": {
 		"winget": "Parsec.parsec",

--- a/config/applications.json
+++ b/config/applications.json
@@ -2147,17 +2147,17 @@
 		"category": "Utilities",
 		"panel": "4",
 		"content": "Snappy Driver Installer Origin",
-		"link": "https://github.com/snappy-driver/snappy-driver-installer",
+		"link": "https://sourceforge.net/projects/snappy-driver-installer-origin",
 		"description": "Snappy Driver Installer Origin is a free and open-source driver updater with a vast driver database for Windows."
 	},
 	"WPFInstallspacedrive": {
-		"winget": "spacedrive.Spacedrive",
+		"winget": "Spacedrive.FileManager",
 		"choco": "na",
 		"category": "Utilities",
 		"panel": "4",
 		"content": "Spacedrive File Manager",
-		"link": "https://spacedrive.org/",
-		"description": "Spacedrive is a file manager that offers cloud storage integration and file synchronization across devices."
+		"link": "https://github.com/spacedriveapp/spacedrive",
+		"description": "Spacedrive is a file manager that offers cloud storage integration and file synchronization across devices. *Currently in Alpha 0.2.0, may be unstable*"
 	},
 	"WPFInstallsuperf4": {
 		"winget": "StefanSundin.Superf4",
@@ -2274,7 +2274,7 @@
 		"panel": "4",
 		"content": "Xtreme Download Manager",
 		"link": "https://github.com/subhra74/xdm",
-		"description": "Xtreme Download Manager is an advanced download manager with support for various protocols and browsers."
+		"description": "Xtreme Download Manager is an advanced download manager with support for various protocols and browsers.*Browser integration deprecated by google store. No official release.*"
 	},
 	"WPFInstallzerotierone": {
 		"winget": "ZeroTier.ZeroTierOne",

--- a/config/applications.json
+++ b/config/applications.json
@@ -858,7 +858,7 @@
 		"winget": "ATLauncher.ATLauncher",
 		"choco": "na",
 		"category": "Games",
-		"panel": "3",
+		"panel": "2",
 		"content": "ATLauncher",
 		"link": "https://github.com/ATLauncher/ATLauncher",
 		"description": "ATLauncher is a Launcher for Minecraft which integrates multiple different ModPacks to allow you to download and install ModPacks easily and quickly."
@@ -1011,7 +1011,7 @@
 		"winget": "TechNobo.TcNoAccountSwitcher",
 		"choco": "tcno-acc-switcher",
 		"category": "Games",
-		"panel": "3",
+		"panel": "2",
 		"content": "TCNO Account Switcher",
 		"link": "https://github.com/TCNOco/TcNo-Acc-Switcher",
 		"description": "A Super-fast account switcher for Steam, Battle.net, Epic Games, Origin, Riot, Ubisoft and many others!"
@@ -1983,7 +1983,7 @@
 		"winget": "na",
 		"choco": "motrix",
 		"category": "Utilities",
-		"panel": "5",
+		"panel": "4",
 		"content": "Motrix Download Manager",
 		"link": "https://github.com/agalwood/Motrix",
 		"description": "A full-featured download manager."

--- a/config/applications.json
+++ b/config/applications.json
@@ -2151,7 +2151,7 @@
 		"description": "Snappy Driver Installer Origin is a free and open-source driver updater with a vast driver database for Windows."
 	},
 	"WPFInstallspacedrive": {
-		"winget": "Spacedrive.FileManager",
+		"winget": "spacedrive.Spacedrive",
 		"choco": "na",
 		"category": "Utilities",
 		"panel": "4",

--- a/config/applications.json
+++ b/config/applications.json
@@ -638,6 +638,15 @@
 		"link": "https://www.anaconda.com/products/distribution",
 		"description": "Anaconda is a distribution of the Python and R programming languages for scientific computing."
     },
+	"WPFInstallThonny": {
+		"winget": "na",
+		"choco": "thonny",
+		"category": "Development",
+		"panel": "1",
+		"content": "Thonny Python IDE",
+		"link": "https://github.com/thonny/thonny",
+		"description": "Python IDE for beginners."
+    },
 	"WPFInstallvscodium": {
 		"winget": "Git.Git;VSCodium.VSCodium",
 		"choco": "vscodium",


### PR DESCRIPTION
- Snappy Driver Installer Origin
Github source code deprecated. Replaced with SourceForge official source code site.

- Spacedrive File Manager
Changed winget, easier to identify.
"spacedrive.org" not working. Changed to official site.
**Recent Alpha ver 0.2.0 - crashing on install for Win10+ (not tested in "lower" win versions), may be better to remove overall or place on standby.**

- Xtreme Download Manager
Web Integration not working for chromium based browsers.
**Deprecated by Manifest V3, no official update release.**