### PR TITLE
[Wiki] Automatically enabling Dark/Light mode set by user's browser Preference 

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,13 +26,15 @@ theme:
   logo: assets/favicon.png
   favicon: assets/favicon.png
   palette:
-    - scheme: default
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
       toggle:
         icon: material/toggle-switch-off-outline 
         name: Switch to dark mode
       primary: black
       accent: purple 
-    - scheme: slate 
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate 
       toggle:
         icon: material/toggle-switch
         name: Switch to light mode    


### PR DESCRIPTION

# Pull Request

## This allows the website to automatically switch to the Dark/Light Theme set by the browser 

## Type of Change
-  New feature

## Testing
- This is a Mkdocs material feature, so it's well tested, although on my system it wouldn't work particularly on Brave maybe something to do with brave shields idk :) 
