### PR TITLE
Add ability to remove MS Copilot

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -2300,8 +2300,7 @@
     ],
     "UndoScript": [
       "
-      Write-Host \"Install Microsoft Edge\"
-      Start-Process -FilePath winget -ArgumentList \"install -e --accept-source-agreements --accept-package-agreements --silent Microsoft.Edge \" -NoNewWindow -Wait
+      
       "
     ]
   },

--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -2285,6 +2285,26 @@
       "
     ]
   },
+  "WPFTweaksRemoveCopilot": {
+    "Content": "Remove Microsoft Copilot",
+    "Description": "Removes MS Copilot AI built into Windows since 23H2.",
+    "category": "z__Advanced Tweaks - CAUTION",
+    "panel": "1",
+    "Order": "a025_",
+    "InvokeScript": [
+        "
+        Remove-AppxPackage \"Microsoft.Windows.Ai.Copilot.Provider\"
+        Remove-AppxPackage \"MicrosoftWindows.Client.CoPilot\"
+        Set-ItemProperty -Path \"HKCU:\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Advanced\" -Name \"ShowCopilotButton\" -Type \"DWord\" -Value \"0\" 
+        "
+    ],
+    "UndoScript": [
+      "
+      Write-Host \"Install Microsoft Edge\"
+      Start-Process -FilePath winget -ArgumentList \"install -e --accept-source-agreements --accept-package-agreements --silent Microsoft.Edge \" -NoNewWindow -Wait
+      "
+    ]
+  },
   "WPFTweaksRemoveOnedrive": {
     "Content": "Remove OneDrive",
     "Description": "Copies OneDrive files to Default Home Folders and Uninstalls it.",


### PR DESCRIPTION
I added the option to remove Copilot AI, this was pretty simple since **_yet_** there aren’t any special roadblocks (can remove Copilot with simple `Remove-AppxPackage`). Tested on latest 23H2 build.