### PR TITLE
Fix Github Actions Auto Close Issues not leaving Issues Open

### DIFF
--- a/.github/workflows/close-old-issues.yaml
+++ b/.github/workflows/close-old-issues.yaml
@@ -38,7 +38,7 @@ jobs:
 
               // Close issues inactive for more than the inactivity period
               for (const issue of issues) {
-                const closeIssue = true;
+                let closeIssue = true;
 
                 // Get all Labels of issue, and compared each label with the labelKeepIssue const variable
                 try {


### PR DESCRIPTION
A Skill Issue moment, not gonna lie 😂
_Now_ this feature should work properly (This PR is a follow-up to https://github.com/ChrisTitusTech/winutil/pull/1801 PR)

> [!NOTE]
> As stated in https://github.com/ChrisTitusTech/winutil/pull/1801 PR, WinUtil Repo will need a new label for this, name of label should be the same as `labelKeepIssue` Const Variable in the Workflow's Script, if you want to change the Label Name, then make sure to change `labelKeepIssue` as well. Not Making a Label with said name, or Making these two Different **will render this feature useless**. Otherwise, it should work just fine 👍