### PR TITLE
Add /close command for the active contributors to close issues

### DIFF
--- a/.github/workflows/issue-slash-commands.yaml
+++ b/.github/workflows/issue-slash-commands.yaml
@@ -40,4 +40,4 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
           echo Closing the issue...
-          gh issue close $ISSUE_NUMBER --repo ${{ github.repositor
+          gh issue close $ISSUE_NUMBER --repo ${{ github.repository }}

--- a/.github/workflows/issue-slash-commands.yaml
+++ b/.github/workflows/issue-slash-commands.yaml
@@ -26,7 +26,7 @@ jobs:
         id: check_user
         if: env.comment == 'true'
         run: |
-          ALLOWED_USERS=("ChrisTitusTech" "og-mrg" "Marterich" "MyDrift-user" "Real-MullaC")
+          ALLOWED_USERS=("ChrisTitusTech" "og-mrk" "Marterich" "MyDrift-user" "Real-MullaC")
           if [[ " ${ALLOWED_USERS[@]} " =~ " ${{ github.event.comment.user.login }} " ]]; then
             echo "user=true" >> $GITHUB_ENV
           else

--- a/.github/workflows/issue-slash-commands.yaml
+++ b/.github/workflows/issue-slash-commands.yaml
@@ -1,0 +1,43 @@
+name: Close issue on /close
+
+on:
+  issue_comment:
+    types: [created, edited]
+
+jobs:
+  closeIssueOnClose:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: none
+      contents: read
+
+    steps:
+      - name: Check for /close comment
+        id: check_comment
+        run: |
+          if [[ "${{ contains(github.event.comment.body, '/close') }}" == "true" ]]; then
+            echo "comment=true" >> $GITHUB_ENV
+          else
+            echo "comment=false" >> $GITHUB_ENV
+          fi
+
+      - name: Check if the user is allowed
+        id: check_user
+        if: env.comment == 'true'
+        run: |
+          ALLOWED_USERS=("ChrisTitusTech" "og-mrg" "Marterich" "MyDrift-user" "Real-MullaC")
+          if [[ " ${ALLOWED_USERS[@]} " =~ " ${{ github.event.comment.user.login }} " ]]; then
+            echo "user=true" >> $GITHUB_ENV
+          else
+            echo "user=false" >> $GITHUB_ENV
+          fi
+
+      - name: Close issue if conditions are met
+        if: env.comment == 'true' && env.user == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          echo Closing the issue...
+          gh issue close $ISSUE_NUMBER --repo ${{ github.repositor


### PR DESCRIPTION
## Type of Change
- [x] New feature

## Description
Add a GitHub Action that checks if any defined Contributors wrote "/close" in the comment body. If yes, close the Issue. 
This enables the specified Users to moderate the issue section and close inactive/old and already-answered Issues without having explicit maintainer permissions on the project 
