### PR TITLE
A Temporary Fix to Compilation Program in 'Compile.ps1' Script

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -1827,7 +1827,7 @@
 		"category": "Development",
 		"choco": "na",
 		"content": "Swift toolchain",
-		"description": "Swift is a general-purpose programming language that’s approachable for newcomers and powerful for experts.",
+		"description": "Swift is a general-purpose programming language that is approachable for newcomers and powerful for experts.",
 		"link": "https://www.swift.org/",
 		"winget": "Swift.Toolchain"
 	},


### PR DESCRIPTION
### Commit Description Message

For whatever reason, Compiling using the 'Compile.ps1' Script when there's a Single Quote, in the description of an App for example, it'll try "escaping" it by adding another Single Quote, which's kind of weird.

Before there was an Apostrophe, and it'll Compile into Question Marks, probably because the Compile Script doesn't know what an Apostrophe is, or it can't escape it (or for another reason, didn't dig deeper into it), in the end I've made it neither an Apostrophe nor a Single Quote, just the sentence without contractions (Without shortening by combining words).