### PR TITLE
Optimize Display Behaviour of Category Labels 

### DIFF
--- a/functions/private/Get-TabXaml.ps1
+++ b/functions/private/Get-TabXaml.ps1
@@ -77,9 +77,12 @@ function Get-TabXaml {
                     $panelcount++
                 }
             }
+
+            # Dot-source the Get-WPFObjectName function
+            . .\functions\private\Get-WPFObjectName
+            
             $categorycontent = $($category -replace '^.__', '')
-            # Remove all special Characters from the name because it will later be used as a Powershell Variable
-            $categoryname = "WPFLabel"+$($categorycontent -replace '[^a-zA-Z0-9]','')
+            $categoryname = Get-WPFObjectName -type "Label" -name $categorycontent
             $blockXml += "<Label Name=""$categoryname"" Content=""$categorycontent"" FontSize=""16""/>`n"
             $sortedApps = $organizedData[$panel][$category].Keys | Sort-Object
             foreach ($appName in $sortedApps) {

--- a/functions/private/Get-TabXaml.ps1
+++ b/functions/private/Get-TabXaml.ps1
@@ -77,7 +77,10 @@ function Get-TabXaml {
                     $panelcount++
                 }
             }
-            $blockXml += "<Label Content=""$($category -replace '^.__', '')"" FontSize=""16""/>`n"
+            $categorycontent = $($category -replace '^.__', '')
+            # Remove all special Characters from the name because it will later be used as a Powershell Variable
+            $categoryname = "WPFLabel"+$($categorycontent -replace '[^a-zA-Z0-9]','')
+            $blockXml += "<Label Name=""$categoryname"" Content=""$categorycontent"" FontSize=""16""/>`n"
             $sortedApps = $organizedData[$panel][$category].Keys | Sort-Object
             foreach ($appName in $sortedApps) {
                 $count++

--- a/functions/private/Get-WPFObjectName.ps1
+++ b/functions/private/Get-WPFObjectName.ps1
@@ -1,0 +1,27 @@
+function Get-WPFObjectName {
+        <#
+    .SYNOPSIS
+        This is a helper function that generates an objectname with the prefix WPF that can be used as a Powershell Variable after compilation.
+        To achieve this, all characters that are not a-z, A-Z or 0-9 are simply removed from the name.
+    .PARAMETER type
+        The type of object for which the name should be generated. (e.g. Label, Button, CheckBox...)
+    .PARAMETER name
+        The name or description to be used for the object. (invalid characters are removed)
+    .OUTPUTS
+        A string that can be used as a object/variable name in powershell.
+        For example: WPFLabelMicrosoftTools
+        
+    .EXAMPLE
+        Get-WPFObjectName -type Label -name "Microsoft Tools"
+    #>
+
+    param( [Parameter(Mandatory=$true)] 
+    $type, 
+    $name
+)
+
+$Output = $("WPF"+$type+$name) -replace '[^a-zA-Z0-9]', '' 
+
+return $Output
+
+}

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -368,7 +368,8 @@ $filter = Get-WinUtilVariables -Type CheckBox
 $CheckBoxes = $sync.GetEnumerator() | Where-Object { $psitem.Key -in $filter }
 
 $filter = Get-WinUtilVariables -Type Label
-$labels = $sync.GetEnumerator() | Where-Object {$PSItem.Key -in $filter}
+$labels = @{}
+$sync.GetEnumerator() | Where-Object {$PSItem.Key -in $filter} | ForEach-Object {$labels[$_.Key] = $_.Value}
 
 $allCategories = $checkBoxes.Name | ForEach-Object {$sync.configs.applications.$_} | Select-Object  -Unique -ExpandProperty category    
 
@@ -415,14 +416,14 @@ $sync["CheckboxFilter"].Add_TextChanged({
     $activeCategories = $activeApplications | Select-Object -ExpandProperty category -Unique
 
     foreach ($category in $activeCategories){
-        $label = $Labels | Where-Object {$_.Key -eq "WPFLabel"+$($category -replace '[^a-zA-Z0-9]','')}
-        $label.Value.Visibility = "Visible"
+        $label = $labels["WPFLabel"+$($category -replace '[^a-zA-Z0-9]')]
+        $label.Visibility = "Visible"
     }
     if ($activeCategories -ne $null){
         $inactiveCategories = Compare-Object -ReferenceObject $allCategories -DifferenceObject $activeCategories -PassThru
         foreach ($category in $inactiveCategories){
-            $label = $Labels | Where-Object {$_.Key -eq "WPFLabel"+$($category -replace '[^a-zA-Z0-9]','')}
-            $label.Value.Visibility = "Collapsed"}
+            $label = $labels["WPFLabel"+$($category -replace '[^a-zA-Z0-9]')]
+            $label.Visibility = "Collapsed"}
     }
 
 })

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -416,16 +416,18 @@ $sync["CheckboxFilter"].Add_TextChanged({
     $activeCategories = $activeApplications | Select-Object -ExpandProperty category -Unique
 
     foreach ($category in $activeCategories){
-        $label = $labels["WPFLabel"+$($category -replace '[^a-zA-Z0-9]')]
+        $label = $labels[$(Get-WPFObjectName -type "Label" -name $category)]
         $label.Visibility = "Visible"
     }
-    if ($activeCategories -ne $null){
+    if ($activeCategories){
         $inactiveCategories = Compare-Object -ReferenceObject $allCategories -DifferenceObject $activeCategories -PassThru
-        foreach ($category in $inactiveCategories){
-            $label = $labels["WPFLabel"+$($category -replace '[^a-zA-Z0-9]')]
-            $label.Visibility = "Collapsed"}
     }
-
+    else{
+        $inactiveCategories = $allCategories
+    }
+    foreach ($category in $inactiveCategories){
+        $label = $labels[$(Get-WPFObjectName -type "Label" -name $category)]
+        $label.Visibility = "Collapsed"}
 })
 
 # Define event handler for button click


### PR DESCRIPTION
Modified the display behavior of the Labels with the Category Description to be hidden on the application page if the category does not contain any applications (for example while using the search) 

### Before:
![image](https://github.com/ChrisTitusTech/winutil/assets/47688561/ec57812e-34b3-48cc-818d-87d33a8e3be1)

### After: 
![image](https://github.com/ChrisTitusTech/winutil/assets/47688561/97099fb3-ff01-4800-b8cc-f7bc9975f7c5)

