### PR TITLE
Made disabling Fullscreen optimizations its own tweak

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -2573,13 +2573,6 @@
       },
       {
         "Path": "HKCU:\\System\\GameConfigStore",
-        "Name": "GameDVR_DXGIHonorFSEWindowsCompatible",
-        "Value": "1",
-        "OriginalValue": "0",
-        "Type": "DWord"
-      },
-      {
-        "Path": "HKCU:\\System\\GameConfigStore",
         "Name": "GameDVR_HonorUserFSEBehaviorMode",
         "Value": "1",
         "OriginalValue": "0",
@@ -2644,6 +2637,22 @@
     ],
     "UndoScript": [
       "Enable-NetAdapterBinding -Name \"*\" -ComponentID ms_tcpip6"
+    ]
+  },
+  "WPFTweaksDisableFSO": {
+    "Content": "Disable Fullscreen Optimizations",
+    "Description": "Disables FSO in all applications. NOTE: This will disable Color Management in Exclusive Fullscreen",
+    "category": "z__Advanced Tweaks - CAUTION",
+    "panel": "1",
+    "Order": "a032_",
+    "registry": [
+      {
+        "Path": "HKCU:\\System\\GameConfigStore",
+        "Name": "GameDVR_DXGIHonorFSEWindowsCompatible",
+        "Value": "1",
+        "OriginalValue": "0",
+        "Type": "DWord"
+      }
     ]
   },
   "WPFTweaksEnableipsix": {


### PR DESCRIPTION
This is to fix the confusion talked about in #1907 

* Removed "GameDVR_DXGIHonorFSEWindowsCompatible" modification from "Disable GameDVR" tweak

* Created advanced tweak "Disable fullscreen optimizations"

Disables fullscreen optimizations in all applications. (Which can cause problems with Color Management in Exclusive Fullscreen)