### PR TITLE
Add a Chocolatey package for Borderless Gaming

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -1281,7 +1281,7 @@
 	},
 	"WPFInstallBorderlessGaming": {
 		"category": "Utilities",
-		"choco": "na",
+		"choco": "borderlessgaming",
 		"content": "Borderless Gaming",
 		"description": "Play your favorite games in a borderless window; no more time consuming alt-tabs.",
 		"link": "https://github.com/Codeusa/Borderless-Gaming",


### PR DESCRIPTION
Hello, this is my first PR ever! I use WinUtil all the time and decided to fix this small error after watching your recent video about contributing to open source. Thanks for all the work you do an this awesome project :).

Very small and hardly noticable, but there actually is a Chocolatey package for Borderless Gaming called "borderlessgaming", not a big deal because from my understanding, Chocolatey packages are just fallback if the winget package is unreachable, and there is a working package there already, but hopefully this makes someone's life easier.