### PR TITLE
Update workflows to remove `::set-output`

### DIFF
--- a/.github/workflows/close-discussion.yml
+++ b/.github/workflows/close-discussion.yml
@@ -16,7 +16,7 @@ jobs:
         if: github.event.pull_request.merged == true
         id: extract-discussion
         run: |
-          echo "::set-output name=discussion::$(echo "${{ github.event.pull_request.body }}" | grep -oP '(?<=Resolves #)\d+')"
+          echo "discussion=$(echo '${{ github.event.pull_request.body }}' | grep -oP '(?<=Resolves #)\d+')" >> $GITHUB_OUTPUT
         shell: bash
 
       - name: Close the discussion

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -23,8 +23,7 @@ jobs:
           Get-Content ./winutil.ps1 -TotalCount 30 | ForEach-Object {
             if ($_ -match 'Version\s*:\s*(\d{2}\.\d{2}\.\d{2})') {
               $version = "pre"+$matches[1]
-              echo "version=$version" >> $GITHUB_ENV
-              echo "::set-output name=version::$version"
+              echo "version=$version" >> $GITHUB_OUTPUT
               break
             }
           }

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,8 +19,7 @@ jobs:
           Get-Content ./winutil.ps1 -TotalCount 30 | ForEach-Object {
             if ($_ -match 'Version\s*:\s*(\d{2}\.\d{2}\.\d{2})') {
               $version = $matches[1]
-              echo "version=$version" >> $GITHUB_ENV
-              echo "::set-output name=version::$version"
+              echo "version=$version" >> $GITHUB_OUTPUT
               break
             }
           }


### PR DESCRIPTION
# Pull Request

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [x] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
remove ::set-output usage https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
remove `$version` as a environment variable as it's not used

## Testing
[Detail the testing you have performed to ensure that these changes function as intended. Include information about any added tests.]

## Impact
removes warnings from GHA runs and removes not used variable from workflows

## Issue related to PR
[What issue/discussion is related to this PR (if any)]
- Resolves #

## Additional Information
[Any additional information that reviewers should be aware of.]

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
