### PR TITLE
Change WinGet ID for 'Fastfetch' to be 'Fastfetch-cli.Fastfetch' instead of 'fastfetch'

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -560,7 +560,7 @@
 		"content": "Fastfetch",
 		"description": "Fastfetch is a neofetch-like tool for fetching system information and displaying them in a pretty way",
 		"link": "https://github.com/fastfetch-cli/fastfetch/",
-		"winget": "fastfetch"
+		"winget": "Fastfetch-cli.Fastfetch"
 	},
 	"WPFInstallferdium": {
 		"category": "Communications",


### PR DESCRIPTION
### Commit Description Message

This will ensure no ambiguity would happen in the near future for this app entry.

### References

This PR is a follow-up to https://github.com/ChrisTitusTech/winutil/pull/2159 PR