### PR TITLE
Fix 'close old issues' workflow

### DIFF
--- a/.github/workflows/close-old-issues.yaml
+++ b/.github/workflows/close-old-issues.yaml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write  # Ensure necessary permissions for issues
+      pull-requests: none
+      contents: none
     steps:
     - name: Close inactive issues
       uses: actions/stale@v9.0.0

--- a/.github/workflows/close-old-issues.yaml
+++ b/.github/workflows/close-old-issues.yaml
@@ -14,8 +14,20 @@ jobs:
     - name: Close inactive issues
       uses: actions/stale@v9.0.0
       with:
+        # A list of labels to reference when looking through issues,
+        # and only when one (or even more) of these labels are found..
+        # then skip this issue, and never try to stale and/or close it.
         exempt-issue-labels: "Keep Issue Open"
-        days-before-issue-close: 14
-        close-issue-message: "This issue was closed because it has been inactive for 14 days"
-        debug-only: false # Make this field equal true if you want to test your configuration if it works or not
+        # Split it into two weeks, after one week the issue will be marked as stale,
+        # after another week have pasted without any update.. the issue will then be closed.
+        days-before-issue-stale: 7
+        days-before-issue-close: 7
+        # NEVER mark PRs as Stale or Close + this workflow should never have write permissions on PRs, EVER!
+        days-before-pr-stale: -1
+        days-before-pr-close: -1
+        # Sends a message for both the Stale and Close events of an issue.
+        stale-issue-message: "This issue was marked as stale because it has been inactive for 7 days"
+        close-issue-message: "This issue was closed because it has been inactive for 7 days since it was marked as stale"
+        # Make this field equal true if you want to test your configuration if it works correctly or not
+        debug-only: false
         repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/close-old-issues.yaml
+++ b/.github/workflows/close-old-issues.yaml
@@ -10,8 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write  # Ensure necessary permissions for issues
-      pull-requests: none
-      contents: none
     steps:
     - name: Close inactive issues
       uses: actions/stale@v9.0.0


### PR DESCRIPTION
### Changes for each commit

- ~Remove un-necessary permissions in 'Close Old Issues' GitHub Workflow. ( commit 8fe062421d32ca67d22a716f69260588ee118541 )~
  **Reverted in commit 6f838142a6674fcc9c4ad9acc402a4970840f496**
- Update 'Close Old Issues' GitHub Workflow to try and fix it, as there's currently a lot of inactive issues in the repo, and this commit adds quite a few comments which aids in future reviewing/understanding of this workflow file. ( commit 6e05426f125d6fc3f0ac94d749f7d583614c8281 )