### PR TITLE
Add 'voicemeeter potato' and 'windowgrid' to 'applications.json'

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -2375,6 +2375,14 @@
 		"link": "https://voicemeeter.com/",
 		"winget": "VB-Audio.Voicemeeter"
 	},
+	"WPFInstallVoicemeeterPotato": {
+		"category": "Multimedia Tools",
+		"choco": "voicemeeter-potato",
+		"content": "Voicemeeter Potato",
+		"description": "Voicemeeter Potato is the ultimate version of the Voicemeeter Audio Mixer Application endowed with Virtual Audio Device to mix and manage any audio sources from or to any audio devices or applications.",
+		"link": "https://voicemeeter.com/",
+		"winget": "VB-Audio.Voicemeeter.Potato"
+	},
 	"WPFInstallvrdesktopstreamer": {
 		"category": "Games",
 		"choco": "na",

--- a/config/applications.json
+++ b/config/applications.json
@@ -2447,6 +2447,14 @@
 		"link": "https://support.microsoft.com/en-us/windows/how-to-use-the-pc-health-check-app-9c8abd9b-03ba-4e67-81ef-36f37caa7844",
 		"winget": "Microsoft.WindowsPCHealthCheck"
 	},
+	"WPFInstallWindowGrid": {
+		"category": "Utilities",
+		"choco": "windowgrid",
+		"content": "WindowGrid",
+		"description": "WindowGrid is a modern window management program for Windows that allows the user to quickly and easily layout their windows on a dynamic grid using just the mouse.",
+		"link": "http://windowgrid.net/",
+		"winget": "na"
+	},
 	"WPFInstallwingetui": {
 		"category": "Utilities",
 		"choco": "wingetui",


### PR DESCRIPTION
Just adding these two apps requested here: https://github.com/ChrisTitusTech/winutil/issues/1782#issuecomment-2195259964.

Note: WindowGrid has no winget package but has a Chocolatey package, not sure if I did this right, but feel free to fix it if I messed it up.