### PR TITLE
Fix Typo in the App Entry 'GlazeWM' in 'applications.json' File

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -2655,7 +2655,7 @@
 		"link": "https://github.com/magic-wormhole/magic-wormhole",
 		"winget": "magic-wormhole.magic-wormhole"
 	},
-	"WPFInstalglazewm": {
+	"WPFInstallglazewm": {
 		"category": "Utilities",
 		"choco": "na",
 		"content": "GlazeWM",


### PR DESCRIPTION
### Problem that arise from such a Typo

<div align="center">
<img src="https://github.com/ChrisTitusTech/winutil/assets/70659536/c959deb9-401b-4fa3-a4e5-a00157783106">
<p><i>The App Entry not order correctly, and the fact the Install Function(s) can't pick the App Name due to the Typo Position affecting the Underlying Logic.</i></p>
</div>

### How to avoid such problem(s) in the future

Beside better/stricter PR review process, _even though in this particular case, the typo was caught waayyy back (approx. 2 weeks ago) in https://github.com/ChrisTitusTech/winutil/pull/1891 PR_, there should be Automatic Checks for these kind of issue, which it can be in the `Compile.ps1` Script, or as a Separate Unit Test all together.

This solution above should reduce the possibility of this ever happening again, because the Unit Test(s) will catch it as soon as possible.. _at least, that's in theory_.