### PR TITLE
Fix 'Close Discussion on PR Merge' Workflow

### DIFF
--- a/.github/workflows/close-discussion.yml
+++ b/.github/workflows/close-discussion.yml
@@ -16,15 +16,24 @@ jobs:
         if: github.event.pull_request.merged == true
         id: extract-discussion
         run: |
-          echo "discussion=$(echo '${{ github.event.pull_request.body }}' | grep -oP '(?<=Resolves #)\d+')" >> $GITHUB_OUTPUT
+          echo '${{ github.event.pull_request.body }}' > pr_body.txt
+
+          discussion_ids_arr=()
+          cat pr_body.txt | grep -i -Po '^\s*(Resolve(s|d)?)\s*#\d+\s*$|^\s*(Fix(es|ed)?)\s*#\d+\s*$|^\s*(Close(s|d)?)\s*#\d+\s*$' | awk -F '#' '{print $2}' > discussion_ids_list.txt
+          while read -r line; do
+            discussion_ids_arr+=("$line")
+          done < discussion_ids_list.txt
+          echo "discussion_ids=(${discussion_ids_arr[@]})" >> $GITHUB_OUTPUT
         shell: bash
 
       - name: Close the discussion
-        if: github.event.pull_request.merged == true && steps.extract-discussion.outputs.discussion
+        if: github.event.pull_request.merged == true && steps.extract-discussion.outputs.discussion_ids
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DISCUSSION_ID: ${{ steps.extract-discussion.outputs.discussion }}
+          DISCUSSION_IDS: ${{ steps.extract-discussion.outputs.discussion_ids }}
         run: |
-          curl -X PATCH -H "Authorization: token $GITHUB_TOKEN" \
-               -d '{"state": "closed"}' \
-               "https://api.github.com/repos/${{ github.repository }}/discussions/${DISCUSSION_ID}"
+          echo $DISCUSSION_IDS
+          #curl -X PATCH -H "Authorization: token $GITHUB_TOKEN" \
+          #     -d '{"state": "closed"}' \
+          #     "https://api.github.com/repos/${{ github.repository }}/discussions/${DISCUSSION_ID}"
+        shell: bash

--- a/.github/workflows/close-discussion.yml
+++ b/.github/workflows/close-discussion.yml
@@ -19,7 +19,7 @@ jobs:
           echo '${{ github.event.pull_request.body }}' > pr_body.txt
 
           discussion_ids_arr=()
-          cat pr_body.txt | grep -i -Po '^\s*(Resolve(s|d)?)\s*#\d+\s*$|^\s*(Fix(es|ed)?)\s*#\d+\s*$|^\s*(Close(s|d)?)\s*#\d+\s*$' | awk -F '#' '{print $2}' > discussion_ids_list.txt
+          cat pr_body.txt | grep -i -Po '^\s*-?\s*(Resolve(s|d)?)\s*#\d+\s*$|^\s*-?\s*(Fix(es|ed)?)\s*#\d+\s*$|^\s*-?\s*(Close(s|d)?)\s*#\d+\s*$' | awk -F '#' '{print $2}' > discussion_ids_list.txt
           while read -r line; do
             discussion_ids_arr+=("$line")
           done < discussion_ids_list.txt

--- a/.github/workflows/close-discussion.yml
+++ b/.github/workflows/close-discussion.yml
@@ -32,8 +32,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DISCUSSION_IDS: ${{ steps.extract-discussion.outputs.discussion_ids }}
         run: |
