### PR TITLE
Makes version work properly when clicked.

### DIFF
--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -496,7 +496,7 @@ Author   : <a href="https://github.com/ChrisTitusTech">@christitustech</a>
 Runspace : <a href="https://github.com/DeveloperDurp">@DeveloperDurp</a>
 MicroWin : <a href="https://github.com/KonTy">@KonTy</a>
 GitHub   : <a href="https://github.com/ChrisTitusTech/winutil">ChrisTitusTech/winutil</a>
-Version  : <a href="https://github.com/ChrisTitusTech/winutil/releases/tag/$($sync.version)">$($sync.version)</a>
+Version  : <a href="https://real-mullac.github.io/WinUtil-Docs/updates/$($sync.version)">$($sync.version)</a>
 "@
     $FontSize = $sync.configs.themes.$ctttheme.CustomDialogFontSize
     $HeaderFontSize = $sync.configs.themes.$ctttheme.CustomDialogFontSizeHeader


### PR DESCRIPTION
# Pull Request

## Title
Makes version work properly when clicked.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [x] UI/UX improvement

## Description
Makes it so when you click the verison even on the windev build takes you to the update log. As before if you click it you go to here - 
![image](https://github.com/ChrisTitusTech/winutil/assets/173318122/f7625e7e-0330-4657-867b-401d19146643)
as the URL should be https://github.com/ChrisTitusTech/winutil/releases/tag/pre24.07.08 when in pre relaese but now it will take you to the update log no matter if in Windev or win build. 

## Testing
Can't test properly as when you compile version changes but based on the look of the URL it will work wonders.

## Impact
The impact will make sure that you can always access the update log.

## Issue related to PR
[What issue is related to this PR (if any)]
- Resolves no issue

## Additional Information
This will require people to do PR's to https://github.com/Real-MullaC/WinUtil-Docs till docs become official.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts. 
