### PR TITLE
Add Disable SCOOBE in Disable Telemetry Tweak

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -1889,6 +1889,13 @@
         "Name": "Scheduling Category",
         "Value": "High",
         "Type": "String"
+      },
+      {
+        "Path": "HKCU:\\Software\\Microsoft\\Windows\\CurrentVersion\\UserProfileEngagement",
+        "OriginalValue": "1",
+        "Name": "ScoobeSystemSettingEnabled",
+        "Value": "0",
+        "Type": "DWord"
       }
     ],
     "InvokeScript": [


### PR DESCRIPTION
As I got suggested by @SkylerWallace on my previous PR #1827, the idea is to disable Second Out of Box Experience (SCOOBE) under the Disable Telemetry tweak. My reasoning is that this screen is a very annoying invitation to re-enable telemetry, and in my professional opinion a security risk. I know there's an option in Windows Settings to disable this, but in my opinion it's maliciously hard to reach (I didn't know about it's existence until now) and easy to forget while setting up a new computer, so adding it on this Tweak would be convenient.

Sources:
https://www.elevenforum.com/t/enable-or-disable-lets-finish-setting-up-your-device-in-windows-11.5205/#Two
https://www.tenforums.com/tutorials/137645-turn-off-get-even-more-out-windows-suggestions-windows-10-a.html#option2