### PR TITLE
Formatting Improvements to Compile Script

### DIFF
--- a/Compile.ps1
+++ b/Compile.ps1
@@ -37,16 +37,17 @@ Get-ChildItem .\config | Where-Object {$psitem.extension -eq ".json"} | ForEach-
 
     # Replace every XML Special Character so it'll render correctly in final build
     # Only do so if json files has content to be displayed (for example the applications, tweaks, features json files)
-    # Some Type Convertion using Casting and Cleaning Up of the convertion result using 'Replace' Method
+        # Some Type Convertion using Casting and Cleaning Up of the convertion result using 'Replace' Method
         $jsonAsObject = $json | convertfrom-json
         $firstLevelJsonList = ([System.String]$jsonAsObject).split('=;') | ForEach-Object {
             $_.Replace('=}','').Replace('@{','').Replace(' ','')
         }
 
-       for ($i = 0; $i -lt $firstLevelJsonList.Count; $i += 1) {
+        # Note:
+        #  Avoid using HTML Entity Codes, for example '&rdquo;' (stands for "Right Double Quotation Mark"),
+        #  Use **HTML decimal/hex codes instead**, as using HTML Entity Codes will result in XML parse Error when running the compiled script.
+        for ($i = 0; $i -lt $firstLevelJsonList.Count; $i += 1) {
             $firstLevelName = $firstLevelJsonList[$i]
-            # Note: Avoid using HTML Entity Codes (for example '&rdquo;' (stands for "Right Double Quotation Mark")), and use HTML decimal/hex codes instead.
-	        # as using HTML Entity Codes will result in XML parse Error when running the compiled script.
 	    if ($jsonAsObject.$firstLevelName.content -ne $null) {
                 $jsonAsObject.$firstLevelName.content = $jsonAsObject.$firstLevelName.content.replace('&','&#38;').replace('“','&#8220;').replace('”','&#8221;').replace("'",'&#39;').replace('<','&#60;').replace('>','&#62;')
                 $jsonAsObject.$firstLevelName.content = $jsonAsObject.$firstLevelName.content.replace('&#39;&#39;',"&#39;") # resolves the Double Apostrophe caused by the first replace function in the main loop
@@ -56,8 +57,8 @@ Get-ChildItem .\config | Where-Object {$psitem.extension -eq ".json"} | ForEach-
                 $jsonAsObject.$firstLevelName.description = $jsonAsObject.$firstLevelName.description.replace('&#39;&#39;',"&#39;") # resolves the Double Apostrophe caused by the first replace function in the main loop
 	    }
 	}
-	# The replace at the end is required, as without it the output of converto-json will be somewhat weird for Multiline String
-	# Most Notably is the scripts in json files, making it harder for users who want to review these scripts that are found in the final compiled script
+	# The replace at the end is required, as without it the output of 'converto-json' will be somewhat weird for Multiline Strings
+	# Most Notably is the scripts in some json files, making it harder for users who want to review these scripts, which're found in the compiled script
         $json = ($jsonAsObject | convertto-json -Depth 3).replace('\r\n',"`r`n")
 
     $sync.configs.$($psitem.BaseName) = $json | convertfrom-json

--- a/Compile.ps1
+++ b/Compile.ps1
@@ -9,6 +9,21 @@ $sync = [Hashtable]::Synchronized(@{})
 $sync.PSScriptRoot = $PSScriptRoot
 $sync.configs = @{}
 
+function Update-Progress {
+    param (
+        [Parameter(Mandatory, position=0)]
+        [string]$StatusMessage,
+
+	[Parameter(Mandatory, position=1)]
+        [int]$Percent,
+
+	[Parameter(position=2)]
+	[string]$Activity = "Compiling",
+    )
+
+    Write-Progress -Activity $Activity -Status $StatusMessage -PercentComplete $Percent
+}
+
 $header = @"
 ################################################################################################################
 ###                                                                                                          ###
@@ -17,20 +32,22 @@ $header = @"
 ################################################################################################################
 "@
 
+
 # Create the script in memory.
+Update-Progress "Pre-req: Allocating Memory" 0
 $script_content = [System.Collections.Generic.List[string]]::new()
 
-Write-Progress -Activity "Compiling" -Status "Adding: Header" -PercentComplete 5
+Update-Progress "Adding: Header" 5
 $script_content.Add($header)
 
-Write-Progress -Activity "Compiling" -Status "Adding: Version" -PercentComplete 10
+Update-Progress "Adding: Version" 10
 $script_content.Add($(Get-Content .\scripts\start.ps1).replace('#{replaceme}',"$(Get-Date -Format yy.MM.dd)"))
 
-Write-Progress -Activity "Compiling" -Status "Adding: Functions" -PercentComplete 20
+Update-Progress "Adding: Functions" 20
 Get-ChildItem .\functions -Recurse -File | ForEach-Object {
     $script_content.Add($(Get-Content $psitem.FullName))
     }
-Write-Progress -Activity "Compiling" -Status "Adding: Config *.json" -PercentComplete 40
+Update-Progress "Adding: Config *.json" 40
 Get-ChildItem .\config | Where-Object {$psitem.extension -eq ".json"} | ForEach-Object {
 
     $json = (Get-Content $psitem.FullName).replace("'","''")
@@ -64,7 +81,7 @@ Get-ChildItem .\config | Where-Object {$psitem.extension -eq ".json"} | ForEach-
     $sync.configs.$($psitem.BaseName) = $json | convertfrom-json
     $script_content.Add($(Write-output "`$sync.configs.$($psitem.BaseName) = '$json' `| convertfrom-json" ))
 }
-Write-Progress -Activity "Compiling" -Status "Adding: Config *.cfg" -PercentComplete 45
+Update-Progress "Adding: Config *.cfg" 45
 Get-ChildItem .\config | Where-Object {$PSItem.Extension -eq ".cfg"} | ForEach-Object {
     $script_content.Add($(Write-output "`$sync.configs.$($psitem.BaseName) = '$(Get-Content $PSItem.FullName)'"))
 }
@@ -77,13 +94,13 @@ $xaml = (Get-Content .\xaml\inputXML.xaml).replace("'","''")
 # Dot-source the Get-TabXaml function
 . .\functions\private\Get-TabXaml.ps1
 
-Write-Progress -Activity "Compiling" -Status "Building: Xaml " -PercentComplete 75
+Update-Progress "Building: Xaml " 75
 $appXamlContent = Get-TabXaml "applications" 5
 $tweaksXamlContent = Get-TabXaml "tweaks"
 $featuresXamlContent = Get-TabXaml "feature"
 
 
-Write-Progress -Activity "Compiling" -Status "Adding: Xaml " -PercentComplete 90
+Update-Progress "Adding: Xaml " 90
 # Replace the placeholder in $inputXML with the content of inputApp.xaml
 $xaml = $xaml -replace "{{InstallPanel_applications}}", $appXamlContent
 $xaml = $xaml -replace "{{InstallPanel_tweaks}}", $tweaksXamlContent
@@ -94,17 +111,17 @@ $script_content.Add($(Write-output "`$inputXML =  '$xaml'"))
 $script_content.Add($(Get-Content .\scripts\main.ps1))
 
 if ($Debug){
-    Write-Progress -Activity "Compiling" -Status "Writing debug files" -PercentComplete 95
+    Update-Progress "Writing debug files" 95
     $appXamlContent | Out-File -FilePath ".\xaml\inputApp.xaml" -Encoding ascii
     $tweaksXamlContent | Out-File -FilePath ".\xaml\inputTweaks.xaml" -Encoding ascii
     $featuresXamlContent | Out-File -FilePath ".\xaml\inputFeatures.xaml" -Encoding ascii
 }
 else {
-    Write-Progress -Activity "Compiling" -Status "Removing temporary files" -PercentComplete 99
+    Update-Progress "Removing temporary files" 99
     Remove-Item ".\xaml\inputApp.xaml" -ErrorAction SilentlyContinue
     Remove-Item ".\xaml\inputTweaks.xaml" -ErrorAction SilentlyContinue
     Remove-Item ".\xaml\inputFeatures.xaml" -ErrorAction SilentlyContinue
 }
 
 Set-Content -Path $scriptname -Value ($script_content -join "`r`n") -Encoding ascii
-Write-Progress -Activity "Compiling" -Completed
+Update-Progress "Finished" 100


### PR DESCRIPTION
### Changes for each commit

- Did some re-formatting to my past comments in `Compile.ps1` script (Making the wording shorter, and better spacing/formatting). ( commit 37b4706ae745b97f429fffdd63d1f104d5fe5a1d )
- Add new helper function, to be an Interface when writing progress to the console (using `Write-Progress`), IMO this will help the script's adhere to the DRY (**D**on't **R**epeat **Y**ourself) Principle, and make the script more readable. ( commit 5e193563aabb43410c6c11b9599b4a7896a1cfdf )

### Additional Info

These changes have been tested, so far I haven't found any issues when viewing the progress bar will compiling (even though the last actions move quite fast, I can't even read them 😅), and after these changes, the resulting `winutil.ps1` is Identical to the compiled one before said changes.