### PR TITLE
Fix Search Box Not Showing Apps/Tweaks Checkboxes When typing out Capital-Letters

### DIFF
--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -381,7 +381,7 @@ $sync["CheckboxFilter"].Add_TextChanged({
             continue
         }
 
-        $textToSearch = $sync.CheckboxFilter.Text
+        $textToSearch = $sync.CheckboxFilter.Text.ToLower()
         $checkBoxName = $CheckBox.Key
         $textBlockName = $checkBoxName + "Link"
 


### PR DESCRIPTION
### Issues this PR Tries to Resolve
Resolves #1731

### The PR in-action
![bugfix_searchbox_capital_letters_recording](https://github.com/ChrisTitusTech/winutil/assets/70659536/9a115259-3e59-407a-af38-ff7f79878c53)
