### PR TITLE
fix Parsec winget id

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -1333,7 +1333,7 @@
 		"content": "Parsec",
 		"description": "Parsec is a low-latency, high-quality remote desktop sharing application for collaborating and gaming across devices.",
 		"link": "https://parsec.app/",
-		"winget": "Parsec.parsec"
+		"winget": "Parsec.Parsec"
 	},
 	"WPFInstallpdf24creator": {
 		"category": "Document",


### PR DESCRIPTION
This PR fixes Parsec's winget id in `applications.json`

`Parsec.parsec` -> `Parsec.Parsec`