### PR TITLE
Redirect dev to latest Full Release if can't find prerelease

### DIFF
--- a/windev.ps1
+++ b/windev.ps1
@@ -20,8 +20,6 @@ function Get-LatestRelease {
         return $latestRelease.tag_name
     } catch {
         Write-Host "Error fetching release data: $_" -ForegroundColor Red
-        Write-Host "Redirecting to latest Full Release"
-        $latestRelease = "releases/latest/download"
         return $latestRelease.tag_name
     }
 }
@@ -31,10 +29,12 @@ function RedirectToLatestPreRelease {
     $latestRelease = Get-LatestRelease
     if ($latestRelease) {
         $url = "https://raw.githubusercontent.com/ChrisTitusTech/winutil/$latestRelease/winutil.ps1"
-        Invoke-RestMethod $url | Invoke-Expression
     } else {
         Write-Host 'Unable to determine latest pre-release version.' -ForegroundColor Red
+        Write-Host "Using latest Full Release"
+        $url = "https://github.com/ChrisTitusTech/winutil/releases/latest/download/winutil.ps1"
     }
+    Invoke-RestMethod $url | Invoke-Expression
 }
 
 # Call the redirect function

--- a/windev.ps1
+++ b/windev.ps1
@@ -20,7 +20,9 @@ function Get-LatestRelease {
         return $latestRelease.tag_name
     } catch {
         Write-Host "Error fetching release data: $_" -ForegroundColor Red
-        return $null
+        Write-Host "Redirecting to latest Full Release"
+        $latestRelease = "releases/latest/download"
+        return $latestRelease.tag_name
     }
 }
 

--- a/windev.ps1
+++ b/windev.ps1
@@ -12,6 +12,9 @@
     Run in Admin Powershell >  ./windev.ps1
 #>
 
+# Set PowerShell window title
+$Host.UI.RawUI.WindowTitle = $myInvocation.MyCommand.Definition
+
 # Function to fetch the latest release tag from the GitHub API
 function Get-LatestRelease {
     try {

--- a/windev.ps1
+++ b/windev.ps1
@@ -12,9 +12,6 @@
     Run in Admin Powershell >  ./windev.ps1
 #>
 
-# Set PowerShell window title
-$Host.UI.RawUI.WindowTitle = $myInvocation.MyCommand.Definition
-
 # Function to fetch the latest release tag from the GitHub API
 function Get-LatestRelease {
     try {
@@ -43,3 +40,6 @@ function RedirectToLatestPreRelease {
 # Call the redirect function
 
 RedirectToLatestPreRelease
+
+# Set PowerShell window title
+$Host.UI.RawUI.WindowTitle = $myInvocation.MyCommand.Definition

--- a/windev.ps1
+++ b/windev.ps1
@@ -40,6 +40,3 @@ function RedirectToLatestPreRelease {
 # Call the redirect function
 
 RedirectToLatestPreRelease
-
-# Set PowerShell window title
-$Host.UI.RawUI.WindowTitle = $myInvocation.MyCommand.Definition


### PR DESCRIPTION
Readded ability to redirect to latest release if it can't find a pre-release.

It was removed becaused we also removed the part specifically mentioning the pre-release, since it is added again because of an Issue I suggest also readding the redirect to the latest release