### PR TITLE
Fix: Uninstall Popup Spelling Mistake

### DIFF
--- a/functions/public/Invoke-WPFUnInstall.ps1
+++ b/functions/public/Invoke-WPFUnInstall.ps1
@@ -15,7 +15,7 @@ function Invoke-WPFUnInstall {
     $PackagesToInstall = (Get-WinUtilCheckBoxes)["Install"]
 
     if ($PackagesToInstall.Count -eq 0) {
-        $WarningMsg = "Please select the program(s) to install"
+        $WarningMsg = "Please select the program(s) to uninstall"
         [System.Windows.MessageBox]::Show($WarningMsg, $AppTitle, [System.Windows.MessageBoxButton]::OK, [System.Windows.MessageBoxImage]::Warning)
         return
     }


### PR DESCRIPTION
Uninstallation Process has a popup that asks for programms to install. I fixed the spelling mistake.