### PR TITLE
Improved the OneDrive Tweak a bit

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -2306,6 +2306,7 @@
 
         Write-Host \"Removing OneDrive leftovers\"
         Remove-Item -Recurse -Force -ErrorAction SilentlyContinue \"$env:localappdata\\Microsoft\\OneDrive\"
+        Remove-Item -Recurse -Force -ErrorAction SilentlyContinue \"$env:localappdata\\OneDrive\"
         Remove-Item -Recurse -Force -ErrorAction SilentlyContinue \"$env:programdata\\Microsoft OneDrive\"
         Remove-Item -Recurse -Force -ErrorAction SilentlyContinue \"$env:systemdrive\\OneDriveTemp\"
         # check if directory is empty before removing:


### PR DESCRIPTION
### Commit Title

Fix OneDrive Remove Tweak not cleaning-up 'OneDrive' Folder under the 'localappdata' Environment Folder

### Commit Message Body

Besides the 'OneDrive' Folder found in 'Microsoft' Folder in 'localappdata', there's Yet Another Cache Folder that OneDrive uses, which's found under the 'localappdata' Environment Folder, read the commit patches for exact details.