### PR TITLE
Restart Explorer after Applying Classic Right-Click Advance Tweak

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -2398,12 +2398,20 @@
     "panel": "1",
     "Order": "a028_",
     "InvokeScript": [
-      "New-Item -Path \"HKCU:\\Software\\Classes\\CLSID\\{86ca1aa0-34aa-4e8b-a509-50c905bae2a2}\" -Name \"InprocServer32\" -force -value \"\" "
+      "
+      New-Item -Path \"HKCU:\\Software\\Classes\\CLSID\\{86ca1aa0-34aa-4e8b-a509-50c905bae2a2}\" -Name \"InprocServer32\" -force -value \"\"
+      Write-Host Restarting explorer.exe ...
+      $process = Get-Process -Name \"explorer\"
+      Stop-Process -InputObject $process
+      "
     ],
     "UndoScript": [
       "
       Remove-Item -Path \"HKCU:\\Software\\Classes\\CLSID\\{86ca1aa0-34aa-4e8b-a509-50c905bae2a2}\" -Recurse -Confirm:$false -Force
-      Write-Host Restart Needed for change
+      # Restarting Explorer in the Undo Script might not be necessary, as the Registry change without restarting Explorer does work, but just to make sure.
+      Write-Host Restarting explorer.exe ...
+      $process = Get-Process -Name \"explorer\"
+      Stop-Process -InputObject $process
       "
     ]
   },


### PR DESCRIPTION
### Commit Message Body
In general, I've added two lines of code to get the explorer process using 'Get-Process', then passed the process object into 'Stop-Process', Windows will automatically restart explorer, so there's no need to run a new process for explorer.

Note: restarting explorer in the UndoScript might not be necessary, as it works just fine without it, that's according to the tests done by the author of this commit.