### PR TITLE
Simple Fix for Taskbar - Change Progress Variable Name from 'x' to 'i' inside 'Install-WinUtilProgramWinget' Private Function

### DIFF
--- a/functions/private/Install-WinUtilProgramWinget.ps1
+++ b/functions/private/Install-WinUtilProgramWinget.ps1
@@ -29,10 +29,10 @@ Function Install-WinUtilProgramWinget {
     Write-Host "==========================================="
     Write-Host "--    Configuring winget packages       ---"
     Write-Host "==========================================="
-    for ($i = 0; $i -lt $count; $i++) {
-        $Program = $ProgramsToInstall[$i]
+    for ($i = 1; $i -le $count; $i++) {
+        $Program = $ProgramsToInstall[$i - 1]
         $failedPackages = @()
-        Write-Progress -Activity "$manage Applications" -Status "$manage $($Program.winget) $($i + 1) of $count" -PercentComplete $((($i + 1)/$count) * 100)
+        Write-Progress -Activity "$manage Applications" -Status "$manage $($Program.winget) $i of $count" -PercentComplete $(($i/$count) * 100)
         if($manage -eq "Installing") {
             # Install package via ID, if it fails try again with different scope and then with an unelevated prompt.
             # Since Install-WinGetPackage might not be directly available, we use winget install command as a workaround.
@@ -43,24 +43,24 @@ Function Install-WinUtilProgramWinget {
                 $status = $(Start-Process -FilePath "winget" -ArgumentList "install --id $($Program.winget) --silent --accept-source-agreements --accept-package-agreements" -Wait -PassThru -NoNewWindow).ExitCode
                 if($status -eq 0) {
                     Write-Host "$($Program.winget) installed successfully."
-                    $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -value (($i + 1)/$count) })
+                    $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -value ($i/$count) })
                     continue
                 }
                 if ($status -eq -1978335189) {
                     Write-Host "$($Program.winget) No applicable update found"
-                    $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -value (($i + 1)/$count) })
+                    $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -value ($i/$count) })
                     continue
                 }
                 Write-Host "Attempt with User scope"
                 $status = $(Start-Process -FilePath "winget" -ArgumentList "install --id $($Program.winget) --scope user --silent --accept-source-agreements --accept-package-agreements" -Wait -PassThru -NoNewWindow).ExitCode
                 if($status -eq 0) {
                     Write-Host "$($Program.winget) installed successfully with User scope."
-                    $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -value (($i + 1)/$count) })
+                    $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -value ($i/$count) })
                     continue
                 }
                 if ($status -eq -1978335189) {
                     Write-Host "$($Program.winget) No applicable update found"
-                    $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -value (($i + 1)/$count) })
+                    $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -value ($i/$count) })
                     continue
                 }
                 Write-Host "Attempt with User prompt"
@@ -75,18 +75,18 @@ Function Install-WinUtilProgramWinget {
                 }
                 if($status -eq 0) {
                     Write-Host "$($Program.winget) installed successfully with User prompt."
-                    $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -value (($i + 1)/$count) })
+                    $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -value ($i/$count) })
                     continue
                 }
                 if ($status -eq -1978335189) {
                     Write-Host "$($Program.winget) No applicable update found"
-                    $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -value (($i + 1)/$count) })
+                    $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -value ($i/$count) })
                     continue
                 }
             } catch {
                 Write-Host "Failed to install $($Program.winget). With winget"
                 $failedPackages += $Program
-                $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -state "Error" -value (($i + 1)/$count) })
+                $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -state "Error" -value ($i/$count) })
             }
         }
         elseif($manage -eq "Uninstalling") {
@@ -105,7 +105,7 @@ Function Install-WinUtilProgramWinget {
                 $failedPackages += $Program
                 $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -state "Error" })
             }
-            $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -value (($i + 1)/$count) })
+            $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -value ($i/$count) })
         }
         else {
             throw "[Install-WinUtilProgramWinget] Invalid Value for Parameter 'manage', Provided Value is: $manage"

--- a/functions/private/Install-WinUtilProgramWinget.ps1
+++ b/functions/private/Install-WinUtilProgramWinget.ps1
@@ -43,24 +43,24 @@ Function Install-WinUtilProgramWinget {
                 $status = $(Start-Process -FilePath "winget" -ArgumentList "install --id $($Program.winget) --silent --accept-source-agreements --accept-package-agreements" -Wait -PassThru -NoNewWindow).ExitCode
                 if($status -eq 0) {
                     Write-Host "$($Program.winget) installed successfully."
-                    $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -value ($i/$count) })
+                    $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -value (($i + 1)/$count) })
                     continue
                 }
                 if ($status -eq -1978335189) {
                     Write-Host "$($Program.winget) No applicable update found"
-                    $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -value ($i/$count) })
+                    $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -value (($i + 1)/$count) })
                     continue
                 }
                 Write-Host "Attempt with User scope"
                 $status = $(Start-Process -FilePath "winget" -ArgumentList "install --id $($Program.winget) --scope user --silent --accept-source-agreements --accept-package-agreements" -Wait -PassThru -NoNewWindow).ExitCode
                 if($status -eq 0) {
                     Write-Host "$($Program.winget) installed successfully with User scope."
-                    $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -value ($i/$count) })
+                    $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -value (($i + 1)/$count) })
                     continue
                 }
                 if ($status -eq -1978335189) {
                     Write-Host "$($Program.winget) No applicable update found"
-                    $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -value ($i/$count) })
+                    $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -value (($i + 1)/$count) })
                     continue
                 }
                 Write-Host "Attempt with User prompt"
