### PR TITLE
Discussions close on PR merge

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,6 +24,8 @@
 ## Issue related to PR
 [What issue is related to this PR (if any)]
 - Resolves #
+[What discussion is related to this PR (if any)]
+- Discussion: #
 
 ## Additional Information
 [Any additional information that reviewers should be aware of.]

--- a/.github/workflows/close-discussion.yml
+++ b/.github/workflows/close-discussion.yml
@@ -1,0 +1,30 @@
+name: Close Discussion on PR Merge
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  closeDiscussion:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if PR was merged
+        if: github.event.pull_request.merged == true
+        run: echo "PR was merged"
+
+      - name: Extract Discussion Number
+        if: github.event.pull_request.merged == true
+        id: extract-discussion
+        run: |
+          echo "::set-output name=discussion::$(echo "${{ github.event.pull_request.body }}" | grep -oP '(?<=Discussion: #)\d+')"
+        shell: bash
+
+      - name: Close the discussion
+        if: github.event.pull_request.merged == true && steps.extract-discussion.outputs.discussion
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DISCUSSION_ID: ${{ steps.extract-discussion.outputs.discussion }}
+        run: |
+          curl -X PATCH -H "Authorization: token $GITHUB_TOKEN" \
+               -d '{"state": "closed"}' \
+               "https://api.github.com/repos/${{ github.repository }}/discussions/${DISCUSSION_ID}"


### PR DESCRIPTION
# Pull Request

## Title
Discussions close on PR merge

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Make it so discussions auto close on PR merge.

## Testing
Can't test till merged.

## Impact
Helps clear up discussions like how we can currently clear up issues.

## Issue related to PR
[What issue is related to this PR (if any)]
- Resolves no issues

## Additional Information
No

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts. 
