### PR TITLE
Windows 7 BSoD Tweak

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -3131,6 +3131,14 @@
     "Order": "a204_",
     "Type": "Toggle"
   },
+  "WPFToggleDetailedBSoD": {
+    "Content": "Detailed BSoD",
+    "Description": "If Enabled then you will see a detailed Blue Screen of Death (BSOD) with more information.",
+    "category": "Customize Preferences",
+    "panel": "2",
+    "Order": "a205_",
+    "Type": "Toggle"
+  },
   "WPFOOSUbutton": {
     "Content": "Run OO Shutup 10",
     "category": "z__Advanced Tweaks - CAUTION",

--- a/functions/private/Get-WinUtilToggleStatus.ps1
+++ b/functions/private/Get-WinUtilToggleStatus.ps1
@@ -154,4 +154,13 @@ Function Get-WinUtilToggleStatus {
             return $true
         }
     }
+    if ($ToggleSwitch -eq "WPFToggleDetailedBSoD") {
+        $DetailedBSoD = (Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\CrashControl').DisplayParameters
+        if($DetailedBSoD -eq 0) {
+            return $false
+        }
+        else{
+            return $true
+        }
+    }
 }

--- a/functions/private/Invoke-WinUtilDetailedBSoD.ps1
+++ b/functions/private/Invoke-WinUtilDetailedBSoD.ps1
@@ -1,0 +1,34 @@
+Function Invoke-WinUtilDetailedBSoD {
+    <#
+
+    .SYNOPSIS
+        Enables/Disables Detailed BSoD
+        (Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\CrashControl' -Name 'DisplayParameters').DisplayParameters
+        
+
+    #>
+    Param($Enabled)
+    Try{
+        if ($Enabled -eq $false){
+            Write-Host "Enabling Detailed BSoD"
+            $value = 1
+        }
+        else {
+            Write-Host "Disabling Detailed BSoD"
+            $value =0
+        }
+
+        $Path = "HKLM:\SYSTEM\CurrentControlSet\Control\CrashControl"
+        Set-ItemProperty -Path $Path -Name DisplayParameters -Value $value
+    }
+    Catch [System.Security.SecurityException] {
+        Write-Warning "Unable to set $Path\$Name to $Value due to a Security Exception"
+    }
+    Catch [System.Management.Automation.ItemNotFoundException] {
+        Write-Warning $psitem.Exception.ErrorRecord
+    }
+    Catch{
+        Write-Warning "Unable to set $Name due to unhandled exception"
+        Write-Warning $psitem.Exception.StackTrace
+    }
+}

--- a/functions/public/Invoke-WPFToggle.ps1
+++ b/functions/public/Invoke-WPFToggle.ps1
@@ -32,5 +32,6 @@ function Invoke-WPFToggle {
         "WPFToggleTaskView" {Invoke-WinUtilTaskView $(Get-WinUtilToggleStatus WPFToggleTaskView)}
         "WPFToggleHiddenFiles" {Invoke-WinUtilHiddenFiles $(Get-WinUtilToggleStatus WPFToggleHiddenFiles)}
         "WPFToggleTaskbarAlignment" {Invoke-WinUtilTaskbarAlignment $(Get-WinUtilToggleStatus WPFToggleTaskbarAlignment)}
+        "WPFToggleDetailedBSoD" {Invoke-WinUtilDetailedBSoD $(Get-WinUtilToggleStatus WPFToggleDetailedBSoD)}
     }
 }


### PR DESCRIPTION
# Pull Request

##Detailed BSoD

## Type of Change
- [x] New feature

## Description
BSoD does not really give u much information, but with this tweak it will tell you what actually is wrong by using the BSoD that was used in Windows 7.

## Testing
Testet it using the recommended method of crashing the system, using a reg key ateration + shortcut.
like [here](https://www.fortect.com/bsod/trigger-bsod-intentionally/)

## Impact
Not much, a once in a lifetime change, understand if this does not get accepted

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
