### PR TITLE
Make the 'Youtube Tutorial' Header be the link instead of the Youtube Thumbnail for it, Making the 'README.md' even shorter

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,7 @@ If you have Issues, refer to [Known Issues](https://christitustech.github.io/win
 
 ### [WinUtil Official Documentation](https://christitustech.github.io/winutil/)
 
-### YouTube Tutorial
-
-[![Watch the video](https://img.youtube.com/vi/6UQZ5oQg8XA/hqdefault.jpg)](https://www.youtube.com/watch?v=6UQZ5oQg8XA)
+### [YouTube Tutorial](https://www.youtube.com/watch?v=6UQZ5oQg8XA)
 
 ### [ChrisTitus.com Article](https://christitus.com/windows-tool/)
 


### PR DESCRIPTION
As described in the title, it'll make the `README.md` file shorter when rendered on GitHub.

Plus it'll follow the surrounding headers in its "linking-style".