### PR TITLE
Disable Background Apps

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -2973,22 +2973,6 @@
       "netsh interface teredo set state default"
     ]
   },
-  "WPFTweaksDisableBGapps": {
-    "Content": "Disable Background Apps",
-    "Description": "Disables all Microsoft Store apps from running in the background, which has to be done individually since Win11",
-    "category": "Essential Tweaks",
-    "panel": "1",
-    "Order": "a015_",
-    "registry": [
-      {
-        "Path": "HKCU:\\Software\\Microsoft\\Windows\\CurrentVersion\\BackgroundAccessApplications",
-        "Name": "GlobalUserDisabled",
-        "Value": "1",
-        "OriginalValue": "0",
-        "Type": "DWord"
-      }
-    ]
-  },
   "WPFTweaksDisableipsix": {
     "Content": "Disable IPv6",
     "Description": "Disables IPv6.",
@@ -3009,6 +2993,22 @@
     ],
     "UndoScript": [
       "Enable-NetAdapterBinding -Name \"*\" -ComponentID ms_tcpip6"
+    ]
+  },
+  "WPFTweaksDisableBGapps": {
+    "Content": "Disable Background Apps",
+    "Description": "Disables all Microsoft Store apps from running in the background, which has to be done individually since Win11",
+    "category": "z__Advanced Tweaks - CAUTION",
+    "panel": "1",
+    "Order": "a024_",
+    "registry": [
+      {
+        "Path": "HKCU:\\Software\\Microsoft\\Windows\\CurrentVersion\\BackgroundAccessApplications",
+        "Name": "GlobalUserDisabled",
+        "Value": "1",
+        "OriginalValue": "0",
+        "Type": "DWord"
+      }
     ]
   },
   "WPFTweaksDisableFSO": {

--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -2973,6 +2973,22 @@
       "netsh interface teredo set state default"
     ]
   },
+  "WPFTweaksDisableBGapps": {
+    "Content": "Disable Background Apps",
+    "Description": "Disables all Microsoft Store apps from running in the background, which has to be done individually since Win11",
+    "category": "Essential Tweaks",
+    "panel": "1",
+    "Order": "a015_",
+    "registry": [
+      {
+        "Path": "HKCU:\\Software\\Microsoft\\Windows\\CurrentVersion\\BackgroundAccessApplications",
+        "Name": "GlobalUserDisabled",
+        "Value": "1",
+        "OriginalValue": "0",
+        "Type": "DWord"
+      }
+    ]
+  },
   "WPFTweaksDisableipsix": {
     "Content": "Disable IPv6",
     "Description": "Disables IPv6.",


### PR DESCRIPTION
# Pull Request

## Disable Background Apps

## Type of Change
- [x] New feature

## Description
Windows lets microsoft store apps run in the background by default. Since Win11 u can't change that for all MS Store apps anymore throught the settings but still using the registry.

## Testing
Worked as expected on multiple win11 instances, should also work on win10

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
