### PR TITLE
Allow for tasks to be distinguished

### DIFF
--- a/functions/public/Invoke-WPFMicrowin.ps1
+++ b/functions/public/Invoke-WPFMicrowin.ps1
@@ -171,13 +171,14 @@ public class PowerManagement {
 		Remove-Features -keepDefender:$keepDefender
 		Write-Host "Removing features complete!"
 
-		Write-Host "Removing Appx Bloat"
 		if (!$keepPackages)
 		{
+			Write-Host "Removing OS packages"
 			Remove-Packages
 		}
 		if (!$keepProvisionedPackages)
 		{
+			Write-Host "Removing Appx Bloat"
 			Remove-ProvisionedPackages -keepSecurity:$keepDefender
 		}
 


### PR DESCRIPTION
This minor change helps distinguish the tasks of removing OS packages and AppX packages since these packages aren't the same. With this, in the case of a processing error, it may help developers to spot the exact issue.