### PR TITLE
Simple improvement: make WinUtil's Shortcut Function Do Less (Lazier)

### DIFF
--- a/functions/public/Invoke-WPFShortcut.ps1
+++ b/functions/public/Invoke-WPFShortcut.ps1
@@ -17,22 +17,24 @@ function Invoke-WPFShortcut {
         [bool]$RunAsAdmin = $false
     )
 
-        $iconPath = $null
-        Switch ($ShortcutToAdd) {
-            "WinUtil" {
-                $SourceExe = "$env:SystemRoot\System32\WindowsPowerShell\v1.0\powershell.exe"
-                $IRM = 'irm https://christitus.com/win | iex'
-                $Powershell = '-ExecutionPolicy Bypass -Command "Start-Process powershell.exe -verb runas -ArgumentList'
-                $ArgumentsToSourceExe = "$powershell '$IRM'"
-                $DestinationName = "WinUtil.lnk"
+    # Preper the Shortcut Fields and add an a Custom Icon if it's available at "$env:TEMP\cttlogo.png", else don't add a Custom Icon.
+    $iconPath = $null
+    Switch ($ShortcutToAdd) {
+        "WinUtil" {
+            $SourceExe = "$env:SystemRoot\System32\WindowsPowerShell\v1.0\powershell.exe"
+            $IRM = 'irm https://christitus.com/win | iex'
+            $Powershell = '-ExecutionPolicy Bypass -Command "Start-Process powershell.exe -verb runas -ArgumentList'
+            $ArgumentsToSourceExe = "$powershell '$IRM'"
+            $DestinationName = "WinUtil.lnk"
 
-                if (Test-Path -Path "$env:TEMP\cttlogo.png") {
-                    $iconPath = "$env:SystempRoot\cttlogo.ico"
-                    ConvertTo-Icon -bitmapPath "$env:TEMP\cttlogo.png" -iconPath $iconPath
-                }
+            if (Test-Path -Path "$env:TEMP\cttlogo.png") {
+                $iconPath = "$env:SystempRoot\cttlogo.ico"
+                ConvertTo-Icon -bitmapPath "$env:TEMP\cttlogo.png" -iconPath $iconPath
             }
         }
+    }
 
+    # Show a File Dialog Browser, to let the User choose the Name and Location of where to save the Shortcut
     $FileBrowser = New-Object System.Windows.Forms.SaveFileDialog
     $FileBrowser.InitialDirectory = [Environment]::GetFolderPath('Desktop')
     $FileBrowser.Filter = "Shortcut Files (*.lnk)|*.lnk"

--- a/functions/public/Invoke-WPFShortcut.ps1
+++ b/functions/public/Invoke-WPFShortcut.ps1
@@ -39,7 +39,13 @@ function Invoke-WPFShortcut {
     $FileBrowser.InitialDirectory = [Environment]::GetFolderPath('Desktop')
     $FileBrowser.Filter = "Shortcut Files (*.lnk)|*.lnk"
     $FileBrowser.FileName = $DestinationName
-    $FileBrowser.ShowDialog() | Out-Null
+
+    # Do an Early Return if The Save Shortcut operation was cancel by User's Input.
+    $FileBrowserResult = $FileBrowser.ShowDialog()
+    $DialogResultEnum = New-Object System.Windows.Forms.DialogResult
+    if (-not ($FileBrowserResult -eq $DialogResultEnum::OK)) {
+        return
+    }
 
     $WshShell = New-Object -comObject WScript.Shell
     $Shortcut = $WshShell.CreateShortcut($FileBrowser.FileName)


### PR DESCRIPTION
### Highlights of these changes (The What & Why)
- Besides adding a few comments to make the Logic of this function slightly more clear (in commit https://github.com/ChrisTitusTech/winutil/commit/e2f07fa109848caf3f210f3a657a26ce0579d0e6)
- I also made the function "Lazier" by simply doing an Early Return when the User cancels the 'Save As' Operation, as we don't need to do the rest of code. (in commit https://github.com/ChrisTitusTech/winutil/commit/e7e41825d5b0843c7469ddb6045de1fa53817786)
  This resolving the False Info outputted in the terminal whenever you cancel the Save As Operation ( it outputs to the Terminal `Shortcut for WinUtil has been saved to %USERPROFILE%\Desktop\WinUtil.lnk with 'Run as administrator' set to True`.. even though we canceled the operation :/ ), and this adds a small efficiency to the process.