### PR TITLE
Rework JDK packages with Corretto LTS ones

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -951,69 +951,37 @@
 		"link": "https://jami.net/",
 		"winget": "SFLinux.Jami"
 	},
-	"java16": {
+	"java8": {
 		"category": "Development",
-		"choco": "temurin16jre",
-		"content": "OpenJDK Java 16",
-		"description": "OpenJDK Java 16 is the latest version of the open-source Java development kit.",
-		"link": "https://adoptopenjdk.net/",
-		"winget": "AdoptOpenJDK.OpenJDK.16"
+		"choco": "corretto8jdk",
+		"content": "Amazon Corretto 8 (LTS)",
+		"description": "Amazon Corretto is a no-cost, multiplatform, production-ready distribution of the Open Java Development Kit (OpenJDK).",
+		"link": "https://aws.amazon.com/corretto",
+		"winget": "Amazon.Corretto.8.JDK"
 	},
-	"java18": {
+	"java11": {
 		"category": "Development",
-		"choco": "temurin18jre",
-		"content": "Oracle Java 18",
-		"description": "Oracle Java 18 is the latest version of the official Java development kit from Oracle.",
-		"link": "https://www.oracle.com/java/",
-		"winget": "EclipseAdoptium.Temurin.18.JRE"
+		"choco": "corretto11jdk",
+		"content": "Amazon Corretto 11 (LTS)",
+		"description": "Amazon Corretto is a no-cost, multiplatform, production-ready distribution of the Open Java Development Kit (OpenJDK).",
+		"link": "https://aws.amazon.com/corretto",
+		"winget": "Amazon.Corretto.11.JDK"
+	},
+	"java17": {
+		"category": "Development",
+		"choco": "corretto17jdk",
+		"content": "Amazon Corretto 17 (LTS)",
+		"description": "Amazon Corretto is a no-cost, multiplatform, production-ready distribution of the Open Java Development Kit (OpenJDK).",
+		"link": "https://aws.amazon.com/corretto",
+		"winget": "Amazon.Corretto.17.JDK"
 	},
 	"java21": {
 		"category": "Development",
-		"choco": "na",
-		"content": "Azul Zulu JDK 21",
-		"description": "Azul Zulu JDK 21 is a distribution of the OpenJDK with long-term support, performance enhancements, and security updates.",
-		"link": "https://www.azul.com/downloads/zulu-community/",
-		"winget": "Azul.Zulu.21.JDK"
-	},
-	"java8": {
-		"category": "Development",
-		"choco": "temurin8jre",
-		"content": "OpenJDK Java 8",
-		"description": "OpenJDK Java 8 is an open-source implementation of the Java Platform, Standard Edition.",
-		"link": "https://adoptopenjdk.net/",
-		"winget": "EclipseAdoptium.Temurin.8.JRE"
-	},
-	"java11runtime": {
-		"category": "Development",
-		"choco": "na",
-		"content": "Eclipse Temurin JRE 11",
-		"description": "Eclipse Temurin JRE is the open source Java SE build based upon OpenJRE.",
-		"link": "https://adoptium.net/",
-		"winget": "EclipseAdoptium.Temurin.11.JRE"
-	},
-	"java17runtime": {
-		"category": "Development",
-		"choco": "na",
-		"content": "Eclipse Temurin JRE 17",
-		"description": "Eclipse Temurin JRE is the open source Java SE build based upon OpenJRE.",
-		"link": "https://adoptium.net/",
-		"winget": "EclipseAdoptium.Temurin.17.JRE"
-	},
-	"java18runtime": {
-		"category": "Development",
-		"choco": "na",
-		"content": "Eclipse Temurin JRE 18",
-		"description": "Eclipse Temurin JRE is the open source Java SE build based upon OpenJRE.",
-		"link": "https://adoptium.net/",
-		"winget": "EclipseAdoptium.Temurin.18.JRE"
-	},
-	"java19runtime": {
-		"category": "Development",
-		"choco": "na",
-		"content": "Eclipse Temurin JRE 19",
-		"description": "Eclipse Temurin JRE is the open source Java SE build based upon OpenJRE.",
-		"link": "https://adoptium.net/",
-		"winget": "EclipseAdoptium.Temurin.19.JRE"
+		"choco": "corretto21jdk",
+		"content": "Amazon Corretto 21 (LTS)",
+		"description": "Amazon Corretto is a no-cost, multiplatform, production-ready distribution of the Open Java Development Kit (OpenJDK).",
+		"link": "https://aws.amazon.com/corretto",
+		"winget": "Amazon.Corretto.21.JDK"
 	},
 	"jdownloader": {
 		"category": "Utilities",


### PR DESCRIPTION
# Pull Request

## Title
Rework JDK packages with Corretto LTS ones

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [x] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
In the Java world, if a JDK release is non-LTS, then it is non-existent. Thus, non-LTS JDK releases, like 16, 18, and 19, create noise without value. Moreover, fragmentation between Oracle, Eclipse, and Temurin is not necessary. I added all the LTS releases through Amazon Corretto, which is known for its solid support with security updates and open source nature, including WinGet and Coco packages.

## Testing
I have compiled and tested the program and the result is much cleaner.
![Screenshot 2024-07-08 184322](https://github.com/ChrisTitusTech/winutil/assets/114044633/e1cc74df-a8fd-4c06-aa59-b63a8d5eb81a)

## Impact
Simplifies the workflow of installing JDK binaries through WinUtil.

## Issue related to PR
[What issue is related to this PR (if any)]
- Resolves #1199

## Additional Information
None.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts. 
