### PR TITLE
Update Winget Install and Uninstall / Add NuGet and Microsoft.Winget.Client Modules

### DIFF
--- a/functions/private/Install-WinUtilProgramWinget.ps1
+++ b/functions/private/Install-WinUtilProgramWinget.ps1
@@ -30,11 +30,15 @@ Function Install-WinUtilProgramWinget {
         if($manage -eq "Installing"){
             # Install package via ID, if it fails try again with different scope. 
             # Install-WinGetPackage always returns "InstallerErrorCode" 0, so we have to check the "Status" of the install.
-            $status=$((Install-WinGetPackage -Id $Program -Scope SystemOrUnknown -Mode Silent -AcceptPackageAgreement -AcceptSourceAgreement).Status)
+            # With WinGet, not all installers honor any of the following: System-wide or User Installs OR Silent Install Mode.
+            # This is up to the individual package maintainers to enable these options. Aka. not as clean as Linux Package Managers.
+            $status=$((Install-WinGetPackage -Id $Program -Scope SystemOrUnknown -Mode Silent -Source winget -MatchOption Equals).Status)
             if($status -ne "Ok"){
-                $status=$((Install-WinGetPackage -Id $Program -Scope UserOrUnknown -Mode Silent -AcceptPackageAgreement -AcceptSourceAgreement).Status)
+                Write-Host "Not System"
+                $status=$((Install-WinGetPackage -Id $Program -Scope UserOrUnknown -Mode Silent -Source winget -MatchOption Equals).Status)
                 if($status -ne "Ok"){
-                    $status=$((Install-WinGetPackage -Id $Program -Scope Any -Mode Silent -AcceptPackageAgreement -AcceptSourceAgreement).Status)
+                    Write-Host "Not User"
+                    $status=$((Install-WinGetPackage -Id $Program -Scope Any -Mode Silent -Source winget -MatchOption Equals).Status)
                     if($status -ne "Ok"){
                         Write-Host "Failed to install $Program."
                     } else {
@@ -50,7 +54,7 @@ Function Install-WinUtilProgramWinget {
         if($manage -eq "Uninstalling"){
             # Uninstall package via ID.
             # Uninstall-WinGetPackage always returns "InstallerErrorCode" 0, so we have to check the "Status" of the uninstall.
-            $status=$((Uninstall-WinGetPackage -Id $Program -Mode Silent -AcceptSourceAgreement).Status)
+            $status=$((Uninstall-WinGetPackage -Id $Program -Mode Silent -MatchOption Equals -Source winget).Status)
             if ("$status" -ne "Ok") {
                 Write-Host "Failed to uninstall $Program."
             } else {

--- a/functions/private/Install-WinUtilWinget.ps1
+++ b/functions/private/Install-WinUtilWinget.ps1
@@ -41,6 +41,9 @@ function Install-WinUtilWinget {
         Write-Host "Installing Winget w/ Prerequsites`r"
         Add-AppxProvisionedPackage -Online -PackagePath $ENV:TEMP\Microsoft.DesktopAppInstaller.msixbundle -DependencyPackagePath $ENV:TEMP\Microsoft.VCLibs.x64.Desktop.appx, $ENV:TEMP\Microsoft.UI.Xaml.x64.appx -LicensePath $ENV:TEMP\License1.xml
         Write-Host "Winget Installed" -ForegroundColor Green
+        Write-Host "Enabling NuGet and Module..."
+        Install-PackageProvider -Name NuGet -Force
+        Install-Module -Name Microsoft.WinGet.Client -Force
         # Winget only needs a refresh of the environment variables to be used.
         Write-Output "Refreshing Environment Variables...`n"
         $ENV:PATH = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")


### PR DESCRIPTION
- Changed how WinGet installs and uninstalls are handled, by utilizing `Install-WinGetPackage` and `Uninstall-WinGetPackage`.

I learned today that PS Modules utilizing WinGet are installed alongside WinGet as of a few years ago. With the changes to how Winget Updating is handled by my other PR #1829, this should be a better solution to handling installs going forward. In the cases I tested, checking Status was the best way to handle issues with a package installer not having machine scope capabilities. 

If anyone has any better ways to handle this, let me know. 

This should fix issues, like: #1805 #1756