### PR TITLE
Add option to remove Microsoft Copilot AI

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -2333,7 +2333,7 @@
         "
         Get-AppxPackage *copilot* | Remove-AppxPackage
         Set-ItemProperty -Path \"HKCU:\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Advanced\" -Name \"ShowCopilotButton\" -Type \"DWord\" -Value \"0\" 
-        Set-ItemProperty -Path \"HKCU:\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsCopilot\" -Name \"TurnOffWindowsCopilot\" -Type \"DWord\" -Value \"1\"
+        New-Item \"HKCU:\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsCopilot\" -Force | New-ItemProperty -Name \"TurnOffWindowsCopilot\" -Value \"1\" -Force -Type \"DWord\"
         "
     ],
     "UndoScript": [

--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -2323,6 +2323,25 @@
       "
     ]
   },
+  "WPFTweaksRemoveCopilot": {
+    "Content": "Remove Microsoft Copilot",
+    "Description": "Removes MS Copilot AI built into Windows since 23H2.",
+    "category": "z__Advanced Tweaks - CAUTION",
+    "panel": "1",
+    "Order": "a025_",
+    "InvokeScript": [
+        "
+        Get-AppxPackage *copilot* | Remove-AppxPackage
+        Set-ItemProperty -Path \"HKCU:\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Advanced\" -Name \"ShowCopilotButton\" -Type \"DWord\" -Value \"0\" 
+        Set-ItemProperty -Path \"HKCU:\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsCopilot\" -Name \"TurnOffWindowsCopilot\" -Type \"DWord\" -Value \"1\"
+        "
+    ],
+    "UndoScript": [
+      "
+
+      "
+    ]
+  },
   "WPFTweaksRemoveOnedrive": {
     "Content": "Remove OneDrive",
     "Description": "Copies OneDrive files to Default Home Folders and Uninstalls it.",

--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -2324,21 +2324,21 @@
     ]
   },
   "WPFTweaksRemoveCopilot": {
-    "Content": "Remove Microsoft Copilot",
-    "Description": "Removes MS Copilot AI built into Windows since 23H2.",
+    "Content": "Disables Microsoft Copilot",
+    "Description": "Disables MS Copilot AI built into Windows since 23H2.",
     "category": "z__Advanced Tweaks - CAUTION",
     "panel": "1",
     "Order": "a025_",
     "InvokeScript": [
         "
-        Get-AppxPackage *copilot* | Remove-AppxPackage
         Set-ItemProperty -Path \"HKCU:\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Advanced\" -Name \"ShowCopilotButton\" -Type \"DWord\" -Value \"0\" 
         New-Item \"HKCU:\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsCopilot\" -Force | New-ItemProperty -Name \"TurnOffWindowsCopilot\" -Value \"1\" -Force -Type \"DWord\"
         "
     ],
     "UndoScript": [
       "
-
+      Set-ItemProperty -Path \"HKCU:\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Advanced\" -Name \"ShowCopilotButton\" -Type \"DWord\" -Value \"1\" 
+      Remove-Item \"HKCU:\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsCopilot\" -Force
       "
     ]
   },


### PR DESCRIPTION
After the last PR I made I had a bit more time to spend creating Copilot removal.

Essentially it works in the following way:

1. It uninstalls some Copilot packages
2. Unpins Copilot from taskbar
3. Disables the ability to pin Copilot back to the taskbar