### PR TITLE
Remove wrong Log Message

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -2413,7 +2413,6 @@
     "Order": "a0015_",
     "InvokeScript": [
         "
-        Write-Host \"Kill OneDrive process\"
         $serviceName = \"LMS\"   
         Write-Host \"Stopping and disabling service: $serviceName\"
         Stop-Service -Name $serviceName -Force -ErrorAction SilentlyContinue;
@@ -2457,9 +2456,7 @@
     ],
     "UndoScript": [
       "
-      Write-Host \"Install Microsoft Edge\"
-      taskkill.exe /F /IM \"OneDrive.exe\"
-
+      Write-Host \"Undo for Disable Intel MM not implemented\"
       "
     ]
   },  

--- a/winutil.ps1
+++ b/winutil.ps1
@@ -8,7 +8,7 @@
     Author         : Chris Titus @christitustech
     Runspace Author: @DeveloperDurp
     GitHub         : https://github.com/ChrisTitusTech
-    Version        : 24.06.11
+    Version        : 24.06.12
 #>
 param (
     [switch]$Debug,
@@ -45,7 +45,7 @@ Add-Type -AssemblyName System.Windows.Forms
 # Variable to sync between runspaces
 $sync = [Hashtable]::Synchronized(@{})
 $sync.PSScriptRoot = $PSScriptRoot
-$sync.version = "24.06.11"
+$sync.version = "24.06.12"
 $sync.configs = @{}
 $sync.ProcessRunning = $false
 


### PR DESCRIPTION
The original creator of this tweak seems to have copied the OneDrive tweak to reuse the code (which is totally fair) but forgot to remove all Onedrive references,
Also the Undo Script didn't make any sense regarding undoing the change, so I replaced it with a simple message telling the user  that Undo isn't implemented for this tweak
 
Resolves: #2096
