### PR TITLE
Pump up the value of 'operations-per-run' Field for 'Close Old Issues' Workflow

### DIFF
--- a/.github/workflows/close-old-issues.yaml
+++ b/.github/workflows/close-old-issues.yaml
@@ -30,6 +30,10 @@ jobs:
         # Sends a message for both the Stale and Close events of an issue.
         stale-issue-message: "This issue was marked as stale because it has been inactive for 7 days"
         close-issue-message: "This issue was closed because it has been inactive for 7 days since it was marked as stale"
+        # Increase this value if the project receives a lot of
+        # PRs (yes.. apparently they're processed no matter what) & Issues.
+        # Default value for it (according to the docs) is 30
+        operations-per-run: 100
         # Make this field equal true if you want to test your configuration if it works correctly or not
         debug-only: false
         repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Commit description message

Provides more 'head-room' for the 'stale' Actions to process all available Issues, as well as PRs.. because they're processed no matter what, and I can't force this action not to.. as far as I know.

### References

- This will also remove the warning shown when this workflow runs shown in the Annotations Section.
  [link to latest one at the time of writing](https://github.com/ChrisTitusTech/winutil/actions/runs/9719913811)
- The docs for `operations-pre-run` Field:
  https://github.com/actions/stale#operations-per-run