### PR TITLE
Remove extra toggle in 'palette' field - WinUtil Docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,17 +26,9 @@ theme:
   logo: assets/favicon.png
   favicon: assets/favicon.png
   palette:
-    # Palette toggle for automatic mode
-    - media: "(prefers-color-scheme)"
-      toggle:
-        icon: material/brightness-auto
-        name: Switch to light mode
-
     # Palette toggle for light mode
     - media: "(prefers-color-scheme: light)"
       scheme: default 
-
-
       toggle:
         icon: material/brightness-7
         name: Switch to dark mode
@@ -45,7 +37,7 @@ theme:
     - media: "(prefers-color-scheme: dark)"
       scheme: slate
       toggle:
-        icon: material/toggle-switch
+        icon: material/brightness-auto
         name: Switch to light mode
       primary: teal
       accent: lime

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,14 +30,14 @@ theme:
     - media: "(prefers-color-scheme: light)"
       scheme: default 
       toggle:
-        icon: material/brightness-7
+        icon: material/brightness-auto
         name: Switch to dark mode
 
     # Palette toggle for dark mode
     - media: "(prefers-color-scheme: dark)"
       scheme: slate
       toggle:
-        icon: material/brightness-auto
+        icon: material/brightness-7
         name: Switch to light mode
       primary: teal
       accent: lime

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,7 +30,7 @@ theme:
     - media: "(prefers-color-scheme: light)"
       scheme: default 
       toggle:
-        icon: material/brightness-auto
+        icon: material/brightness-4
         name: Switch to dark mode
 
     # Palette toggle for dark mode


### PR DESCRIPTION
## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [x] UI/UX improvement

## Description
Currently you need to press the toggle them button twice to switch to another theme (rather then once to switch), this PR fixes this by removing an extra theme toggle.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
