### PR TITLE
Remove copied entries in applications.json

### DIFF
--- a/config/applications.json:Zone.Identifier
+++ b/config/applications.json:Zone.Identifier
@@ -1,0 +1,3 @@
+[ZoneTransfer]
+ZoneId=3
+ReferrerUrl=C:\Users\thoma\Downloads\winutil-main.zip


### PR DESCRIPTION
I removed a copy of `ditto` and added `ShareX`

This makes winutil less cluttered and nicer to code in.

ShareX is a: Screen capture, file sharing and productivity tool.

Hope you like the PR!
[applications.json](https://github.com/user-attachments/files/15929505/applications.json)
