### PR TITLE
Re-apply PR #2271 & Fix For Loop in 'Install-WinUtilProgramWinget' Private Function

### DIFF
--- a/functions/private/Install-WinUtilProgramWinget.ps1
+++ b/functions/private/Install-WinUtilProgramWinget.ps1
@@ -29,10 +29,10 @@ Function Install-WinUtilProgramWinget {
     Write-Host "==========================================="
     Write-Host "--    Configuring winget packages       ---"
     Write-Host "==========================================="
-    for ($i = 0; $i -le $ProgramsToInstall.Count; $i++) {
+    for ($i = 0; $i -lt $count; $i++) {
         $Program = $ProgramsToInstall[$i]
         $failedPackages = @()
-        Write-Progress -Activity "$manage Applications" -Status "$manage $($Program.winget) $($i + 1) of $count" -PercentComplete $(($i/$count) * 100)
+        Write-Progress -Activity "$manage Applications" -Status "$manage $($Program.winget) $($i + 1) of $count" -PercentComplete $((($i + 1)/$count) * 100)
         if($manage -eq "Installing") {
             # Install package via ID, if it fails try again with different scope and then with an unelevated prompt.
             # Since Install-WinGetPackage might not be directly available, we use winget install command as a workaround.


### PR DESCRIPTION
## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [x] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
PR #2271 had a major flaw of installing some un-wanted apps from MS Store (as described in issue #2385), It was temporarily solved by reverting its changes in commit c90363181cf974c4342d5c3e01a58766d04cacf6.

This PR tries to solve the underlying logical error that PR #2271 had, which was trying to access out-of-bound memory (a common off-by-one error), where PowerShell would return `$null` (meaning the item this function has requested from `$ProgramsToInstall` Object Array is **an empty item**), which will make the Program ID (the input) an invalid value, causing un-expected behaviors from WinGet (The Package Manager), like installing the newest released app from MS Store.

## Testing
After further testing (tried it with all sort of combinations, one app, multiple applications, some are installed already, some had to upgrade, etc...), the updated code is working as expected.

## Impact
At the end.. it won't be noticeable by the end user, as the only thing this PR (and #2271 PR) tried to solve is the terminal progress bar (it was broken in original `ForEach` loop, off by one in #2271 PR, and in this PR it's working as expected).

So generally speaking.. User won't really notice this issue (The progress bar being off or broken), but it would be nice to fix this if possible.

## Issue related to PR
- Resolves #2385 

## Additional Information
If you've the time to spare, please consider testing these changes, thanks in advance 😄

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
