### PR TITLE
Add “a few ”apps

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -1735,6 +1735,14 @@
 		"link": "https://www.spacedrive.com/",
 		"winget": "spacedrive.Spacedrive"
 	},
+	"WPFInstallspacesniffer": {
+		"category": "Utilities",
+		"choco": "spacesniffer",
+		"content": "SpaceSniffer",
+		"description": "A tool application that lets you understand how folders and files are structured on your disks",
+		"link": "http://www.uderzo.it/main_products/space_sniffer/",
+		"winget": "UderzoSoftware.SpaceSniffer"
+	},
 	"WPFInstallstarship": {
 		"category": "Development",
 		"choco": "starship",

--- a/config/applications.json
+++ b/config/applications.json
@@ -1615,6 +1615,14 @@
 		"link": "https://www.revouninstaller.com/",
 		"winget": "RevoUninstaller.RevoUninstaller"
 	},
+	"WPFInstallrevolt": {
+		"category": "Communications",
+		"choco": "na",
+		"content": "Revolt",
+		"description": "Find your community, connect with the world. Revolt is one of the best ways to stay connected with your friends and community without sacrificing any usability.",
+		"link": "https://revolt.chat/",
+		"winget": "Revolt.RevoltDesktop"
+	},
 	"WPFInstallripgrep": {
 		"category": "Utilities",
 		"choco": "ripgrep",

--- a/config/applications.json
+++ b/config/applications.json
@@ -1639,11 +1639,19 @@
 		"link": "https://signal.org/",
 		"winget": "OpenWhisperSystems.Signal"
 	},
+	"WPFInstallsimplenote": {
+		"category": "Document",
+		"choco": "simplenote",
+		"content": "simplenote",
+		"description": "Simplenote is an easy way to keep notes, lists, ideas and more.",
+		"link": "https://simplenote.com/",
+		"winget": "Automattic.Simplenote"
+	},
 	"WPFInstallsimplewall": {
 		"category": "Pro Tools",
 		"choco": "simplewall",
 		"content": "simplewall",
-		"description": "simplewall is a free and open-source firewall application for Windows. It allows users to control and manage the inbound and outbound network traffic of applications.",
+		"description": "Simplewall is a free and open-source firewall application for Windows. It allows users to control and manage the inbound and outbound network traffic of applications.",
 		"link": "https://github.com/henrypp/simplewall",
 		"winget": "Henry++.simplewall"
 	},

--- a/config/applications.json
+++ b/config/applications.json
@@ -775,6 +775,14 @@
 		"link": "https://handbrake.fr/",
 		"winget": "HandBrake.HandBrake"
 	},
+	"WPFInstallharmonoid": {
+		"category": "Multimedia Tools",
+		"choco": "na",
+		"content": "Harmonoid",
+		"description": "Plays & manages your music library. Looks beautiful & juicy. Playlists, visuals, synced lyrics, pitch shift, volume boost & more.",
+		"link": "https://harmonoid.com/",
+		"winget": "Harmonoid.Harmonoid"
+	},
 	"WPFInstallheidisql": {
 		"category": "Pro Tools",
 		"choco": "heidisql",

--- a/config/applications.json
+++ b/config/applications.json
@@ -567,6 +567,14 @@
 		"link": "https://floorp.app/",
 		"winget": "Ablaze.Floorp"
 	},
+	"WPFInstallflow": {
+		"category": "Utilities",
+		"choco": "flow-launcher",
+		"content": "Flow launcher",
+		"description": "Keystroke launcher for Windows to search, manage and launch files, folders bookmarks, websites and more.",
+		"link": "https://www.flowlauncher.com/",
+		"winget": "Flow-Launcher.Flow-Launcher"
+	},
 	"WPFInstallflux": {
 		"category": "Utilities",
 		"choco": "flux",

--- a/config/applications.json
+++ b/config/applications.json
@@ -1119,6 +1119,14 @@
 		"link": "https://mullvad.net/browser",
 		"winget": "MullvadVPN.MullvadBrowser"
 	},
+	"WPFInstallmusescore": {
+		"category": "Multimedia Tools",
+		"choco": "musescore",
+		"content": "MuseScore",
+		"description": "Create, play back and print beautiful sheet music with free and easy to use music notation software MuseScore.",
+		"link": "https://musescore.org/en",
+		"winget": "Musescore.Musescore"
+	},
 	"WPFInstallmusicbee": {
 		"category": "Multimedia Tools",
 		"choco": "musicbee",

--- a/config/applications.json
+++ b/config/applications.json
@@ -1039,6 +1039,14 @@
 		"link": "https://localsend.org/",
 		"winget": "LocalSend.LocalSend"
 	},
