### PR TITLE
Add code editor Brackets.io/phcode.io

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -2630,5 +2630,13 @@
 		"description": "Fast Node Manager (fnm) allows you to switch your Node version by using the Terminal",
 		"link": "https://github.com/Schniz/fnm",
 		"winget": "Schniz.fnm"
+	},
+	"WPFInstallbrackets": {
+		"category": "Development",
+		"choco": "Brackets",
+		"content": "Brackets.io",
+		"description": "customizable Webb development editor with live preview",
+		"link": "https://github.com/brackets-cont/brackets",
+		"winget": "Adobe.Brackets"
 	}
 }

--- a/config/applications.json
+++ b/config/applications.json
@@ -2637,6 +2637,6 @@
 		"content": "Brackets.io",
 		"description": "customizable Webb development editor with live preview",
 		"link": "https://github.com/brackets-cont/brackets",
-		"winget": "Adobe.Brackets"
+		"winget": "brackets-cont.brackets"
 	}
 }


### PR DESCRIPTION
I want to add Brackets.io code editor for Webb development, as i feel its nice and clean and very useful with its easy live preview and many extensions.
[Brackets.io](https://brackets.io/#/home)
Bracktes was a [Adobe backed software](https://helpx.adobe.com/se/security/products/brackets.htm).

HOWEVER i think its considerd dead as the developers have a new editor Phoenix Code wich is out now but does not have a winget installer. 
But i want to add it at a later time.
[phcode.io](https://phcode.io/#/home)
Also the choco version seems to be the out of date Adobe version.

still a newbie to github so sorry if i messed somethin up.
