### PR TITLE
Simplify 'Close Old Issues' Workflow by using 'actions/stale' GitHub Action

### DIFF
--- a/.github/workflows/close-old-issues.yaml
+++ b/.github/workflows/close-old-issues.yaml
@@ -4,91 +4,20 @@ on:
   schedule:
     - cron: '0 0 * * *'  # Run daily
   workflow_dispatch:  # This line enables manual triggering
+
 jobs:
   close-issues:
     runs-on: ubuntu-latest
     permissions:
       issues: write  # Ensure necessary permissions for issues
-
+      pull-requests: none
+      contents: none
     steps:
     - name: Close inactive issues
-      uses: actions/github-script@v7
+      uses: actions/stale@v9.0.0
       with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        script: |
-          const octokit = github;
-
-          // Get the repository owner and name
-          const { owner, repo } = context.repo;
-
-          // Define the inactivity period (14 days)
-          const inactivityPeriod = new Date();
-          inactivityPeriod.setDate(inactivityPeriod.getDate() - 14);
-
-          const labelKeepIssue = 'Keep Issue Open';
-
-          try {
-            // Get all open issues with pagination
-            for await (const response of octokit.paginate.iterator(octokit.rest.issues.listForRepo, {
-              owner,
-              repo,
-              state: 'open',
-            })) {
-              const issues = response.data;
-
-              // Close issues inactive for more than the inactivity period
-              for (const issue of issues) {
-                let closeIssue = true;
-
-                // Get all Labels of issue, and compared each label with the labelKeepIssue const variable
-                try {
-                  const respondIssueLabels = await octokit.request("GET /repos/{owner}/{repo}/issues/{issue_number}/labels", {
-                    owner: owner,
-                    repo: repo,
-                    issue_number: issue.number
-                  });
-                  const labels = respondIssueLabels.data;
-
-                  for (let i = 0; i < labels.length; i++) {
-                    const label = labels[i]
-                    if (label.name === labelKeepIssue) {
-                      console.log(`Issue #${issue.number} will not be closed`);
-                      closeIssue = false;
-                      break; // Break from the loop, no need to check the remaining Labels.
-                    }
-                  }
-                } catch (error) {
-                  console.error(`Error while Fetching Labels for Issue #${issue.number}, Error: ${error}`);
-                }
-
-                if (!closeIssue) {
-                  continue; // Skip the next bit of code
-                }
-
-                const lastCommentDate = issue.updated_at;
-                if (new Date(lastCommentDate) < inactivityPeriod) {
-                  try {
-                    // Close the issue
-                    await octokit.rest.issues.update({
-                      owner,
-                      repo,
-                      issue_number: issue.number,
-                      state: 'closed',
-                    });
-
-                    // Add a comment
-                    await octokit.rest.issues.createComment({
-                      owner,
-                      repo,
-                      issue_number: issue.number,
-                      body: 'Closed due to inactivity',
-                    });
-                  } catch (error) {
-                    console.error(`Error updating or commenting on issue #${issue.number}: ${error}`);
-                  }
-                }
-              }
-            }
-          } catch (error) {
-            console.error(`Error fetching issues: ${error}`);
-          }
+        exempt-issue-labels: "Keep Issue Open"
+        days-before-issue-close: 14
+        close-issue-message: "This issue was closed because it has been inactive for 14 days"
+        debug-only: false # Make this field equal true if you want to test your configuration if it works or not
+        repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This would allow this workflow to be more maintainable in the future, and will offload the responsibility of the core feature(s) to be maintained by the GitHub community over on [their repo](https://github.com/actions/stale).

@ChrisTitusTech if you want to make this workflow more customizable, for example, adding a Stale to Issues, to notify the Author(s) and participances about an Issue _**before**_ it get closed shortly after, then you can do so, please refer to [the README file over on actions/stale repo](https://github.com/actions/stale/blob/main/README.md).

Also, it support closing of PRs if you want to add this functionality.. even though I do see it that useful for a project like WinUtil, but hay, the choice is yours Chris.

> [!NOTE]
> There's a great example with explanation over on GitHub Docs, here's a link to it:
> https://docs.github.com/en/actions/managing-issues-and-pull-requests/closing-inactive-issues