### PR TITLE
Improvements/Fixes for the Release Actions

### DIFF
--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -22,7 +22,7 @@ jobs:
           $version = ''
           Get-Content ./winutil.ps1 -TotalCount 30 | ForEach-Object {
             if ($_ -match 'Version\s*:\s*(\d{2}\.\d{2}\.\d{2})') {
-              $version = $matches[1]
+              $version = "pre"+$matches[1]
               echo "version=$version" >> $GITHUB_ENV
               echo "::set-output name=version::$version"
               break

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,5 +38,6 @@ jobs:
           name: Release ${{ steps.extract_version.outputs.version }}
           files: ./winutil.ps1
           prerelease: false
+          make_latest: "true"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/windev.ps1
+++ b/windev.ps1
@@ -16,7 +16,7 @@
 function Get-LatestRelease {
     try {
         $releases = Invoke-RestMethod -Uri 'https://api.github.com/repos/ChrisTitusTech/winutil/releases'
-        $latestRelease = $releases | Select-Object -First 1
+        $latestRelease = $releases | Where-Object {$_.prerelease -eq $true} | Select-Object -First 1
         return $latestRelease.tag_name
     } catch {
         Write-Host "Error fetching release data: $_" -ForegroundColor Red


### PR DESCRIPTION
- Changes prerelease to include the prefix "pre" in the Tag to never overwrite/change main releases. (otherwise if you create a main release in the morning and merge a PR in the evening, the main Release will be marked as a pre-release again)
- Fix: Adds the Tag "Latest" to the Main Releases so that it works as expected
- change windev.ps1 to explicitly search for pre-releases (this is done because Github does not necessarily order the releases by last modified, but rather by the tag and name) 
