### PR TITLE
Update applications.json - Added NDI tools

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -2742,5 +2742,13 @@
 		"description": "ForceAutoHDR simplifies the process of adding games to the AutoHDR list in the Windows Registry",
 		"link": "https://github.com/7gxycn08/ForceAutoHDR",
 		"winget": "ForceAutoHDR.7gxycn08"
+	},
+	"WPFInstallnditools": {
+		"category": "Multimedia Tools",
+		"choco": "na",
+		"content": "NDI Tools",
+		"description":"NDI, or Network Device Interface, is a video connectivity standard that enables multimedia systems to identify and communicate with one another over IP and to encode, transmit, and receive high-quality, low latency, frame-accurate video and audio, and exchange metadata in real-time.",
+		"link": "https://ndi.video/",
+		"winget": "NDI.NDITools"
 	}
 }


### PR DESCRIPTION
NDI, or Network Device Interface, is developed by Newtek. It enables the encoding, transmission, and reception of high-quality, low latency, video and audio on your local network via IP.

You can turn computer desktops (via included screen capture apps) and even phones into video sources that can be brought into apps like OBS or vMix. Includes a plug-in for VLC that turns VLC into a video or audio playback source. You can even view and control many PTZ cameras, and tons of other features. Everything connects automatically over your local network.  

https://ndi.video/

