### PR TITLE
Skip 'Close Issue on /close' Workflow if the comment was posted on a PR

### DIFF
--- a/.github/workflows/issue-slash-commands.yaml
+++ b/.github/workflows/issue-slash-commands.yaml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   closeIssueOnClose:
+    # Skip this job if the comment was created/edited on a PR
+    if: ${{ !github.event.issue.pull_request }}
     runs-on: ubuntu-latest
     permissions:
       issues: write


### PR DESCRIPTION
## Type of Change
- [x] CI

## Description
Simple Optimization for the 'Close Issue on /close' Workflow ( made by @Marterich in PR #2380 ).

## Testing
On my WinUtil Fork, there's a PR ([link to it](https://github.com/og-mrk/winutil/pull/14)) that didn't get closed by GitHub Actions after commenting on it ([link to the GitHub Actions run](https://github.com/og-mrk/winutil/actions/runs/10029358621)).

Also on my WinUtil Fork, you'll find an Issue Ticket ([link to it](https://github.com/og-mrk/winutil/issues/15)) that was closed after commenting on it with `/close` ([link to the GitHub Actions run](https://github.com/og-mrk/winutil/actions/runs/10029362195)).

## Impact
This won't impact WinUtil Users, nor will it impact Contributors to this Project. But it'll optimize the Workflow a bit (shaving a few runtime minutes each month, depending on how the activity of WinUtil Repo).

## Additional Information
What I've referenced for this PR changes:
- [issue_comment on issues only or pull requests only - GitHub Docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#issue_comment-on-issues-only-or-pull-requests-only)

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
