### PR TITLE
Remove Nano from applications

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -1223,15 +1223,6 @@
 		"panel": "4",
 		"winget": "M2Team.NanaZip"
 	},
-	"WPFInstallnano": {
-		"category": "Development",
-		"choco": "nano",
-		"content": "Nano",
-		"description": "Nano is a text editor for Unix-like computing systems or operating environments using a command-line interface.",
-		"link": "https://www.nano-editor.org/",
-		"panel": "1",
-		"winget": "GNU.Nano"
-	},
 	"WPFInstallnaps2": {
 		"category": "Document",
 		"choco": "naps2",


### PR DESCRIPTION
Fixes https://github.com/ChrisTitusTech/winutil/issues/1490 for now.

Winget's Nano package has several problems:

- The URL is broken and nano-editor.org no longer provides a Winget-friendly installer file, just standalone .exe's. 
- The version is Nano 2.7 which is years out of date. The newer builds are bugged https://github.com/microsoft/winget-pkgs/issues/95161#issuecomment-1430423987 and have no documentation. 