### PR TITLE
Change the titles for each section from Bold Text to Header 2 in Bug Report Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,21 +6,21 @@ labels: ''
 assignees: ''
 ---
 
-### Describe the bug
+## Describe the bug
 A clear and concise description of what the bug is.
 
-### To Reproduce
+## To Reproduce
 Steps to reproduce the behavior:
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
-### Expected behavior
+## Expected behavior
 A clear and concise description of what you expected to happen.
 
-### Screenshots
+## Screenshots
 If applicable, add screenshots to help explain your problem.
 
-### Additional context
+## Additional context
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,24 +4,23 @@ about: Create a report to help us improve
 title: ''
 labels: ''
 assignees: ''
-
 ---
 
-**Describe the bug**
+### Describe the bug
 A clear and concise description of what the bug is.
 
-**To Reproduce**
+### To Reproduce
 Steps to reproduce the behavior:
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
-**Expected behavior**
+### Expected behavior
 A clear and concise description of what you expected to happen.
 
-**Screenshots**
+### Screenshots
 If applicable, add screenshots to help explain your problem.
 
-**Additional context**
+### Additional context
 Add any other context about the problem here.


### PR DESCRIPTION
## Type of Change
- [x] Refactoring

## Description
The change from Bold Text to a Header will make the Titles of each section pop more visually, which will _hoepfully_ make Bug Report Issues easier to review.

## Testing
Tested these changes by committing to my main branch and see if it works as expected.

## Impact
This won't impact the WinUtil Program directly, but will improve the Reporting of bugs a bit (indirect impact).

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts. 
