### PR TITLE
change neofetch link to correct project

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -1108,7 +1108,7 @@
 		"choco": "na",
 		"content": "Neofetch",
 		"description": "Neofetch is a command-line utility for displaying system information in a visually appealing way.",
-		"link": "https://github.com/dylanaraps/neofetch",
+		"link": "https://github.com/nepnep39/neofetch-win",
 		"winget": "nepnep.neofetch-win"
 	},
 	"WPFInstallneovim": {


### PR DESCRIPTION
the neofetch-win package is from the [https://github.com/nepnep39/neofetch-win](https://github.com/nepnep39/neofetch-win) project and is separate to the neofetch used on linux