@@ -75,18 +75,18 @@ Function Install-WinUtilProgramWinget {
                 }
                 if($status -eq 0) {
                     Write-Host "$($Program.winget) installed successfully with User prompt."
-                    $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -value ($i/$count) })
+                    $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -value (($i + 1)/$count) })
                     continue
                 }
                 if ($status -eq -1978335189) {
                     Write-Host "$($Program.winget) No applicable update found"
-                    $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -value ($i/$count) })
+                    $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -value (($i + 1)/$count) })
                     continue
                 }
             } catch {
                 Write-Host "Failed to install $($Program.winget). With winget"
                 $failedPackages += $Program
-                $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -state "Error" -value ($i/$count) })
+                $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -state "Error" -value (($i + 1)/$count) })
             }
         }
         elseif($manage -eq "Uninstalling") {
@@ -105,7 +105,7 @@ Function Install-WinUtilProgramWinget {
                 $failedPackages += $Program
                 $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -state "Error" })
             }
-            $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -value ($i/$count) })
+            $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -value (($i + 1)/$count) })
         }
         else {
             throw "[Install-WinUtilProgramWinget] Invalid Value for Parameter 'manage', Provided Value is: $manage"

--- a/functions/private/Install-WinUtilProgramWinget.ps1
+++ b/functions/private/Install-WinUtilProgramWinget.ps1
@@ -43,24 +43,24 @@ Function Install-WinUtilProgramWinget {
                 $status = $(Start-Process -FilePath "winget" -ArgumentList "install --id $($Program.winget) --silent --accept-source-agreements --accept-package-agreements" -Wait -PassThru -NoNewWindow).ExitCode
                 if($status -eq 0) {
                     Write-Host "$($Program.winget) installed successfully."
-                    $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -value ($x/$count) })
+                    $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -value ($i/$count) })
                     continue
                 }
                 if ($status -eq -1978335189) {
                     Write-Host "$($Program.winget) No applicable update found"
-                    $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -value ($x/$count) })
+                    $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -value ($i/$count) })
                     continue
                 }
                 Write-Host "Attempt with User scope"
                 $status = $(Start-Process -FilePath "winget" -ArgumentList "install --id $($Program.winget) --scope user --silent --accept-source-agreements --accept-package-agreements" -Wait -PassThru -NoNewWindow).ExitCode
                 if($status -eq 0) {
                     Write-Host "$($Program.winget) installed successfully with User scope."
-                    $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -value ($x/$count) })
+                    $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -value ($i/$count) })
                     continue
                 }
                 if ($status -eq -1978335189) {
                     Write-Host "$($Program.winget) No applicable update found"
-                    $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -value ($x/$count) })
+                    $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -value ($i/$count) })
                     continue
                 }
                 Write-Host "Attempt with User prompt"
@@ -75,18 +75,18 @@ Function Install-WinUtilProgramWinget {
                 }
                 if($status -eq 0) {
                     Write-Host "$($Program.winget) installed successfully with User prompt."
-                    $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -value ($x/$count) })
+                    $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -value ($i/$count) })
                     continue
                 }
                 if ($status -eq -1978335189) {
                     Write-Host "$($Program.winget) No applicable update found"
-                    $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -value ($x/$count) })
+                    $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -value ($i/$count) })
                     continue
                 }
             } catch {
                 Write-Host "Failed to install $($Program.winget). With winget"
                 $failedPackages += $Program
-                $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -state "Error" -value ($x/$count) })
+                $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -state "Error" -value ($i/$count) })
             }
         }
         elseif($manage -eq "Uninstalling") {
@@ -105,7 +105,7 @@ Function Install-WinUtilProgramWinget {
                 $failedPackages += $Program
                 $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -state "Error" })
             }
-            $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -value ($x/$count) })
+            $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -value ($i/$count) })
         }
         else {
             throw "[Install-WinUtilProgramWinget] Invalid Value for Parameter 'manage', Provided Value is: $manage"


### PR DESCRIPTION
## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [x] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Because of the recent Flood of PRs to WinUtil, some overlapping happened as some PRs were changing same files as other (not in Merge Conflicts, but in Code Logic), therefore PR #2309 had its variable naming out-of-sync _when_ PR #2396 _was merged_.

This PR fixes this to bring back what's @MyDrift-user originally intended of showing a Progress bar in Task Item for WinUtil.

## Testing
Tested it by selecting multiple items to install, and it works as expected.

## Impact
Brings back progress bar in task item when installing/uninstalling using WinGet Package Manager.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