+	"WPFInstalllockhunter": {
+		"category": "Utilities",
+		"choco": "lockhunter",
+		"content": "LockHunter",
+		"description": "LockHunter is a free tool to delete files blocked by something you do not know.",
+		"link": "https://lockhunter.com/",
+		"winget": "CrystalRich.LockHunter"
+	},
 	"WPFInstalllogseq": {
 		"category": "Document",
 		"choco": "logseq",

--- a/config/applications.json
+++ b/config/applications.json
@@ -255,6 +255,14 @@
 		"link": "https://clonehero.net/",
 		"winget": "CloneHeroTeam.CloneHero"
 	},
+	"WPFInstallcmake": {
+		"category": "Development",
+		"choco": "cmake",
+		"content": "CMake",
+		"description": "CMake is an open-source, cross-platform family of tools designed to build, test and package software.",
+		"link": "https://cmake.org/",
+		"winget": "Kitware.CMake"
+	},
 	"WPFInstallcopyq": {
 		"category": "Multimedia Tools",
 		"choco": "copyq",

--- a/config/applications.json
+++ b/config/applications.json
@@ -104,6 +104,14 @@
 		"winget": "Twilio.Authy"
 	},
 	"WPFInstallautohotkey": {
+		"category": "Microsoft Tools",
+		"choco": "autoruns",
+		"content": "Autoruns",
+		"description": "This utility shows you what programs are configured to run during system bootup or login",
+		"link": "https://learn.microsoft.com/en-us/sysinternals/downloads/autoruns",
+		"winget": "Microsoft.Sysinternals.Autoruns"
+	},	
+	"WPFInstallautohotkey": {
 		"category": "Utilities",
 		"choco": "autohotkey",
 		"content": "AutoHotkey",

--- a/config/applications.json
+++ b/config/applications.json
@@ -495,6 +495,14 @@
 		"link": "https://www.balena.io/etcher/",
 		"winget": "Balena.Etcher"
 	},
+	"WPFInstallexplorerpatcher": {
+		"category": "Utilities",
+		"choco": "na",
+		"content": "Explorer Patcher",
+		"description": "This project aims to enhance the working environment on Windows.",
+		"link": "https://github.com/valinet/ExplorerPatcher",
+		"winget": "valinet.ExplorerPatcher"
+	},
 	"WPFInstallfalkon": {
 		"category": "Browsers",
 		"choco": "falkon",

--- a/config/applications.json
+++ b/config/applications.json
@@ -1871,6 +1871,14 @@
 		"link": "https://github.com/canton7/SyncTrayzor/",
 		"winget": "SyncTrayzor.SyncTrayzor"
 	},
+	"WPFInstalltabby": {
+		"category": "Utilities",
+		"choco": "tabby",
+		"content": "Tabby.sh",
+		"description": "Tabby is a highly configurable terminal emulator, SSH and serial client for Windows, macOS and Linux",
+		"link": "https://tailscale.com/",
+		"winget": "Eugeny.Tabby"
+	},
 	"WPFInstalltailscale": {
 		"category": "Utilities",
 		"choco": "tailscale",

--- a/config/applications.json
+++ b/config/applications.json
@@ -183,6 +183,14 @@
 		"link": "https://www.bcuninstaller.com/",
 		"winget": "Klocman.BulkCrapUninstaller"
 	},
+	"WPFInstallbulkrenameutility": {
+		"category": "Utilities",
+		"choco": "bulkrenameutility",
+		"content": "Bulk Rename Utility",
+		"description": "Bulk Rename Utility allows you to easily rename files and folders recursively based upon find-replace, character place, fields, sequences, regular expressions, EXIF data, and more.",
+		"link": "https://www.bulkrenameutility.co.uk",
+		"winget": "TGRMNSoftware.BulkRenameUtility"
+	},
 	"WPFInstallcalibre": {
 		"category": "Document",
 		"choco": "calibre",

--- a/config/applications.json
+++ b/config/applications.json
@@ -607,6 +607,14 @@
 		"link": "https://www.freecadweb.org/",
 		"winget": "FreeCAD.FreeCAD"
 	},
+	"WPFInstallfxsound": {
+		"category": "Multimedia Tools",
+		"choco": "fxsound",
+		"content": "FxSound",
+		"description": "FxSound is a cutting-edge audio enhancement software that elevates your listening experience across all media.",
+		"link": "https://www.fxsound.com/",
+		"winget": "FxSoundLLC.FxSound"
+	},
 	"WPFInstallfzf": {
 		"category": "Utilities",
 		"choco": "fzf",

--- a/config/applications.json
+++ b/config/applications.json
@@ -1031,6 +1031,14 @@
 		"link": "https://librewolf-community.gitlab.io/",
 		"winget": "LibreWolf.LibreWolf"
 	},
