### PR TITLE
Optimize winget download speed

### DIFF
--- a/functions/private/Get-WinUtilWingetLatest.ps1
+++ b/functions/private/Get-WinUtilWingetLatest.ps1
@@ -5,14 +5,16 @@ function Get-WinUtilWingetLatest {
     .DESCRIPTION
         This function grabs the latest version of Winget and returns the download path to Install-WinUtilWinget for installation.
     #>
-
+    # Invoke-WebRequest is notoriously slow when the byte progress is displayed. The following lines disable the progress bar and reset them at the end of the function  
+    $PreviousProgressPreference = $ProgressPreference 
+    $ProgressPreference = "silentlyContinue"
     Try{
         # Grabs the latest release of Winget from the Github API for the install process.
         $response = Invoke-RestMethod -Uri "https://api.github.com/repos/microsoft/Winget-cli/releases/latest" -Method Get -ErrorAction Stop
         $latestVersion = $response.tag_name #Stores version number of latest release.
-        $licenseWingetUrl = $response.assets.browser_download_url[0] #Index value for License file.
+        $licenseWingetUrl = $response.assets.browser_download_url | Where-Object {$_ -like "*License1.xml"} #Index value for License file.
         Write-Host "Latest Version:`t$($latestVersion)`n"
-        $assetUrl = $response.assets.browser_download_url[2] #Index value for download URL.
+        $assetUrl = $response.assets.browser_download_url | Where-Object {$_ -like "*Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle"}
         Invoke-WebRequest -Uri $licenseWingetUrl -OutFile $ENV:TEMP\License1.xml
         # The only pain is that the msixbundle for winget-cli is 246MB. In some situations this can take a bit, with slower connections.
         Invoke-WebRequest -Uri $assetUrl -OutFile $ENV:TEMP\Microsoft.DesktopAppInstaller.msixbundle
@@ -20,4 +22,5 @@ function Get-WinUtilWingetLatest {
     Catch{
         throw [WingetFailedInstall]::new('Failed to get latest Winget release and license')
     }
+    $ProgressPreference = $PreviousProgressPreference
 }

--- a/functions/private/Get-WinUtilWingetLatest.ps1
+++ b/functions/private/Get-WinUtilWingetLatest.ps1
@@ -14,6 +14,7 @@ function Get-WinUtilWingetLatest {
         $latestVersion = $response.tag_name #Stores version number of latest release.
         $licenseWingetUrl = $response.assets.browser_download_url | Where-Object {$_ -like "*License1.xml"} #Index value for License file.
         Write-Host "Latest Version:`t$($latestVersion)`n"
+        Write-Host "Downloading..."
         $assetUrl = $response.assets.browser_download_url | Where-Object {$_ -like "*Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle"}
         Invoke-WebRequest -Uri $licenseWingetUrl -OutFile $ENV:TEMP\License1.xml
         # The only pain is that the msixbundle for winget-cli is 246MB. In some situations this can take a bit, with slower connections.


### PR DESCRIPTION
Microsoft in its endless wisdom, created Invoke-Webrequest in such a way that the progress bar, which is shown during a download, drastically reduces the download speed that can be achieved. This is especially painful when downloading larger files (like winget ~200+ MB) 
The simplest workaround is, to disable the progress bar for the time of the download and print a message like "Downloading..." manually. 