### PR TITLE
Remove WwanSvc Service From Manual Services Tweak

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -1224,11 +1224,6 @@
         "OriginalType": "Automatic"
       },
       {
-        "Name": "WwanSvc",
-        "StartupType": "Manual",
-        "OriginalType": "Manual"
-      },
-      {
         "Name": "XblAuthManager",
         "StartupType": "Manual",
         "OriginalType": "Manual"

--- a/winutil.ps1
+++ b/winutil.ps1
@@ -8,7 +8,7 @@
     Author         : Chris Titus @christitustech
     Runspace Author: @DeveloperDurp
     GitHub         : https://github.com/ChrisTitusTech
-    Version        : 24.06.11
+    Version        : 24.06.12
 #>
 param (
     [switch]$Debug,
@@ -45,7 +45,7 @@ Add-Type -AssemblyName System.Windows.Forms
 # Variable to sync between runspaces
 $sync = [Hashtable]::Synchronized(@{})
 $sync.PSScriptRoot = $PSScriptRoot
-$sync.version = "24.06.11"
+$sync.version = "24.06.12"
 $sync.configs = @{}
 $sync.ProcessRunning = $false
 


### PR DESCRIPTION
Should Resolve: #2032

It should not change anything to remove the service from the Tweak.

The default value Windows Assigns the service is Manual anyway so for most people, this setting never changed anything, but in some cases (as in the above issue) the service seems to get set to Automatic by the OEM which would be overwritten by winutil and therefore break functionality for part of the Wwan components.  