### PR TITLE
Remove Authy (Reached EOL)

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -95,14 +95,6 @@
 		"link": "https://www.audacityteam.org/",
 		"winget": "Audacity.Audacity"
 	},
-	"WPFInstallauthy": {
-		"category": "Utilities",
-		"choco": "authy-desktop",
-		"content": "Authy",
-		"description": "Simple and cross-platform 2FA app",
-		"link": "https://authy.com/",
-		"winget": "Twilio.Authy"
-	},
 	"WPFInstallautoruns": {
 		"category": "Microsoft Tools",
 		"choco": "autoruns",


### PR DESCRIPTION
Authy reached EOL in march 2024, no longer supporting desktop app

see:
https://help.twilio.com/articles/22771146070299-User-guide-End-of-Life-EOL-for-Twilio-Authy-Desktop-app