### PR TITLE
Create Windev.ps1 loader

### DIFF
--- a/windev.ps1
+++ b/windev.ps1
@@ -1,6 +1,6 @@
 <#
 .SYNOPSIS
-	This Script is used as a target for the https://christitus.com/windev alias.
+    This Script is used as a target for the https://christitus.com/windev alias.
     It queries the latest winget release (no matter if Pre-Release, Draft or Full Release) and invokes It
 .DESCRIPTION
     This Script provides a simple way to always start the bleeding edge release even if it's not yet a full release.

--- a/windev.ps1
+++ b/windev.ps1
@@ -1,0 +1,40 @@
+<#
+.SYNOPSIS
+	This Script is used as a target for the https://christitus.com/windev alias.
+    It queries the latest winget release (no matter if Pre-Release, Draft or Full Release) and invokes It
+.DESCRIPTION
+    This Script provides a simple way to always start the bleeding edge release even if it's not yet a full release.
+    This function should be run with administrative privileges.
+    Because this way of recursively invoking scripts via Invoke-Expression it might very well happen that AV Programs flag this because it's a common way of mulitstage exploits to run
+.EXAMPLE
+	irm https://christitus.com/windev | iex 
+    OR
+    Run in Admin Powershell >  ./windev.ps1
+#>
+
+# Function to fetch the latest release tag from the GitHub API
+function Get-LatestRelease {
+    try {
+        $releases = Invoke-RestMethod -Uri 'https://api.github.com/repos/ChrisTitusTech/winutil/releases'
+        $latestRelease = $releases | Select-Object -First 1
+        return $latestRelease.tag_name
+    } catch {
+        Write-Host "Error fetching release data: $_" -ForegroundColor Red
+        return $null
+    }
+}
+
+# Function to redirect to the latest pre-release version
+function RedirectToLatestPreRelease {
+    $latestRelease = Get-LatestRelease
+    if ($latestRelease) {
+        $url = "https://raw.githubusercontent.com/ChrisTitusTech/winutil/$latestRelease/winutil.ps1"
+        Invoke-RestMethod $url | Invoke-Expression
+    } else {
+        Write-Host 'Unable to determine latest pre-release version.' -ForegroundColor Red
+    }
+}
+
+# Call the redirect function
+
+RedirectToLatestPreRelease

--- a/windev.ps1
+++ b/windev.ps1
@@ -7,7 +7,7 @@
     This function should be run with administrative privileges.
     Because this way of recursively invoking scripts via Invoke-Expression it might very well happen that AV Programs flag this because it's a common way of mulitstage exploits to run
 .EXAMPLE
-	irm https://christitus.com/windev | iex 
+    irm https://christitus.com/windev | iex 
     OR
     Run in Admin Powershell >  ./windev.ps1
 #>


### PR DESCRIPTION
Initializes the windev.ps1 file at the root of the project.

It allows the contributors to change the loader in the future via a simple PR and removes the necessity of maintaining the file on the web server. 

**!!! Important !!!**
Please create an alias for https://christitus.com/windev and reference the following link: https://raw.githubusercontent.com/ChrisTitusTech/winutil/main/windev.ps1

If a user runs the command: `irm https://christitus.com/windev | iex` the latest (pre) release will be started. 

Closes #2154
Closes #2060

Note:
Technically, it would also be possible to point the windev URL directly at the winutil.ps1 in the main branch since a pre-release is created for EVERY merge. I still think implementing this loader is the smartest way forward, in case the branch structure changes or you start selectively creating pre-release releases separate from the merges in the main branch 