### PR TITLE
Add new 'Disable Powershell 7 Telemetry' Tweak

### DIFF
--- a/config/preset.json
+++ b/config/preset.json
@@ -14,7 +14,8 @@
     "WPFTweaksDeleteTempFiles",
     "WPFTweaksEndTaskOnTaskbar",
     "WPFTweaksRestorePoint",
-    "WPFTweaksTeredo"
+    "WPFTweaksTeredo",
+    "WPFTweaksPowershell7Tele"
   ],
   "Minimal": [
     "WPFTweaksConsumerFeatures",

--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -2317,6 +2317,19 @@
       "Invoke-WPFTweakPS7 -action \"PS5\""
     ]
   },
+  "WPFTweaksPowershell7Tele": {
+    "Content": "Disable Powershell 7 Telemetry",
+    "Description": "This will create an Environment Variable called 'POWERSHELL_TELEMETRY_OPTOUT' with a value of '1' which will tell Powershell 7 to not send Telemetry Data.",
+    "category": "Essential Tweaks",
+    "panel": "1",
+    "Order": "a009_",
+    "InvokeScript": [
+      "[Environment]::SetEnvironmentVariable('POWERSHELL_TELEMETRY_OPTOUT', '1', 'Machine')"
+    ],
+    "UndoScript": [
+      "[Environment]::SetEnvironmentVariable('POWERSHELL_TELEMETRY_OPTOUT', '', 'Machine')"
+    ]
+  },
   "WPFTweaksStorage": {
     "Content": "Disable Storage Sense",
     "Description": "Storage Sense deletes temp files automatically.",


### PR DESCRIPTION
As suggested in Issue #2248 , this will disable the Powershell 7 Telemetry by creating a new Environment Variable, tested it on Windows 11 23H2 (Build Number 22631.3737) and it works as expected.

The UndoScript simply deletes the Environment variable, [as explained in Microsoft Docs](https://learn.microsoft.com/en-gb/powershell/module/microsoft.powershell.core/about/about_environment_variables?view=powershell-7.4#set-environment-variables-with-setenvironmentvariable).