### PR TITLE
Tweak: Remove News Feeds

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -2546,6 +2546,19 @@
       "Disable-NetAdapterBinding -Name \"*\" -ComponentID ms_tcpip6"
     ]
   },
+  "WPFTweaksNews": {
+    "Content": "Disable News Feeds",
+    "Description": "Disables News and Interests from the Windows 10 Start Menu or disable the Widgets applet on Windows 11.",
+    "category": "Essential Tweaks",
+    "panel": "1",
+    "Order": "a015_",
+    "InvokeScript": [
+      "Start-Process 'winget uninstall 9MSSGKG348SP --accept-source-agreements'"
+    ],
+    "UndoScript": [
+      "Start-Process 'winget install 9MSSGKG348SP --accept-source-agreements'"
+    ]
+  },
   "WPFToggleDarkMode": {
     "Content": "Dark Theme",
     "Description": "Enable/Disable Dark Mode.",


### PR DESCRIPTION
Fixes https://github.com/ChrisTitusTech/winutil/issues/1029

* Delete Widgets or News and Interests without Group Policy Editor
* Should be run after O&O Shutup since that tweak re-enables feeds 