### PR TITLE
Fix WinUtil Crashing on Startup - Xaml Error from Generated Applications List

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -2911,7 +2911,7 @@
 		"link": "https://github.com/BartoszCichecki/LenovoLegionToolkit",
 		"winget": "BartoszCichecki.LenovoLegionToolkit"
   },
-	"Pulsar-Edit": {
+	"PulsarEdit": {
 		"category": "Development",
 		"choco": "pulsar",
 		"content": "Pulsar",


### PR DESCRIPTION
## Description
This will fix WinUtil refusing to startup issue, giving an Xaml Syntax error.

At first I thought it's from your new Easter Egg.. _cogh_.. but after literally staring at the screen for 10 minute 😆 (just looking for syntax errors in your changes).. I was stuck to no avail ...

but at last, _and by using a similar technique I've used before in PR #1850_ (going through commit history, one commit at a time).. I've found the root cause of this issue (in PR #2316), which's the App Name Entry having a dash/minus symbol.. I'm just astounded on how it came to be, and how it passed the testing pipeline, but it was simple fix nonetheless.

## Issue related to PR
- Resolves #2360

## Additional Information
We should try avoiding this issue by updating the docs to tell people _**not to**_ add specific symbols in Field Names, and make the testing pipeline handle such situations without ignoring them.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no errors/warnings/merge conflicts. 
