### PR TITLE
DisableConsumerFeatures Tweak

### DIFF
--- a/config/preset.json
+++ b/config/preset.json
@@ -1,6 +1,7 @@
 {
   "Standard": [
     "WPFTweaksAH",
+    "WPFTweaksConsumerFeatures",
     "WPFTweaksDVR",
     "WPFTweaksHiber",
     "WPFTweaksHome",
@@ -16,6 +17,7 @@
     "WPFTweaksTeredo"
   ],
   "Minimal": [
+    "WPFTweaksConsumerFeatures",
     "WPFTweaksHome",
     "WPFTweaksServices",
     "WPFTweaksTele"

--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -1580,6 +1580,22 @@
       }
     ]
   },
+  "WPFTweaksConsumerFeatures":{
+    "Content": "Disable ConsumerFeatures",
+    "Description": "Windows 10 will not automatically install any games, third-party apps, or application links from the Windows Store for the signed-in user. Some default Apps will be inaccessible (eg. Phone Link)",
+    "category": "Essential Tweaks",
+    "panel": "1",
+    "Order": "a003_",
+    "registry": [
+      {
+      "Path": "HKLM:\\SOFTWARE\\Policies\\Microsoft\\Windows\\CloudContent",
+      "OriginalValue": "0",
+      "Name": "DisableWindowsConsumerFeatures",
+      "Value": "1",
+      "Type": "DWord"
+      }
+    ]
+  },
   "WPFTweaksTele": {
     "Content": "Disable Telemetry",
     "Description": "Disables Microsoft Telemetry. Note: This will lock many Edge Browser settings. Microsoft spies heavily on you when using the Edge browser.",
@@ -1736,13 +1752,6 @@
         "OriginalValue": "1",
         "Name": "SystemPaneSuggestionsEnabled",
         "Value": "0",
-        "Type": "DWord"
-      },
-      {
-        "Path": "HKLM:\\SOFTWARE\\Policies\\Microsoft\\Windows\\CloudContent",
-        "OriginalValue": "0",
-        "Name": "DisableWindowsConsumerFeatures",
-        "Value": "1",
         "Type": "DWord"
       },
       {

--- a/winutil.ps1
+++ b/winutil.ps1
@@ -8,7 +8,7 @@
     Author         : Chris Titus @christitustech
     Runspace Author: @DeveloperDurp
     GitHub         : https://github.com/ChrisTitusTech
-    Version        : 24.06.25
+    Version        : 24.06.26
 #>
 param (
     [switch]$Debug,
@@ -45,7 +45,7 @@ Add-Type -AssemblyName System.Windows.Forms
 # Variable to sync between runspaces
 $sync = [Hashtable]::Synchronized(@{})
 $sync.PSScriptRoot = $PSScriptRoot
-$sync.version = "24.06.25"
+$sync.version = "24.06.26"
 $sync.configs = @{}
 $sync.ProcessRunning = $false
 

--- a/winutil.ps1
+++ b/winutil.ps1
@@ -8,7 +8,7 @@
     Author         : Chris Titus @christitustech
     Runspace Author: @DeveloperDurp
     GitHub         : https://github.com/ChrisTitusTech
-    Version        : 24.06.26
+    Version        : 24.06.25
 #>
 param (
     [switch]$Debug,
@@ -45,7 +45,7 @@ Add-Type -AssemblyName System.Windows.Forms
 # Variable to sync between runspaces
 $sync = [Hashtable]::Synchronized(@{})
 $sync.PSScriptRoot = $PSScriptRoot
-$sync.version = "24.06.26"
+$sync.version = "24.06.25"
 $sync.configs = @{}
 $sync.ProcessRunning = $false
 


### PR DESCRIPTION
Removes `HKLM:\SOFTWARE\Policies\Microsoft\Windows\CloudContent\DisableWindowsConsumerFeatures` from the big Telemetry Tweak and moves it into its own Tweak with a meaningful description of what it does.

This was done because it also inhibits the use of the Phone Link App which some people do use, so this provides a fairly easy way to selectively disable the tweak without needing to open an Issue or Coding/Windows Internals knowledge.  

Resolves: #2033
Resolves: #1670 
