### PR TITLE
Fixed issue #1736 and #1749

### DIFF
--- a/winutil.ps1
+++ b/winutil.ps1
@@ -1610,7 +1610,7 @@ function Invoke-WinUtilFeatureInstall {
     }
 }
 function Invoke-GPUCheck {
-    $gpuInfo = Get-WmiObject Win32_VideoController
+    $gpuInfo = Get-CimInstance -ClassName Win32_OperatingSystem 
     
     foreach ($gpu in $gpuInfo) {
         $gpuName = $gpu.Name


### PR DESCRIPTION
Fixed The Term "Get-WmiObject" is not recognized as the name of a cmdlet
$gpuinfo = Get-WmiObject Win32_VideoController which caused winutil to perform badly