### PR TITLE
Add SMPlayer to `applications.json`

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -2622,7 +2622,7 @@
 		"description": "SMPlayer is a free media player for Windows and Linux with built-in codecs that can play virtually all video and audio formats.",
 		"link": "https://www.smplayer.info",
 		"winget": "SMPlayer.SMPlayer"
-  },
+	},
 	"WPFInstallfancontrol": {
 		"category": "Utilities",
 		"choco": "na",

--- a/config/applications.json
+++ b/config/applications.json
@@ -2590,5 +2590,13 @@
 		"description": "get things from one computer to another, safely",
 		"link": "https://github.com/magic-wormhole/magic-wormhole",
 		"winget": "magic-wormhole.magic-wormhole"
+	},
+	"WPFInstallsmplayer": {
+		"category": "Multimedia Tools",
+		"choco": "smplayer",
+		"content": "SMPlayer",
+		"description": "SMPlayer is a free media player for Windows and Linux with built-in codecs that can play virtually all video and audio formats.",
+		"link": "https://www.smplayer.info",
+		"winget": "SMPlayer.SMPlayer"
 	}
 }


### PR DESCRIPTION
Added [SMPlayer](https://smplayer.info): free media player for Windows and Linux with built-in codecs that can play virtually all video and audio formats.

Request by https://github.com/ChrisTitusTech/winutil/issues/1782#issuecomment-2098024528.