### PR TITLE
Move Launch Issues from ReadMe to Known Issues

### DIFF
--- a/KnownIssues.md
+++ b/KnownIssues.md
@@ -1,4 +1,26 @@
 ## Known Issues and Fixes
+
+### Launch Issues:
+
+- If you are unable to resolve `christitus.com/win` and are getting  errors launching the tool, it might be due to India blocking GitHub's content domain and preventing downloads.
+
+Source: <https://timesofindia.indiatimes.com/gadgets-news/github-content-domain-blocked-for-these-indian-users-reports/articleshow/96687992.cms>
+
+- Windows Security (formerly Defender) and other anti-virus software are known to block the script. The script gets flagged due to the fact that it requires administrator privileges & makes drastic system changes.
+
+- If you are having TLS 1.2 issues, or are having trouble resolving `christitus.com/win` then run with the following command:
+
+```
+[Net.ServicePointManager]::SecurityProtocol=[Net.SecurityProtocolType]::Tls12;iex(New-Object Net.WebClient).DownloadString('https://github.com/ChrisTitusTech/winutil/releases/latest/download/winutil.ps1')
+```
+
+If you are still having issues try using a **VPN**, or changing your **DNS provider** to:
+
+| `1.1.1.1` | `1.0.0.1` | or  | `8.8.8.8` | `8.8.4.4` |
+|---------|---------|-----|---------|---------|
+
+### Other Issues:
+
 - Windows taking longer to shut down:
   - [#69](https://github.com/ChrisTitusTech/winutil/issues/69) Turn on fast startup: Press Windows key + R, then type:
   ```

--- a/KnownIssues.md
+++ b/KnownIssues.md
@@ -2,11 +2,8 @@
 
 ### Launch Issues:
 
-- If you are unable to resolve `christitus.com/win` and are getting  errors launching the tool, it might be due to India blocking GitHub's content domain and preventing downloads.
-
-Source: <https://timesofindia.indiatimes.com/gadgets-news/github-content-domain-blocked-for-these-indian-users-reports/articleshow/96687992.cms>
-
 - Windows Security (formerly Defender) and other anti-virus software are known to block the script. The script gets flagged due to the fact that it requires administrator privileges & makes drastic system changes.
+  - If possible: Allow script in Anti-Virus software settings.
 
 - If you are having TLS 1.2 issues, or are having trouble resolving `christitus.com/win` then run with the following command:
 
@@ -14,11 +11,25 @@ Source: <https://timesofindia.indiatimes.com/gadgets-news/github-content-domain-
 [Net.ServicePointManager]::SecurityProtocol=[Net.SecurityProtocolType]::Tls12;iex(New-Object Net.WebClient).DownloadString('https://github.com/ChrisTitusTech/winutil/releases/latest/download/winutil.ps1')
 ```
 
+- If you are unable to resolve `christitus.com/win` and are getting  errors launching the tool, it might be due to India blocking GitHub's content domain and preventing downloads.
+  - Source: <https://timesofindia.indiatimes.com/gadgets-news/github-content-domain-blocked-for-these-indian-users-reports/articleshow/96687992.cms>
+
 If you are still having issues try using a **VPN**, or changing your **DNS provider** to:
 
 | `1.1.1.1` | `1.0.0.1` | or  | `8.8.8.8` | `8.8.4.4` |
 |---------|---------|-----|---------|---------|
 
+- Script doesn't run/PowerShell crashes:
+  1. Press Windows Key+X and select 'PowerShell (Admin)' (Windows 10) or 'Windows Terminal (Admin)' (Windows 11)
+  2. Run:
+  ```
+  Set-ExecutionPolicy Unrestricted -Scope Process -Force
+  ```
+  3. Run:
+  ```
+  irm christitus.com/win | iex
+  ```
+  
 ### Other Issues:
 
 - Windows taking longer to shut down:
@@ -43,13 +54,3 @@ Set-ItemProperty -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\DataCollection
 - Winget requires interaction on first run: Manually type 'y' and 'enter' into the PowerShell console to continue
 - (Windows 11) Quick Settings no longer works: Launch the Script and click 'Enable Action Center'
 - Explorer no longer launches: Go to Control Panel, File Explorer Options, Change the 'Open File Explorer to' option to 'This PC'.
-- Script doesn't run/PowerShell crashes:
-  1. Press Windows Key+X and select 'PowerShell (Admin)' (Windows 10) or 'Windows Terminal (Admin)' (Windows 11)
-  2. Run:
-  ```
-  Set-ExecutionPolicy Unrestricted -Scope Process -Force
-  ```
-  3. Run:
-  ```
-  irm christitus.com/win | iex
-  ```

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ If this site is not reachable from your country, please try running it directly 
 irm "https://github.com/ChrisTitusTech/winutil/releases/latest/download/winutil.ps1" | iex
 ```
 
+If you still have Issues, refer to [Known Issues](https://github.com/ChrisTitusTech/winutil/blob/main/KnownIssues.md).
+
+
 #### Automation
 
 Some features are available through automation. This allows you to save your config file pass it to Winutil walk away and come back to a finished system. Here is how you can set it up currently with Winutil >24.01.15
@@ -52,21 +55,6 @@ iex "& { $(irm christitus.com/win) } -Config [path-to-your-config] -Run"
 7. Have a cup of coffee! Come back when it's done.
 
 
-## Issues:
-
-- If you are unable to resolve christitus.com/win and are getting  errors launching the tool, it might be due to India blocking GitHub's content domain and preventing downloads. You may use a VPN or change your DNS provider to Google/Cloudflare/etc.
-
-Source: <https://timesofindia.indiatimes.com/gadgets-news/github-content-domain-blocked-for-these-indian-users-reports/articleshow/96687992.cms>
-
-- Windows Security (formerly Defender) and other anti-virus software are known to block the script. The script gets flagged due to the fact that it requires administrator privileges & makes drastic system changes.
-
-- If you are having TLS 1.2 issues, or are having trouble resolving `christitus.com/win` then run with the following command:
-
-```
-[Net.ServicePointManager]::SecurityProtocol=[Net.SecurityProtocolType]::Tls12;iex(New-Object Net.WebClient).DownloadString('https://raw.githubusercontent.com/ChrisTitusTech/winutil/main/winutil.ps1')
-```
-
-If you are still having issues try changing your DNS provider to 1.1.1.1 || 1.0.0.1 or 8.8.8.8 || 8.8.4.4
 
 ## Support
 - To morally and mentally support the project, make sure to leave a ⭐️!


### PR DESCRIPTION
At the time there are two Titles named Issues, to minimize confusion and properly use Known Issues for known Issues i moved that part to the file and referenced it directly under the launch command.

In addition i fixed the link in the command:

`[Net.ServicePointManager]::SecurityProtocol=[Net.SecurityProtocolType]::Tls12;iex(New-Object Net.WebClient).DownloadString('https://raw.githubusercontent.com/ChrisTitusTech/winutil/main/winutil.ps1')`

to use the link of the latest release instead of the winutil file in the repo folder:

`[Net.ServicePointManager]::SecurityProtocol=[Net.SecurityProtocolType]::Tls12;iex(New-Object Net.WebClient).DownloadString('https://github.com/ChrisTitusTech/winutil/releases/latest/download/winutil.ps1')`


I also moved an Issue that has to do with running the script to that section and titles it "Launch Issues"

If this PR does not get accepted I will make another one only fixing the mentioned link.