### PR TITLE
Add Overlay to Taskbaritem

### DIFF
--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -301,6 +301,37 @@ Add-Type @"
     # Write-Host $icon.Handle
     # [Window]::SendMessage($windowHandle, 0x80, [IntPtr]::Zero, $icon.Handle)
 
+    # Using a TaskbarItem Overlay until someone figures out how to replace the icon correctly
+
+    # URL of the image
+    $imageUrl = "https://christitus.com/images/logo-full.png"
+
+    # Download the image
+    $imagePath = "$env:TEMP\logo-full.png"
+    Invoke-WebRequest -Uri $imageUrl -OutFile $imagePath
+
+    # Read the image file as a byte array
+    $imageBytes = [System.IO.File]::ReadAllBytes($imagePath)
+
+    # Convert the byte array to a Base64 string
+    $base64String = [System.Convert]::ToBase64String($imageBytes)
+
+    # Create a streaming image by streaming the base64 string to a bitmap streamsource
+    $bitmap = New-Object System.Windows.Media.Imaging.BitmapImage
+    $bitmap.BeginInit()
+    $bitmap.StreamSource = [System.IO.MemoryStream][System.Convert]::FromBase64String($base64String)
+    $bitmap.EndInit()
+    $bitmap.Freeze()
+
+    # Ensure TaskbarItemInfo is created if not already
+    if (-not $sync["Form"].TaskbarItemInfo) {
+        $sync["Form"].TaskbarItemInfo = New-Object System.Windows.Shell.TaskbarItemInfo
+    }
+
+    # Set the overlay icon for the taskbar
+    $sync["Form"].TaskbarItemInfo.Overlay = $bitmap
+
+
     $rect = New-Object RECT
     [Window]::GetWindowRect($windowHandle, [ref]$rect)
     $width  = $rect.Right  - $rect.Left

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -287,19 +287,6 @@ Add-Type @"
         }
     }
 
-    # need to experiemnt more
-    # setting icon for the windows is still not working
-    # $pngUrl = "https://christitus.com/images/logo-full.png"
-    # $pngPath = "$env:TEMP\cttlogo.png"
-    # $iconPath = "$env:TEMP\cttlogo.ico"
-    # # Download the PNG file
-    # Invoke-WebRequest -Uri $pngUrl -OutFile $pngPath
-    # if (Test-Path -Path $pngPath) {
-    #     ConvertTo-Icon -bitmapPath $pngPath -iconPath $iconPath
-    # }
-    # $icon = [System.Drawing.Icon]::ExtractAssociatedIcon($iconPath)
-    # Write-Host $icon.Handle
-    # [Window]::SendMessage($windowHandle, 0x80, [IntPtr]::Zero, $icon.Handle)
 
     # Using a TaskbarItem Overlay until someone figures out how to replace the icon correctly
 


### PR DESCRIPTION
Since I and other did not find a way to correctly change the Icon of the Taskbaritem, i added the icon as an overlay.

Preview:
![image](https://github.com/ChrisTitusTech/winutil/assets/121827219/1b4a5d4b-0a1b-4dc7-b78f-253011d97fa2)
![image](https://github.com/ChrisTitusTech/winutil/assets/121827219/84735f03-ed11-4835-9a22-82f668f280e0)

Edit:
- Removed old commented-out code to set Taskbar Icon since it does not work.