### PR TITLE
remove duplicate of ditto

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -407,7 +407,6 @@
 		"link": "https://discord.com/",
 		"winget": "Discord.Discord"
 	},
-	},
 	"WPFInstalldockerdesktop": {
 		"category": "Development",
 		"choco": "docker-desktop",

--- a/config/applications.json
+++ b/config/applications.json
@@ -407,13 +407,6 @@
 		"link": "https://discord.com/",
 		"winget": "Discord.Discord"
 	},
-	"WPFInstallditto": {
-		"category": "Utilities",
-		"choco": "ditto",
-		"content": "Ditto",
-		"description": "Ditto is an extension to the standard windows clipboard.",
-		"link": "https://ditto-cp.sourceforge.io/",
-		"winget": "Ditto.Ditto"
 	},
 	"WPFInstalldockerdesktop": {
 		"category": "Development",


### PR DESCRIPTION
The program Ditto had a duplicate entry.

I removed:
```
"WPFInstallditto": {
		"category": "Utilities",
		"choco": "ditto",
		"content": "Ditto",
		"description": "Ditto is an extension to the standard windows clipboard.",
		"link": "https://ditto-cp.sourceforge.io/",
		"winget": "Ditto.Ditto"
},
```
In favor of:
```
"WPFInstallditto": {
		"category": "Utilities",
		"choco": "ditto",
		"content": "Ditto (Clipboard Manager)",
		"description": "Ditto is an extension to the Windows Clipboard. You copy something to the Clipboard and Ditto takes what you copied and stores it in a database to retrieve at a later time.",
		"link": "https://github.com/sabrogden/Ditto",
		"winget": "Ditto.Ditto"
},
```
Because I think that the title "Ditto (Clipboard Manager)" is more helpful than just "Ditto" and that it is more useful to be linked to the GitHub rather than the SourceForge.