### PR TITLE
Add Tweak to disable Microsoft Account Login

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -2655,5 +2655,21 @@
     "panel": "2",
     "Order": "a082_",
     "Type": "300"
+  },
+  "WPFTweaksDisableMicrosoftAccountLogin": {
+    "Content": "Disable Microsoft Account Login",
+    "Description": "Disables new logins into Microsoft Accounts, so you can use local accounts in peace.",
+    "category": "z__Advanced Tweaks - CAUTION",
+    "panel": "1",
+    "Order": "a023_",
+    "registry": [
+      {
+        "Path": "HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System",
+        "Name": "NoConnectedUser",
+        "Type": "DWord",
+        "Value": "1",
+        "OriginalValue": "0"
+      }
+    ]
   }
 }


### PR DESCRIPTION
A suggestion to disable Microsoft Account login for Windows Accounts. The idea behind this is to stop Windows from showing those blocking screens at login and pop-us in the UI that push local account users to switch to a Microsoft Login Account.
At work this is considered a security risk, so normally I disable it using group policy, but for this tweak I decided to use a registry method so those poor souls using Windows 10/11 Home can benefit too.

This is the source I used: https://www.elevenforum.com/t/enable-or-disable-microsoft-accounts-in-windows-11.23799/

In the tweak I used value "1" instead of "3" to avoid possible locks if a Microsoft Account is already in use and because this allows other users to use Microsoft Accounts before applying the tweak.
In the undo tweak part, as I didn't found a way in the tool to delete a registry key like the article suggests, I opted instead to use the value "0".  I tested this on a VM and it seems to work.

Comments on the name, order and description of the tweak are welcomed, as I lack a bit of imagination and this is my first time contributing to this tool. I this pull request is denied, I will completely understand it.