### PR TITLE
Adobe Network Block Credit

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -2697,7 +2697,7 @@
   },
   "WPFTweaksBlockAdobeNet": {
     "Content": "Adobe Network Block",
-    "Description": "Reduce user interruptions by selectively blocking connections to Adobe's activation and telemetry servers. ",
+    "Description": "Reduce user interruptions by selectively blocking connections to Adobe's activation and telemetry servers. Credit: Ruddernation-Designs",
     "category": "z__Advanced Tweaks - CAUTION",
     "panel": "1",
     "Order": "a021_",    


### PR DESCRIPTION
Add Credit to Author of Hosts file from Adobe Networ Block in description.
- Giving Credit (if reasonable) is always a good thing