### PR TITLE
Fix 'Close Old Issues' Workflow

### DIFF
--- a/.github/workflows/close-old-issues.yaml
+++ b/.github/workflows/close-old-issues.yaml
@@ -14,7 +14,7 @@ jobs:
       contents: none
     steps:
     - name: Close inactive issues
-      uses: actions/stale@v9.0.0
+      uses: actions/stale@v8
       with:
         # A list of labels to reference when looking through issues,
         # and only when one (or even more) of these labels are found..

--- a/.github/workflows/close-old-issues.yaml
+++ b/.github/workflows/close-old-issues.yaml
@@ -33,7 +33,7 @@ jobs:
         # Increase this value if the project receives a lot of
         # PRs (yes.. apparently they're processed no matter what) & Issues.
         # Default value for it (according to the docs) is 30
-        operations-per-run: 100
+        operations-per-run: 200
         # Make this field equal true if you want to test your configuration if it works correctly or not
         debug-only: false
         repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Context

To get more context, I highly recommend reading the commit patches, as well as their Title & Description.

And if you want, you can see more detail over on the References Section of this PR.

### Issues this PR tries to resolve

Resolves: https://github.com/ChrisTitusTech/winutil/issues/2262

### References

- [PR made in apache/eventmesh Repo - [ISSUE #4832] Downgrade stale bot to v8 to resolve state cache reserving error](https://github.com/apache/eventmesh/pull/4833#top)
- [Issue made in actions/stale Repo - Error delete _state: [403] Resource not accessible by integration](https://github.com/actions/stale/issues/1133)
  - [A comment highlighting the concerns over the possible solution in 'v9' of 'actions/stale', also links some resources about this topic](https://github.com/actions/stale/issues/1133#issuecomment-2133029572)