### PR TITLE
Update Paint.NET Winget name.

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -1341,7 +1341,7 @@
 		"content": "Paint.NET",
 		"description": "Paint.NET is a free image and photo editing software for Windows. It features an intuitive user interface and supports a wide range of powerful editing tools.",
 		"link": "https://www.getpaint.net/",
-		"winget": "dotPDNLLC.paintdotnet"
+		"winget": "dotPDN.PaintDotNet"
 	},
 	"WPFInstallparsec": {
 		"category": "Utilities",


### PR DESCRIPTION
Paint.NET's winget package name changed. Pull request to fix #1756. 