### PR TITLE
Fix: Remove "pre" vom versioning of pre-releases

### DIFF
--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -22,7 +22,7 @@ jobs:
           $version = ''
           Get-Content ./winutil.ps1 -TotalCount 30 | ForEach-Object {
             if ($_ -match 'Version\s*:\s*(\d{2}\.\d{2}\.\d{2})') {
-              $version = "pre"+$matches[1]
+              $version = $matches[1]
               echo "version=$version" >> $GITHUB_ENV
               echo "::set-output name=version::$version"
               break


### PR DESCRIPTION
# Pull Request

## Remove "pre" from github release versioning 


## Type of Change
- [x] Bug fix

## Description
Since Pre-Releases will be renamed to the full release if it gets approved by chris, the versioning with the pre does not work with the versioning link in the about section. It does not really help anything and causes more harm the way releases work rn. This also fixes the versioning link in pre-releases in general. For those reasons I suggest just removing it. 

![Screenshot 2024-07-16 145108](https://github.com/user-attachments/assets/8e9151aa-0e68-4521-85c6-2c358c3e3f85)

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts. 
