### PR TITLE
Remove force install of Winget + Small improvements

### DIFF
--- a/Compile.ps1
+++ b/Compile.ps1
@@ -1,5 +1,6 @@
 param (
-    [switch]$Debug
+    [switch]$Debug,
+    [switch]$Run
 )
 $OFS = "`r`n"
 $scriptname = "winutil.ps1"
@@ -107,3 +108,7 @@ else {
 
 Set-Content -Path $scriptname -Value ($script_content -join "`r`n") -Encoding ascii
 Write-Progress -Activity "Compiling" -Completed
+
+if ($run){
+    Start-Process -FilePath "powershell" -ArgumentList ".\$scriptname"
+}

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -133,9 +133,17 @@ $sync.keys | ForEach-Object {
 
 # Load computer information in the background
 Invoke-WPFRunspace -ScriptBlock {
-    $sync.ConfigLoaded = $False
-    $sync.ComputerInfo = Get-ComputerInfo
-    $sync.ConfigLoaded = $True
+    try{
+        $oldProgressPreference = $ProgressPreference
+        $ProgressPreference = "SilentlyContinue"
+        $sync.ConfigLoaded = $False
+        $sync.ComputerInfo = Get-ComputerInfo
+        $sync.ConfigLoaded = $True
+    }
+    finally{
+        $ProgressPreference = "Continue"
+    }
+    
 } | Out-Null
 
 #===========================================================================
@@ -144,9 +152,6 @@ Invoke-WPFRunspace -ScriptBlock {
 
 # Print the logo
 Invoke-WPFFormVariables
-
-# Install Winget if not already present
-Install-WinUtilWinget
 
 # Set the titlebar
 $sync["Form"].title = $sync["Form"].title + " " + $sync.version

--- a/winutil.ps1
+++ b/winutil.ps1
@@ -8,7 +8,7 @@
     Author         : Chris Titus @christitustech
     Runspace Author: @DeveloperDurp
     GitHub         : https://github.com/ChrisTitusTech
-    Version        : 24.06.11
+    Version        : 24.06.12
 #>
 param (
     [switch]$Debug,
@@ -45,7 +45,7 @@ Add-Type -AssemblyName System.Windows.Forms
 # Variable to sync between runspaces
 $sync = [Hashtable]::Synchronized(@{})
 $sync.PSScriptRoot = $PSScriptRoot
-$sync.version = "24.06.11"
+$sync.version = "24.06.12"
 $sync.configs = @{}
 $sync.ProcessRunning = $false
 


### PR DESCRIPTION
- Removes the forced install of winget on startup. Suppose a user clicks install on the applications page. In that case, winget will be installed anyways, but this removes the delay on bootup for users with a bad internet connection and only want to use winget for the tweaks or micro win. (Closes #2076, Closes #2068, Closes #2039, Closes #2022, Closes #2065) (Maybe it's possible to install winget in a separate Runspace but I haven't tested this)

- Disables the unnecessary Progress bar on bootup which is normally shown when "Get-ComputerInfo" is run. The user doesn't care how long this takes, because the command runs in a separate Runspace anyway. 

- Adds a -Run Toggle in the Compile script so when developing and constantly recompiling and testing, it's easier to compile and run with a single command