### PR TITLE
Removed Free File Sync because of Malware warning on choco repo

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -1303,14 +1303,6 @@
 		"link": "https://sourceforge.net/projects/equalizerapo",
 		"winget": "na"
 	},
-	"WPFInstallFreeFileSync": {
-		"category": "Utilities",
-		"choco": "freefilesync",
-		"content": "FreeFileSync",
-		"description": "Synchronize Files and Folders",
-		"link": "https://freefilesync.org",
-		"winget": "na"
-	},
 	"WPFInstallCompactGUI": {
 		"category": "Utilities",
 		"choco": "compactgui",


### PR DESCRIPTION
Closes: #2066
Chocolatey Flagged this app as a Virus. The Package will be removed from winutil and (potentially) can later be readded if it turns out to be a False Positive
https://community.chocolatey.org/packages/FreeFileSync#virus

_Originally posted by @Marterich in https://github.com/ChrisTitusTech/winutil/issues/2066#issuecomment-2174075678_
            