### PR TITLE
Added Try-Catch block for AppX package removal

### DIFF
--- a/functions/private/Invoke-MicroWin-Helper.ps1
+++ b/functions/private/Invoke-MicroWin-Helper.ps1
@@ -159,7 +159,13 @@ function Remove-ProvisionedPackages([switch] $keepSecurity = $false)
 	    {
 		    $status = "Removing Provisioned $($appx.PackageName)"
 		    Write-Progress -Activity "Removing Provisioned Apps" -Status $status -PercentComplete ($counter++/$appxProvisionedPackages.Count*100)
-			Remove-AppxProvisionedPackage -Path $scratchDir -PackageName $appx.PackageName -ErrorAction SilentlyContinue
+			try {
+				Remove-AppxProvisionedPackage -Path $scratchDir -PackageName $appx.PackageName -ErrorAction SilentlyContinue
+			}
+			catch {
+				Write-Host "Application $($appx.PackageName) could not be removed"
+				continue
+			}			
 	    }
 	    Write-Progress -Activity "Removing Provisioned Apps" -Status "Ready" -Completed
     }


### PR DESCRIPTION
This PR provides a possible fix for AppX package removal, which many users reported fails for some apps with errors like "Removal failed. Please contact your software vendor"

Here's a link to a Stack Overflow post about a user facing this issue: https://stackoverflow.com/questions/70700451/remove-appxpackage-fails-with-error-0x80070002

Now, an application that fails at being removed will go to the `catch` block and continue the loop, effectively ignoring it.

Please make changes to this PR if it doesn't solve the issue. Also, with this new way of contributing things, I'm lost in the weeds, given that now we contribute to the main branch.