-          echo $DISCUSSION_IDS
-          #curl -X PATCH -H "Authorization: token $GITHUB_TOKEN" \
-          #     -d '{"state": "closed"}' \
-          #     "https://api.github.com/repos/${{ github.repository }}/discussions/${DISCUSSION_ID}"
+          number_of_ids=${#DISCUSSION_IDS[@]}
+          for (( i=0; i<${number_of_ids}; i++ ));
+          do
+            discussion_id=${DISCUSSION_IDS[$i]}
+            echo "$discussion_id"
+            curl -X PATCH -H "Authorization: token $GITHUB_TOKEN" \
+                 -d '{"state": "closed"}' \
+                 "https://api.github.com/repos/${{ github.repository }}/discussions/$discussion_id"
+          done
         shell: bash

--- a/.github/workflows/close-discussion.yml
+++ b/.github/workflows/close-discussion.yml
@@ -21,7 +21,7 @@ jobs:
           echo '${{ github.event.pull_request.body }}' > pr_body.txt
 
           discussion_ids_arr=()
-          cat pr_body.txt | grep -i -Po '^\s*-?\s*(Resolve(s|d)?)\s*#\d+\s*$|^\s*-?\s*(Fix(es|ed)?)\s*#\d+\s*$|^\s*-?\s*(Close(s|d)?)\s*#\d+\s*$' | awk -F '#' '{print $2}' > discussion_ids_list.txt
+          cat pr_body.txt | grep -i -Po '^\s*(-|\d+\.)?\s*(Resolve(s|d)?)\s*#\d+\s*$|^\s*(-|\d+\.)?\s*(Fix(es|ed)?)\s*#\d+\s*$|^\s*(-|\d+\.)?\s*(Close(s|d)?)\s*#\d+\s*$' | awk -F '#' '{print $2}' > discussion_ids_list.txt
           while read -r line; do
             discussion_ids_arr+=("$line")
           done < discussion_ids_list.txt

--- a/.github/workflows/close-discussion.yml
+++ b/.github/workflows/close-discussion.yml
@@ -12,7 +12,7 @@ jobs:
         if: github.event.pull_request.merged == true
         run: echo "PR was merged"
 
-      - name: Extract Discussion Number
+      - name: Extract Discussion Number & Close If any Where Found
         if: github.event.pull_request.merged == true
         id: extract-discussion
         run: |
@@ -23,19 +23,11 @@ jobs:
           while read -r line; do
             discussion_ids_arr+=("$line")
           done < discussion_ids_list.txt
-          echo "discussion_ids=(${discussion_ids_arr[@]})" >> $GITHUB_OUTPUT
-        shell: bash
 
-      - name: Close the discussion
-        if: github.event.pull_request.merged == true && steps.extract-discussion.outputs.discussion_ids
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DISCUSSION_IDS: ${{ steps.extract-discussion.outputs.discussion_ids }}
-        run: |
-          number_of_ids=${#DISCUSSION_IDS[@]}
+          number_of_ids=${#discussion_ids_arr[@]}
           for (( i=0; i<${number_of_ids}; i++ ));
           do
-            discussion_id=${DISCUSSION_IDS[$i]}
+            discussion_id=${discussion_ids_arr[$i]}
             echo "$discussion_id"
             curl -X PATCH -H "Authorization: token $GITHUB_TOKEN" \
                  -d '{"state": "closed"}' \

--- a/.github/workflows/close-discussion.yml
+++ b/.github/workflows/close-discussion.yml
@@ -13,6 +13,8 @@ jobs:
         run: echo "PR was merged"
 
       - name: Extract Discussion Number & Close If any Where Found
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: github.event.pull_request.merged == true
         id: extract-discussion
         run: |
@@ -31,6 +33,6 @@ jobs:
             echo "$discussion_id"
             curl -X PATCH -H "Authorization: token $GITHUB_TOKEN" \
                  -d '{"state": "closed"}' \
-                 "https://api.github.com/repos/${{ github.repository }}/discussions/$discussion_id"
+                 'https://api.github.com/repos/${{ github.repository }}/discussions/$discussion_id'
           done
         shell: bash


### PR DESCRIPTION
## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Testing
After trial & error, it now works as expected.

## Additional Information
Supports all of [GitHub's Official Linking Keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), which're:
- Fix[es|ed]
- Close[s|d]
- Resolve[s|d]

This's done through Regex, look at the bash script in the workflow for more details...

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
