### PR TITLE
Change shortcut command link to github release

### DIFF
--- a/functions/public/Invoke-WPFShortcut.ps1
+++ b/functions/public/Invoke-WPFShortcut.ps1
@@ -29,7 +29,7 @@ function Invoke-WPFShortcut {
                 $shell = "powershell.exe"
             }
 
-            $shellArgs = "-ExecutionPolicy Bypass -Command `"Start-Process $shell -verb runas -ArgumentList `'-Command `"irm https://christitus.com/win | iex`"`'"
+            $shellArgs = "-ExecutionPolicy Bypass -Command `"Start-Process $shell -verb runas -ArgumentList `'-Command `"irm https://github.com/ChrisTitusTech/winutil/releases/latest/download/winutil.ps1 | iex`"`'"
 
             $DestinationName = "WinUtil.lnk"
 


### PR DESCRIPTION
# Pull Request

## Change Shortcut command URL

## Type of Change
- [x] Bug fix

## Description
Since noone looks at the command in the shortcut itself it would be the best Idea to make the command in there as compatible as possible. Since the one linked [here](https://christitustech.github.io/winutil/KnownIssues/#:~:text=If%20you%20are%20having%20TLS%201.2%20issues%2C%20or%20are%20having%20trouble%20resolving%20christitus.com/win%20then%20run%20with%20the%20following%20command%3A) is to long I've settled to changing the ctt url to the github url.

## Testing
Worked

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
