### PR TITLE
Fix White space (bottom right of Application Tab)

### DIFF
--- a/xaml/inputXML.xaml
+++ b/xaml/inputXML.xaml
@@ -571,6 +571,18 @@
                 </Setter.Value>
             </Setter>
         </Style>
+        <Style x:Key="ScrollVisibilityRectangle" TargetType="Rectangle">
+            <Setter Property="Visibility" Value="Collapsed"/>
+            <Style.Triggers>
+                <MultiDataTrigger>
+                    <MultiDataTrigger.Conditions>
+                        <Condition Binding="{Binding Path=ComputedHorizontalScrollBarVisibility, ElementName=scrollViewer}" Value="Visible"/>
+                        <Condition Binding="{Binding Path=ComputedVerticalScrollBarVisibility, ElementName=scrollViewer}" Value="Visible"/>
+                    </MultiDataTrigger.Conditions>
+                    <Setter Property="Visibility" Value="Visible"/>
+                </MultiDataTrigger>
+            </Style.Triggers>
+        </Style>
     </Window.Resources>
     <Grid Background="{MainBackgroundColor}" ShowGridLines="False" Name="WPFMainGrid" Width="Auto" Height="Auto" HorizontalAlignment="Stretch">
         <Grid.RowDefinitions>
@@ -706,12 +718,14 @@
                         <Button Name="WPFclearWinget" Content=" Clear Selection" Margin="2"/>
                     </StackPanel>
 
-                    <ScrollViewer Grid.Row="1" Grid.Column="0" Padding="-1" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto" 
-                        BorderBrush="Transparent" BorderThickness="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+                    <ScrollViewer x:Name="scrollViewer" Grid.Row="1" Grid.Column="0" Padding="-1" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto" 
+                                BorderBrush="Transparent" BorderThickness="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
                         <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
-                        {{InstallPanel_applications}}
+                            {{InstallPanel_applications}}
                         </Grid>
                     </ScrollViewer>
+
+                    <Rectangle Grid.Row="1" Grid.Column="0" Width="18" Height="18" Fill="{MainBackgroundColor}" HorizontalAlignment="Right" VerticalAlignment="Bottom" Style="{StaticResource ScrollVisibilityRectangle}"/>
 
                 </Grid>
             </TabItem>


### PR DESCRIPTION
When I use WinUtil in dark mode I always get a small offcolored rectangle on the bottom right of the toolbox. I did following things to fix it:

- created rectangle, color it with backgroundcolor and place it at the blank space.
- added xName to Application ScrollViewer to get the state of it's scrollbars
- added style for rectangle that triggers it to show if both scrollbars are visible

Before:
![image](https://github.com/ChrisTitusTech/winutil/assets/121827219/b50d45ec-1ed5-4c1c-af10-8c37b9d5d984)

After:
![image](https://github.com/ChrisTitusTech/winutil/assets/121827219/a90ef009-7a51-4b63-b1aa-aa7269fbfabe)

bc of the trigger the rectangle will not show if not needed so it won't brake anything else.