### PR TITLE
Fix & Rename Nilesoft Shell

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -1946,7 +1946,7 @@
 	"nilesoftShell": {
 		"category": "Utilities",
 		"choco": "nilesoft-shell",
-		"content": "Nilesoft Shell (Context Menu)",
+		"content": "Nilesoft Shell",
 		"description": "Shell is an expanded context menu tool that adds extra functionality and customization options to the Windows context menu.",
 		"link": "https://nilesoft.org/",
 		"winget": "Nilesoft.Shell"

--- a/config/applications.json
+++ b/config/applications.json
@@ -1943,10 +1943,10 @@
 		"link": "https://getsharex.com/",
 		"winget": "ShareX.ShareX"
 	},
-	"nilesoftShel": {
+	"nilesoftShell": {
 		"category": "Utilities",
 		"choco": "nilesoft-shell",
-		"content": "Shell (Expanded Context Menu)",
+		"content": "Nilesoft Shell (Context Menu)",
 		"description": "Shell is an expanded context menu tool that adds extra functionality and customization options to the Windows context menu.",
 		"link": "https://nilesoft.org/",
 		"winget": "Nilesoft.Shell"


### PR DESCRIPTION
closes #2260
- Fix "nilesoftShel" to "nilesoftShell"
- Rename from "Shell (Expanded Context Menu)" to "Nilesoft Shell"