### PR TITLE
Better JSON Parsing for Compile Script!!

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -1955,7 +1955,7 @@
 		"category": "Development",
 		"choco": "na",
 		"content": "Swift toolchain",
-		"description": "Swift is a general-purpose programming language that is approachable for newcomers and powerful for experts.",
+		"description": "Swift is a general-purpose programming language that's approachable for newcomers and powerful for experts.",
 		"link": "https://www.swift.org/",
 		"winget": "Swift.Toolchain"
 	},


### PR DESCRIPTION
### Key Takeaway from these changes

- Fixes `Cannot convert value "XAML STRING HERE" to type "System.Xml.XmlDocument". Error: "An error occurred while parsing ENTRY-NAME. Line X, position Y."` Issue when running `winutil.ps1`, which's shown when some special characters are present in WinUtil's XAML Strings. So I've Handled these special character by simply replacing them in the `content` and `description` fields with (the places where it's most common/only found at the time of writing) with Escaped Ones, see commit https://github.com/ChrisTitusTech/winutil/commit/c2055c4efcde454b412a5377ea90ac51c0885482 for more details.
- reverted the changes of https://github.com/ChrisTitusTech/winutil/pull/1844 PR in commit https://github.com/ChrisTitusTech/winutil/commit/f918b2228015595fb8a92e7788c40f80c960316b

- ~Committed & Pushed a "Compile Artifacts", made by running `Compile.ps1` Locally, for review in https://github.com/ChrisTitusTech/winutil/pull/1850/commits/ec81eadab92a7ebaa194b4e013481d898a772f4b Commit
  if you want to make sure that it isn't Made Up (Changes by me after running `Compile.ps1` Script), then you can download a `.zip` of the [PR's Git Branch](https://github.com/og-mrk/winutil/tree/compile-fix/proper-escaping-of-xml-characters), or use GitHub-CLI if you want to/have it installed (Command is `gh pr checkout 1850` to Checkout the PR's Changes).~ Reverted the changes, as it causes some Merge Conflicts.

### Story behind finding This Bug

In a Calm & warm summer afternoon, I've noticed a [new issue](https://github.com/ChrisTitusTech/winutil/issues/1848) in the WinUtil Issues page, so firing-up PowerShell and going ahead and ran WinUtl locally while being _on the Test Branch_, and to my surprise it was failing to start the GUI Front, almost finishing the setup phase.. but not quite, it displayed an output error never have I ever seen before, It such a humongous Error Output that it would de-motivate anyone unfamiliar of WinUtil's Code Base, One might say it was even longer than those annoying gcc's Compiler Errors 😂

Now onto fixing it to get back on fixing that OneDrive Copy Issue, and luckily with some reverting of previous commits in the git tree, I've found out [The Bad PR](https://github.com/ChrisTitusTech/winutil/pull/1818) behind this issue, which surprised me, as it was a PR I've made in the past, Credits.. _or blame I guess_, goes to @ModernTTY, Please do note as you continue on reading, the problem was Non-trivial to people who didn't spent enough time debugging/looking at Compile Script Output/Changes, so I believe it wasn't made on purpose by @ModernTTY, **_continuing with the story_**... of course, not knowing What changes might cause this issue, I went ahead and reverted through each junk/block, _which's contained as commits in the PR_, of the PR, one at a time, and found out that [The Root](https://github.com/ChrisTitusTech/winutil/pull/1818/commits/fdd048e6bd69e696f7dd903fcd1688c7181ba627) cause of it.

I stared at it.. but with no luck, and then by accident I've made a search one of the characters that I had some suspicion about, which's the **Ampersand Symbol (&)**, noticed something weird about it... there wasn't a single instance (outside that app entry) in the `applications.json` file, which had an Ampersand Symbol in it's fields, then I ran `Compile.ps1` locally, Looked into the difference (using `git diff`), I've found out that it was always Re-compiling that app entry and its xml version, which reminded me of https://github.com/ChrisTitusTech/winutil/pull/1844 PR, so looking at Which Character(s) it was always recompiling, it turned out to be.. An Invalid Character Problem, where you need to escape [some characters](https://stackoverflow.com/questions/730133/what-are-invalid-characters-in-xml) to be able to render said characters without problems.

... Then the pain started.. actually implementing the solution for it was by far the hardest part for me! and this part took the loooongest (almost 7-8 HOURS!), like.. in C for example, it would be somewhat easy to do what I've done, it was just a Nested For Loops! Not to mention how the difference it makes when you have a Single Quote String, and a Double Quote String.. I'll be honest, I'm no expert in PowerShell Scripting, so it was an obvious Skill Issue on my part 🙃.

In the end... I learnt a bit of PowerShell techniques by doing this, and how to properly escape characters (embarrassingly long time to debug it, not gonna lie 😥), but it was worth it at the end.

Anyhow, take care reader of this PR, and have a nice day 😄