### PR TITLE
Fixing an issue related to winget install & Improving winget uninstall command

### DIFF
--- a/functions/private/Install-WinUtilProgramWinget.ps1
+++ b/functions/private/Install-WinUtilProgramWinget.ps1
@@ -33,8 +33,8 @@ Function Install-WinUtilProgramWinget {
             Start-Process -FilePath winget -ArgumentList "install -e --accept-source-agreements --accept-package-agreements --scope=machine --silent $Program" -NoNewWindow -Wait
         }
         if($manage -eq "Uninstalling"){
-            Start-Process -FilePath winget -ArgumentList "uninstall -e --purge --force --silent $Program" -NoNewWindow -Wait
-        }
+        Start-Process -FilePath winget -ArgumentList "uninstall -e --accept-source-agreements --purge --force --silent $Program" -NoNewWindow -Wait
+	}
 
         $X++
     }

--- a/functions/public/Invoke-WPFInstall.ps1
+++ b/functions/public/Invoke-WPFInstall.ps1
@@ -2,12 +2,12 @@ function Invoke-WPFInstall {
     <#
 
     .SYNOPSIS
-        Installs the selected programs using winget
+        Installs the selected programs using winget, if one or more of the selected programs are already installed on the system, winget will try and perform an upgrade if there's a newer version to install.
 
     #>
 
     if($sync.ProcessRunning){
-        $msg = "[Invoke-WPFInstall] Install process is currently running."
+        $msg = "[Invoke-WPFInstall] An Install process is currently running."
         [System.Windows.MessageBox]::Show($msg, "Winutil", [System.Windows.MessageBoxButton]::OK, [System.Windows.MessageBoxImage]::Warning)
         return
     }
@@ -15,7 +15,7 @@ function Invoke-WPFInstall {
     $WingetInstall = (Get-WinUtilCheckBoxes)["Install"]
 
     if ($wingetinstall.Count -eq 0) {
-        $WarningMsg = "Please select the program(s) to install"
+        $WarningMsg = "Please select the program(s) to install or upgrade"
         [System.Windows.MessageBox]::Show($WarningMsg, $AppTitle, [System.Windows.MessageBoxButton]::OK, [System.Windows.MessageBoxImage]::Warning)
         return
     }

--- a/xaml/inputXML.xaml
+++ b/xaml/inputXML.xaml
@@ -690,7 +690,7 @@
                         <RowDefinition Height="0.95*"/>
                     </Grid.RowDefinitions>
                     <StackPanel Background="{MainBackgroundColor}" Orientation="Horizontal" Grid.Row="0" HorizontalAlignment="Left" VerticalAlignment="Top" Grid.Column="0" Grid.ColumnSpan="3" Margin="5">
-                        <Button Name="WPFinstall" Content=" Install Selected" Margin="2" />
+                        <Button Name="WPFinstall" Content=" Install/Upgrade Selected" Margin="2" />
                         <Button Name="WPFInstallUpgrade" Content=" Upgrade All" Margin="2"/>
                         <Button Name="WPFuninstall" Content=" Uninstall Selection" Margin="2"/>
                         <Button Name="WPFGetInstalled" Content=" Get Installed" Margin="2"/>


### PR DESCRIPTION
### The changes

1. The later one mentioned in the title is related to winget uninstall command found under the `Install-WinUtilProgramWinget.ps1` private function, I've added an extra argument, which's `--accept-source-agreements`, to make sure the uninstall is completely unattended.
2. An issue ( #1661 ) mentioned that the `Install Selected` doesn't do exactly what it says.. yes, it runs `winget install ...`, but the install command for winget is really an install if said package isn't found, or an upgrade for said package, if there's a newer version available.
So I've modified it to make it more accurate to what it does.