### PR TITLE
Fix incorrect url for jellyfin-media-player

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -988,7 +988,7 @@
 		"choco": "jellyfin-media-player",
 		"content": "Jellyfin Media Player",
 		"description": "Jellyfin Media Player is a client application for the Jellyfin media server, providing access to your media library.",
-		"link": "https://github.com/jellyfin/jellyfin-media-playerf",
+		"link": "https://github.com/jellyfin/jellyfin-media-player",
 		"winget": "Jellyfin.JellyfinMediaPlayer"
 	},
 	"WPFInstalljellyfinserver": {


### PR DESCRIPTION
The url link when clicking on `?` goes to the wrong repository, a trailing `f` character.