+	"WPFInstalllinkshellextension": {
+		"category": "Utilities",
+		"choco": "linkshellextension",
+		"content": "Link Shell extension",
+		"description": "Link Shell Extension (LSE) provides for the creation of Hardlinks, Junctions, Volume Mountpoints, Symbolic Links, a folder cloning process that utilises Hardlinks or Symbolic Links and a copy process taking care of Junctions, Symbolic Links, and Hardlinks. LSE, as its name implies is implemented as a Shell extension and is accessed from Windows Explorer, or similar file/folder managers.",
+		"link": "https://schinagl.priv.at/nt/hardlinkshellext/hardlinkshellext.html",
+		"winget": "HermannSchinagl.LinkShellExtension"
+	},
 	"WPFInstalllinphone": {
 		"category": "Communications",
 		"choco": "linphone",

--- a/config/applications.json
+++ b/config/applications.json
@@ -2239,6 +2239,14 @@
 		"link": "https://toys.wisecleaner.com/",
 		"winget": "WiseCleaner.WiseToys"
 	},
+	"WPFInstallwizfile": {
+		"category": "Utilities",
+		"choco": "na",
+		"content": "WizFile",
+		"description": "Find files by name on your hard drives almost instantly.",
+		"link": "https://antibody-software.com/wizfile/",
+		"winget": "AntibodySoftware.WizFile"
+	},
 	"WPFInstallwiztree": {
 		"category": "Utilities",
 		"choco": "wiztree",

--- a/config/applications.json
+++ b/config/applications.json
@@ -1735,6 +1735,14 @@
 		"link": "https://signal.org/",
 		"winget": "OpenWhisperSystems.Signal"
 	},
+	"WPFInstallsignalrgb": {
+		"category": "Utilities",
+		"choco": "na",
+		"content": "SignalRGB",
+		"description": "SignalRGB lets you control and sync your favorite RGB devices with one free application.",
+		"link": "https://www.signalrgb.com/",
+		"winget": "WhirlwindFX.SignalRgb"
+	},
 	"WPFInstallsimplenote": {
 		"category": "Document",
 		"choco": "simplenote",

--- a/config/applications.json
+++ b/config/applications.json
@@ -2287,6 +2287,14 @@
 		"link": "https://xemu.app/",
 		"winget": "xemu-project.xemu"
 	},
+	"WPFInstallxnview": {
+		"category": "Utilities",
+		"choco": "xnview",
+		"content": "XnView classic",
+		"description": "XnView is an efficient image viewer, browser and converter for Windows.",
+		"link": "https://www.xnview.com/en/xnview/",
+		"winget": "XnSoft.XnView.Classic"
+	},
 	"WPFInstallxournal": {
 		"category": "Document",
 		"choco": "xournalplusplus",

--- a/config/applications.json
+++ b/config/applications.json
@@ -1583,6 +1583,14 @@
 		"link": "https://qtox.github.io/",
 		"winget": "Tox.qTox"
 	},
+	"WPFInstallquicklook": {
+		"category": "Utilities",
+		"choco": "quicklook",
+		"content": "Quicklook",
+		"description": "Bring macOS “Quick Look” feature to Windows",
+		"link": "https://github.com/QL-Win/QuickLook",
+		"winget": "QL-Win.QuickLook"
+	},
 	"WPFInstallrainmeter": {
 		"category": "Utilities",
 		"choco": "na",

--- a/config/applications.json
+++ b/config/applications.json
@@ -927,6 +927,14 @@
 		"link": "https://joplinapp.org/",
 		"winget": "Joplin.Joplin"
 	},
+	"WPFInstalljpegview": {
+		"category": "Utilities",
+		"choco": "jpegview",
+		"content": "JPEG View",
+		"description": "JPEGView is a lean, fast and highly configurable viewer/editor for JPEG, BMP, PNG, WEBP, TGA, GIF, JXL, HEIC, HEIF, AVIF and TIFF images with a minimal GUI",
+		"link": "https://github.com/sylikc/jpegview",
+		"winget": "sylikc.JPEGView"
+	},
 	"WPFInstallkdeconnect": {
 		"category": "Utilities",
 		"choco": "kdeconnect-kde",

--- a/config/applications.json
+++ b/config/applications.json
@@ -823,6 +823,14 @@
 		"link": "https://www.hwinfo.com/",
 		"winget": "REALiX.HWiNFO"
 	},
+	"WPFInstallhwmonitor": {
+		"category": "Utilities",
+		"choco": "hwmonitor",
+		"content": "HWMonitor",
+		"description": "HWMonitor is a hardware monitoring program that reads PC systems main health sensors.",
+		"link": "https://www.cpuid.com/softwares/hwmonitor.html",
+		"winget": "CPUID.HWMonitor"
+	},
 	"WPFInstallimageglass": {
 		"category": "Multimedia Tools",
 		"choco": "imageglass",


### PR DESCRIPTION
I added most of the apps mentioned in issue #374.

All other apps that I didn’t add aren’t available in WinGet so obviously cannot be added.

List of apps:

- FxSound
- SimpleNote
- Flow launcher
- CMake
- MuseScore
- JPEGView
- Explorer patcher
- Lockhunter
- Bulk Rename Utility (BRU)
- SpaceSniffer
- Quick Look
- Harmonoid
- Revolt
- Link shell extensions
- WizFile
- HWMonitor
- XnView
- Tabby
- SignalRGB
- Autoruns