### PR TITLE
Add 'Advanced Ranamer' & 'Transmission' Apps into 'applications.json' File

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -215,6 +215,14 @@
 		"link": "https://www.bulkrenameutility.co.uk",
 		"winget": "TGRMNSoftware.BulkRenameUtility"
 	},
+	"WPFInstallAdvancedRenamer": {
+		"category": "Utilities",
+		"choco": "advanced-renamer",
+		"content": "Advanced Renamer",
+		"description": "Advanced Renamer is a program for renaming multiple files and folders at once. By configuring renaming methods the names can be manipulated in various ways.",
+		"link": "https://www.advancedrenamer.com/",
+		"winget": "XP9MD3S1KFCPH1"
+	},
 	"WPFInstallcalibre": {
 		"category": "Document",
 		"choco": "calibre",
@@ -1790,6 +1798,14 @@
 		"description": "qBittorrent is a free and open-source BitTorrent client that aims to provide a feature-rich and lightweight alternative to other torrent clients.",
 		"link": "https://www.qbittorrent.org/",
 		"winget": "qBittorrent.qBittorrent"
+	},
+	"WPFInstalltransmission": {
+		"category": "Utilities",
+		"choco": "transmission",
+		"content": "Transmission",
+		"description": "Transmission is a cross-platform BitTorrent client that is open source, easy, powerful, and lean.",
+		"link": "https://transmissionbt.com/",
+		"winget": "Transmission.Transmission"
 	},
 	"WPFInstalltixati": {
 		"category": "Utilities",


### PR DESCRIPTION
### Issues this PR tries to resolve

Satisfies a request made in Issue #1782 Tracking List.

### The Apps being Added

- **Advanced Renamer** ([website](https://www.advancedrenamer.com/)): Advanced Renamer is a program for renaming multiple files and folders at once. By configuring renaming methods the names can be manipulated in various ways.
  **License**: Proprietary
  **Privacy Notice**: https://www.advancedrenamer.com/privacy
  **Alternatives found in WinUtil**: PowerToys by Microsoft (Open Source) - has a tool called "PowerRenamer", Bulk Rename Utility (Proprietary).

- **Transmission** ([website](https://transmissionbt.com/) , [GitHub Repo](https://github.com/transmission/transmission)): Transmission is a cross-platform BitTorrent client that is open source, easy, powerful, and lean.
  **License(s)**: GNU v2 & GNU v3 (among other Licenses), [here's a link to all license](https://github.com/transmission/transmission/tree/main/licenses), which's found on the project's GitHub repo.
  **Alternatives found in WinUtil**: qbittorent (Open Source) - [repo on GitHub](https://github.com/qbittorrent/qBittorrent), deluge torrent (Open Source) - [repo hosted on their site](https://git.deluge-torrent.org/deluge)