### PR TITLE
Fix winget ID of Advanced Renamer

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -205,7 +205,7 @@
 		"content": "Advanced Renamer",
 		"description": "Advanced Renamer is a program for renaming multiple files and folders at once. By configuring renaming methods the names can be manipulated in various ways.",
 		"link": "https://www.advancedrenamer.com/",
-		"winget": "XP9MD3S1KFCPH1"
+		"winget": "HulubuluSoftware.AdvancedRenamer"
 	},
 	"calibre": {
 		"category": "Document",

--- a/winutil.ps1
+++ b/winutil.ps1
@@ -8,7 +8,7 @@
     Author         : Chris Titus @christitustech
     Runspace Author: @DeveloperDurp
     GitHub         : https://github.com/ChrisTitusTech
-    Version        : 24.07.25
+    Version        : 24.07.26
 #>
 param (
     [switch]$Debug,
@@ -45,7 +45,7 @@ Add-Type -AssemblyName System.Windows.Forms
 # Variable to sync between runspaces
 $sync = [Hashtable]::Synchronized(@{})
 $sync.PSScriptRoot = $PSScriptRoot
-$sync.version = "24.07.25"
+$sync.version = "24.07.26"
 $sync.configs = @{}
 $sync.ProcessRunning = $false
 

--- a/winutil.ps1
+++ b/winutil.ps1
@@ -8,7 +8,7 @@
     Author         : Chris Titus @christitustech
     Runspace Author: @DeveloperDurp
     GitHub         : https://github.com/ChrisTitusTech
-    Version        : 24.07.26
+    Version        : 24.07.25
 #>
 param (
     [switch]$Debug,
@@ -45,7 +45,7 @@ Add-Type -AssemblyName System.Windows.Forms
 # Variable to sync between runspaces
 $sync = [Hashtable]::Synchronized(@{})
 $sync.PSScriptRoot = $PSScriptRoot
-$sync.version = "24.07.26"
+$sync.version = "24.07.25"
 $sync.configs = @{}
 $sync.ProcessRunning = $false
 


### PR DESCRIPTION
## Type of Change
- [x] Bug fix

## Description
Replace the Winget ID of Advanced Renamer. 
The old one works for the installation, but if you run winget list after advanced renamed is installed, this new ID is referenced. Therefore the app also wasn't shown under installed applications.
