### PR TITLE
Change Chrome installer from MSI to EXE

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -245,7 +245,7 @@
 		"content": "Chrome",
 		"description": "Google Chrome is a widely used web browser known for its speed, simplicity, and seamless integration with Google services.",
 		"link": "https://www.google.com/chrome/",
-		"winget": "Google.Chrome"
+		"winget": "Google.Chrome.EXE"
 	},
 	"chromium": {
 		"category": "Browsers",


### PR DESCRIPTION
# Change installer type of Chrome from MSI to EXE

## Type of Change
- [x] Bug fix
- [x] Hotfix

## Description
Chrome usually uses a .exe installer. From the main Website you'll also get the .exe installer. WinUtil uses the msi installer meaning if u installed chrome from the website WinUtil does not know it is installed. Meaning it will try to install chrome even tho it is already installed. the installer type stays the .exe one. The Get installed button will not detect chrome.
- The only place you'll get the MSI installer from is from the enterprise website, which almost noone uses.
- the exe installer is also an official one from google, so nothing 3rd party here.

## Testing
worked

## Issue related to PR
- Resolves #2156

## Additional Information
I did suggest another solution in the issue. I decided not to proceed with that because it would be much for nothing Since Chrome is the only one affected and I never saw someone use the msi installer from the website i made this simple change.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts. 
