### PR TITLE
Add Simple Feature to keep the Service Startup upon Applying Service Tweaks, but not when Undoing it

### DIFF
--- a/functions/private/Invoke-WinUtilTweaks.ps1
+++ b/functions/private/Invoke-WinUtilTweaks.ps1
@@ -10,11 +10,15 @@ function Invoke-WinUtilTweaks {
     .PARAMETER undo
         Indicates whether to undo the operation contained in the checkbox
 
+    .PARAMETER KeepServiceStartup
+        Indicates whether to override the startup of a service with the one given from WinUtil,
+        or to keep the startup of said service, if it was changed by the user, or another program, from its default value.
     #>
 
     param(
         $CheckBox,
-        $undo = $false
+        $undo = $false,
+        $KeepServiceStartup = $true
     )
 
     Write-Debug "Tweaks: $($CheckBox)"
@@ -32,6 +36,7 @@ function Invoke-WinUtilTweaks {
             Registry = "Value"
             ScheduledTask = "State"
             Service = "StartupType"
+            OriginalService = "OriginalType"
             ScriptType = "InvokeScript"
         }
     }
@@ -42,9 +47,29 @@ function Invoke-WinUtilTweaks {
         }
     }
     if($sync.configs.tweaks.$CheckBox.service){
+        Write-Debug "KeepServiceStartup is $KeepServiceStartup"
         $sync.configs.tweaks.$CheckBox.service | ForEach-Object {
-            Write-Debug "$($psitem.Name) and state is $($psitem.$($values.service))"
-            Set-WinUtilService -Name $psitem.Name -StartupType $psitem.$($values.Service)
+            $changeservice = $true
+            
+	    # The check for !($undo) is required, without it the script will throw an error for accessing unavailable memeber, which's the 'OriginalService' Property
+            if($KeepServiceStartup -AND !($undo)) {
+                try {
+                    # Check if the service exists
+                    $service = Get-Service -Name $psitem.Name -ErrorAction Stop
+                    if(!($service.StartType.ToString() -eq $psitem.$($values.OriginalService))) {
+                        Write-Debug "Service $($service.Name) was changed in the past to $($service.StartType.ToString()) from it's original type of $($psitem.$($values.OriginalService)), will not change it to $($psitem.$($values.service))"
+                        $changeservice = $false
+                    }
+                }
+                catch [System.ServiceProcess.ServiceNotFoundException] {
+                    Write-Warning "Service $($psitem.Name) was not found"
+                }
+            }
+
+            if($changeservice) {
+                Write-Debug "$($psitem.Name) and state is $($psitem.$($values.service))"
+                Set-WinUtilService -Name $psitem.Name -StartupType $psitem.$($values.Service)
+            }
         }
     }
     if($sync.configs.tweaks.$CheckBox.registry){


### PR DESCRIPTION
### Commit Message Body
Added a new parameter that gives freedom of control on whether to disable this feature or not, and of course the simple feature in question.

The way it works is by Getting the service using its name, and see if the Startup Value of this service is equal to the default type that Windows comes with it, if not (The User has changed it in the past), then WinUtil won't change it by default (The KeepServiceStartup is true by default), this is a more desirable behaviour when compared to how it previously worked.

These changes were tested by the Author of this commit, Please read the commit patches for exact details on the changes.

### Issues this PR tries to Resolve
Resolves #1726