### PR TITLE
Winget install return code handling & Window management

### DIFF
--- a/functions/private/Install-WinUtilProgramWinget.ps1
+++ b/functions/private/Install-WinUtilProgramWinget.ps1
@@ -12,6 +12,7 @@ Function Install-WinUtilProgramWinget {
     
     .NOTES
     The triple quotes are required any time you need a " in a normal script block.
+    The winget Return codes are documented here: https://github.com/microsoft/winget-cli/blob/master/doc/windows/package-manager/winget/returnCodes.md
     #>
     
     param(

--- a/functions/private/Install-WinUtilProgramWinget.ps1
+++ b/functions/private/Install-WinUtilProgramWinget.ps1
@@ -35,22 +35,30 @@ Function Install-WinUtilProgramWinget {
             # This is up to the individual package maintainers to enable these options. Aka. not as clean as Linux Package Managers.
             Write-Host "Starting install of $($Program.winget) with winget."
             try {
-                $status = $(Start-Process -FilePath "winget" -ArgumentList "install --id $($Program.winget) --silent --accept-source-agreements --accept-package-agreements" -Wait -PassThru).ExitCode
+                $status = $(Start-Process -FilePath "winget" -ArgumentList "install --id $($Program.winget) --silent --accept-source-agreements --accept-package-agreements" -Wait -PassThru -NoNewWindow).ExitCode
                 if($status -eq 0){
                     Write-Host "$($Program.winget) installed successfully."
                     continue
                 }
+                if ($status -eq  -1978335189){
+                    Write-Host "$($Program.winget) No applicable update found"
+                    continue
+                }
                 Write-Host "Attempt with User scope"
-                $status = $(Start-Process -FilePath "winget" -ArgumentList "install --id $($Program.winget) --scope user --silent --accept-source-agreements --accept-package-agreements" -Wait -PassThru).ExitCode
+                $status = $(Start-Process -FilePath "winget" -ArgumentList "install --id $($Program.winget) --scope user --silent --accept-source-agreements --accept-package-agreements" -Wait -PassThru -NoNewWindow).ExitCode
                 if($status -eq 0){
                     Write-Host "$($Program.winget) installed successfully with User scope."
+                    continue
+                }
+                if ($status -eq  -1978335189){
+                    Write-Host "$($Program.winget) No applicable update found"
                     continue
                 }
                 Write-Host "Attempt with User prompt"
                 $userChoice = [System.Windows.MessageBox]::Show("Do you want to attempt $($Program.winget) installation with specific user credentials? Select 'Yes' to proceed or 'No' to skip.", "User Credential Prompt", [System.Windows.MessageBoxButton]::YesNo)
                 if ($userChoice -eq 'Yes') {
                     $getcreds = Get-Credential
-                    $process = Start-Process -FilePath "winget" -ArgumentList "install --id $($Program.winget) --silent --accept-source-agreements --accept-package-agreements" -Credential $getcreds -PassThru
+                    $process = Start-Process -FilePath "winget" -ArgumentList "install --id $($Program.winget) --silent --accept-source-agreements --accept-package-agreements" -Credential $getcreds -PassThru -NoNewWindow
                     Wait-Process -Id $process.Id
                     $status = $process.ExitCode
                 } else {
@@ -58,6 +66,10 @@ Function Install-WinUtilProgramWinget {
                 }
                 if($status -eq 0){
                     Write-Host "$($Program.winget) installed successfully with User prompt."
+                    continue
+                }
+                if ($status -eq  -1978335189){
+                    Write-Host "$($Program.winget) No applicable update found"
                     continue
                 }
             } catch {
@@ -68,7 +80,7 @@ Function Install-WinUtilProgramWinget {
         if($manage -eq "Uninstalling"){
             # Uninstall package via ID using winget directly.
             try {
-                $status = $(Start-Process -FilePath "winget" -ArgumentList "uninstall --id $($Program.winget) --silent" -Wait -PassThru).ExitCode
+                $status = $(Start-Process -FilePath "winget" -ArgumentList "uninstall --id $($Program.winget) --silent" -Wait -PassThru -NoNewWindow).ExitCode
                 if($status -ne 0){
                     Write-Host "Failed to uninstall $($Program.winget)."
                 } else {


### PR DESCRIPTION
Fix return code handling : 
- If you had an application installed and clicked install/update again, winget would exit with return code "-1978335189" No applicable update found, which is != 0, and therefore the logic for the fallback installation methods would start.

Changed winget window management: 
- Modified the winget install to utilize the open powershell window rather than create new windows for each install. 

Personal opinion: I think the function Install-WinUtilProgramWinget is starting to get a bit out of hand in terms of repetition of code blocks, repetition of the same arguments for winget, and so on.  I think that we should rework the function (maybe after the next release when it's clear if the fallback works as expected) and maybe split it up into smaller logic blocks, or multiple functions to remove some of the repeated code and keep the quality of the code up to the standard of the rest of winutil.