### PR TITLE
Add New Toggle to Disable/Enable Widgets found in Taskbar

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -2613,6 +2613,14 @@
     "Order": "a067_",
     "Type": "Toggle"
   },
+  "WPFToggleTaskbarWidgets": {
+    "Content": "Taskbar Widgets",
+    "Description": "If Enabled then Widgets Icon in Taskbar will be shown.",
+    "category": "Customize Preferences",
+    "panel": "2",
+    "Order": "a068_",
+    "Type": "Toggle"
+  },
   "WPFchangedns": {
     "Content": "DNS",
     "category": "z__Advanced Tweaks - CAUTION",

--- a/functions/private/Get-WinUtilToggleStatus.ps1
+++ b/functions/private/Get-WinUtilToggleStatus.ps1
@@ -89,4 +89,13 @@ Function Get-WinUtilToggleStatus {
             return $true
         }
     }
+    if ($ToggleSwitch -eq "WPFToggleTaskbarWidgets") {
+        $TaskbarWidgets = (Get-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced").TaskBarDa
+	if($TaskbarWidgets -eq 0) {
+            return $false
+	}
+	else{
+            return $true
+	}
+    }
 }

--- a/functions/private/Invoke-WinUtilTaskbarWidgets.ps1
+++ b/functions/private/Invoke-WinUtilTaskbarWidgets.ps1
@@ -1,0 +1,34 @@
+function Invoke-WinUtilTaskbarWidgets {
+    <#
+
+    .SYNOPSIS
+        Enable/Disable Taskbar Widgets
+
+    .PARAMETER Enabled
+        Indicates whether to enable or disable Taskbar Widgets
+
+    #>
+    Param($Enabled)
+    Try{
+        if ($Enabled -eq $false){
+            Write-Host "Enabling Taskbar Widgets"
+            $value = 1
+        }
+        else {
+            Write-Host "Disabling Taskbar Widgets"
+            $value = 0
+        }
+        $Path = "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced"
+        Set-ItemProperty -Path $Path -Name TaskbarDa -Value $value
+    }
+    Catch [System.Security.SecurityException] {
+        Write-Warning "Unable to set $Path\$Name to $Value due to a Security Exception"
+    }
+    Catch [System.Management.Automation.ItemNotFoundException] {
+        Write-Warning $psitem.Exception.ErrorRecord
+    }
+    Catch{
+        Write-Warning "Unable to set $Name due to unhandled exception"
+        Write-Warning $psitem.Exception.StackTrace
+    }
+}

--- a/functions/public/Invoke-WPFToggle.ps1
+++ b/functions/public/Invoke-WPFToggle.ps1
@@ -25,5 +25,6 @@ function Invoke-WPFToggle {
         "WPFToggleSnapFlyout" {Invoke-WinUtilSnapFlyout $(Get-WinUtilToggleStatus WPFToggleSnapFlyout)}
         "WPFToggleMouseAcceleration" {Invoke-WinUtilMouseAcceleration $(Get-WinUtilToggleStatus WPFToggleMouseAcceleration)}
         "WPFToggleStickyKeys" {Invoke-WinUtilStickyKeys $(Get-WinUtilToggleStatus WPFToggleStickyKeys)}
+        "WPFToggleTaskbarWidgets" {Invoke-WinUtilTaskbarWidgets $(Get-WinUtilToggleStatus WPFToggleTaskbarWidgets)}
     }
 }


### PR DESCRIPTION
### Some Background
A while back when I was watching one of your live stream records on youtube, You pointed out that Widgets found on Taskbar gets shown for whatever reason after applying tweaks, so I wondered if there's a way to disable/enable this feature, one or two google searches and found this [great blog post](https://www.top-password.com/blog/remove-widgets-on-windows-11-taskbar/) by top-password.com

After days of wanting to do it, I've found the free time to implement/understand how it all works, not knowing how to implement it was the hard part, noticed there isn't much on the documentation side for devs who want to contribute, may be something a more experienced person can help with this if they have the time to do so.. but nonetheless, any project can be understood with good old grep's recursive search 🤣 (worked great actually, not gonna lie)

### What This Solution do "In a Nutshell"
Changing the registry key `TaskbarDa` found inside `HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced`
`1` to **Enable it**
`0` to **Disable it**

### The Feature in-action
![toggle_taskbar_widgets_recording](https://github.com/ChrisTitusTech/winutil/assets/70659536/3c14442f-bfae-49b5-92ef-1e3c9482498e)