### PR TITLE
Purging applications

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -151,14 +151,6 @@
 		"link": "https://github.com/sharkdp/bat",
 		"winget": "sharkdp.bat"
 	},
-	"WPFInstallbitcomet": {
-		"category": "Utilities",
-		"choco": "bitcomet",
-		"content": "BitComet",
-		"description": "BitComet is a free and open-source BitTorrent client that supports HTTP/FTP downloads and provides download management features.",
-		"link": "https://www.bitcomet.com/",
-		"winget": "CometNetwork.BitComet"
-	},
 	"WPFInstallbitwarden": {
 		"category": "Utilities",
 		"choco": "bitwarden",

--- a/config/applications.json
+++ b/config/applications.json
@@ -175,14 +175,6 @@
 		"link": "https://www.blender.org/",
 		"winget": "BlenderFoundation.Blender"
 	},
-	"WPFInstallbluestacks": {
-		"category": "Games",
-		"choco": "bluestacks",
-		"content": "Bluestacks",
-		"description": "Bluestacks is an Android emulator for running mobile apps and games on a PC.",
-		"link": "https://www.bluestacks.com/",
-		"winget": "BlueStack.BlueStacks"
-	},
 	"WPFInstallbrave": {
 		"category": "Browsers",
 		"choco": "brave",

--- a/config/applications.json
+++ b/config/applications.json
@@ -311,14 +311,6 @@
 		"link": "https://copyq.readthedocs.io/",
 		"winget": "hluk.CopyQ"
 	},
-	"WPFInstallditto": {
-		"category": "Utilities",
-		"choco": "ditto",
-		"content": "Ditto (Clipboard Manager)",
-		"description": "Ditto is an extension to the Windows Clipboard. You copy something to the Clipboard and Ditto takes what you copied and stores it in a database to retrieve at a later time.",
-		"link": "https://github.com/sabrogden/Ditto",
-		"winget": "Ditto.Ditto"
-	},
 	"WPFInstallcpuz": {
 		"category": "Utilities",
 		"choco": "cpu-z",
@@ -412,7 +404,7 @@
 		"choco": "ditto",
 		"content": "Ditto",
 		"description": "Ditto is an extension to the standard windows clipboard.",
-		"link": "https://ditto-cp.sourceforge.io/",
+		"link": "https://github.com/sabrogden/Ditto",
 		"winget": "Ditto.Ditto"
 	},
 	"WPFInstalldockerdesktop": {

--- a/config/applications.json
+++ b/config/applications.json
@@ -183,14 +183,6 @@
 		"link": "https://www.bluestacks.com/",
 		"winget": "BlueStack.BlueStacks"
 	},
-	"WPFInstallbrave": {
-		"category": "Browsers",
-		"choco": "brave",
-		"content": "Brave",
-		"description": "Brave is a privacy-focused web browser that blocks ads and trackers, offering a faster and safer browsing experience.",
-		"link": "https://www.brave.com",
-		"winget": "Brave.Brave"
-	},
 	"WPFInstallbulkcrapuninstaller": {
 		"category": "Utilities",
 		"choco": "bulk-crap-uninstaller",

--- a/config/applications.json
+++ b/config/applications.json
@@ -2415,14 +2415,6 @@
 		"link": "https://wezfurlong.org/wezterm/index.html",
 		"winget": "wez.wezterm"
 	},
-	"WPFInstallwindirstat": {
-		"category": "Utilities",
-		"choco": "windirstat",
-		"content": "WinDirStat",
-		"description": "WinDirStat is a disk usage statistics viewer and cleanup tool for Windows.",
-		"link": "https://windirstat.net/",
-		"winget": "WinDirStat.WinDirStat"
-	},
 	"WPFInstallwindowspchealth": {
 		"category": "Utilities",
 		"choco": "na",

--- a/config/applications.json
+++ b/config/applications.json
@@ -183,6 +183,14 @@
 		"link": "https://www.bluestacks.com/",
 		"winget": "BlueStack.BlueStacks"
 	},
+	"WPFInstallbrave": {
+		"category": "Browsers",
+		"choco": "brave",
+		"content": "Brave",
+		"description": "Brave is a privacy-focused web browser that blocks ads and trackers, offering a faster and safer browsing experience.",
+		"link": "https://www.brave.com",
+		"winget": "Brave.Brave"
+	},
 	"WPFInstallbulkcrapuninstaller": {
 		"category": "Utilities",
 		"choco": "bulk-crap-uninstaller",


### PR DESCRIPTION
Removed the following applications that I think are bloating the app list:

[WinDirStat](https://windirstat.net/) - WinDirStat is outdated. WizTree should be used instead

[BitComet](https://www.bitcomet.com) - BitComet is adware and has a history of unethical practices. [VirusTotal](https://www.virustotal.com/gui/file/7ccef9af5267c22a56bdbaf2f9109a02611bba461e0b0321bed42b5911163272), I don't know if these are false positives or not but there are so many better options

[BlueStacks](https://www.bluestacks.com/) - BlueStack 5's installation process forcibly install BlueStacks X and a crypto wallet alongside it

Additionally I have removed a duplicate entry of Ditto and changed the link on the entry remaining