### PR TITLE
Detect free space of installation drive and compare it with the ISO size and delete temporary MicroWin files from previous runs

### DIFF
--- a/functions/public/Invoke-WPFGetIso.ps1
+++ b/functions/public/Invoke-WPFGetIso.ps1
@@ -146,6 +146,19 @@ function Invoke-WPFGetIso {
          $sync.MicrowinScratchDirBox.Text = Join-Path   $sync.MicrowinScratchDirBox.Text.Trim() '\'
 
     }
+    
+    # Detect if the folders already exist and remove them
+    if (($sync.MicrowinMountDir.Text -ne "") -and (Test-Path -Path $sync.MicrowinMountDir.Text))
+    {
+        try {
+            Write-Host "Deleting temporary files from previous run. Please wait..."
+            Remove-Item -Path $sync.MicrowinMountDir.Text -Recurse -Force
+            Remove-Item -Path $sync.MicrowinScratchDir.Text -Recurse -Force
+        }
+        catch {
+            Write-Host "Could not delete temporary files. You need to delete those manually."
+        }
+    }
 
     Write-Host "Setting up mount dir and scratch dirs"
     $timestamp = Get-Date -Format "yyyyMMdd_HHmmss"

--- a/winutil.ps1
+++ b/winutil.ps1
@@ -10,7 +10,7 @@
     Author         : Chris Titus @christitustech
     Runspace Author: @DeveloperDurp
     GitHub         : https://github.com/ChrisTitusTech
-    Version        : 24.03.29
+    Version        : 24.03.30
 #>
 param (
     [switch]$Debug,
@@ -47,7 +47,7 @@ Add-Type -AssemblyName System.Windows.Forms
 # Variable to sync between runspaces
 $sync = [Hashtable]::Synchronized(@{})
 $sync.PSScriptRoot = $PSScriptRoot
-$sync.version = "24.03.29"
+$sync.version = "24.03.30"
 $sync.configs = @{}
 $sync.ProcessRunning = $false
 
@@ -3302,6 +3302,19 @@ function Invoke-WPFGetIso {
 
          $sync.MicrowinScratchDirBox.Text = Join-Path   $sync.MicrowinScratchDirBox.Text.Trim() '\'
 
+    }
+    
+    # Detect if the folders already exist and remove them
+    if (($sync.MicrowinMountDir.Text -ne "") -and (Test-Path -Path $sync.MicrowinMountDir.Text))
+    {
+        try {
+            Write-Host "Deleting temporary files from previous run. Please wait..."
+            Remove-Item -Path $sync.MicrowinMountDir.Text -Recurse -Force
+            Remove-Item -Path $sync.MicrowinScratchDir.Text -Recurse -Force
+        }
+        catch {
+            Write-Host "Could not delete temporary files. You need to delete those manually."
+        }
     }
 
     Write-Host "Setting up mount dir and scratch dirs"


### PR DESCRIPTION
This PR adds checks to see if the available disk space is lower than a threshold specified by the ISO file chosen.

- If the disk space is lower than double the ISO size, the script will throw a warning
- If the disk space is lower than the ISO size, the script will throw an error and fail the operations

This should work fine and should close #1740

*P.S.: I may have finally figured out how to avoid the indentation issues!*