### PR TITLE
Remove StartAllBack + Adobe Debloater Tweak + Add Netbird

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -1255,6 +1255,14 @@
 		"link": "https://github.com/M2Team/NanaZip",
 		"winget": "M2Team.NanaZip"
 	},
+	"WPFInstallnetbird": {
+		"category": "Pro Tools",
+		"choco": "netbird",
+		"content": "NetBird",
+		"description": "NetBird is a Open Source alternative comparable to TailScale that can be connected to a selfhosted Server.",
+		"link": "https://netbird.io/",
+		"winget": "netbird"
+	},
 	"WPFInstallnaps2": {
 		"category": "Document",
 		"choco": "naps2",

--- a/config/applications.json
+++ b/config/applications.json
@@ -1871,14 +1871,6 @@
 		"link": "https://starship.rs/",
 		"winget": "starship"
 	},
-	"WPFInstallstartallback": {
-		"category": "Utilities",
-		"choco": "na",
-		"content": "StartAllBack",
-		"description": "StartAllBack is a Tool that can be used to edit the Windows appearance by your liking (Taskbar, Start Menu, File Explorer, Control Panel, Context Menu ...)",
-		"link": "https://www.startallback.com/",
-		"winget": "startallback"
-	},
 	"WPFInstallsteam": {
 		"category": "Games",
 		"choco": "steam-client",

--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -77,6 +77,60 @@
       }
     ]
   },
+  "WPFTweaksAdobe": {
+    "Content": "Disable Adobe Services",
+    "Description": "Disables many of the services that come with Adobe and run in the background.",
+    "category": "Essential Tweaks",
+    "panel": "1",
+    "Order": "a009_",
+    "service": [
+      {
+        "Name": "AGSService",
+        "StartupType": "Manual",
+        "OriginalType": "Automatic"
+      },
+      {
+        "Name": "AdobeUpdateService",
+        "StartupType": "Manual",
+        "OriginalType": "Automatic"
+      },
+      {
+        "Name": "Adobe Acrobat Update",
+        "StartupType": "Manual",
+        "OriginalType": "Automatic"
+      },
+      {
+        "Name": "Adobe Genuine Monitor Service",
+        "StartupType": "Manual",
+        "OriginalType": "Automatic"
+      },
+      {
+        "Name": "AdobeARMservice",
+        "StartupType": "Manual",
+        "OriginalType": "Automatic"
+      },
+      {
+        "Name": "Adobe Licensing Console",
+        "StartupType": "Manual",
+        "OriginalType": "Automatic"
+      },
+      {
+        "Name": "CCXProcess",
+        "StartupType": "Manual",
+        "OriginalType": "Automatic"
+      },
+      {
+        "Name": "AdobeIPCBroker",
+        "StartupType": "Manual",
+        "OriginalType": "Automatic"
+      },
+      {
+        "Name": "CoreSync",
+        "StartupType": "Manual",
+        "OriginalType": "Automatic"
+      }
+    ]
+  },
   "WPFTweaksLoc": {
     "Content": "Disable Location Tracking",
     "Description": "Disables Location Tracking...DUH!",


### PR DESCRIPTION
- Removes StartAllBack as of your request and because it apparently does not work in 24H2 anymore.
- Adds Netbird (https://netbird.io)
- Adds Tweak that sets the many Services from Adobe to manual
  - That seems to work for me, didn't test it on multiple Machines because i dont want unnecessary shit on my devices