### PR TITLE
Update Invoke-WinUtilGPU.ps1

### DIFF
--- a/functions/private/Invoke-WinUtilGPU.ps1
+++ b/functions/private/Invoke-WinUtilGPU.ps1
@@ -1,5 +1,5 @@
 function Invoke-GPUCheck {
-    $gpuInfo = Get-WmiObject Win32_VideoController
+    $gpuInfo = Get-CimInstance Win32_VideoController
     
     foreach ($gpu in $gpuInfo) {
         $gpuName = $gpu.Name


### PR DESCRIPTION
- This should be a proper fix to Invoke-WinUtilGPU.ps1. Tested in Win10 and Win11. @YusufKhalifadev made the fix to the wrong file. Fixes #1736 and #1749 