### PR TITLE
Disable the Generate Sponsors Cronjob on Forks

### DIFF
--- a/.github/workflows/sponsors.yml
+++ b/.github/workflows/sponsors.yml
@@ -8,6 +8,7 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    if: (github.event_name == 'schedule' && github.repository == 'ChrisTitusTech/winutil') || (github.event_name != 'schedule')
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v4

--- a/winutil.ps1
+++ b/winutil.ps1
@@ -8,7 +8,7 @@
     Author         : Chris Titus @christitustech
     Runspace Author: @DeveloperDurp
     GitHub         : https://github.com/ChrisTitusTech
-    Version        : 24.07.25
+    Version        : 24.07.26
 #>
 param (
     [switch]$Debug,
@@ -45,7 +45,7 @@ Add-Type -AssemblyName System.Windows.Forms
 # Variable to sync between runspaces
 $sync = [Hashtable]::Synchronized(@{})
 $sync.PSScriptRoot = $PSScriptRoot
-$sync.version = "24.07.25"
+$sync.version = "24.07.26"
 $sync.configs = @{}
 $sync.ProcessRunning = $false
 

--- a/winutil.ps1
+++ b/winutil.ps1
@@ -8,7 +8,7 @@
     Author         : Chris Titus @christitustech
     Runspace Author: @DeveloperDurp
     GitHub         : https://github.com/ChrisTitusTech
-    Version        : 24.07.26
+    Version        : 24.07.25
 #>
 param (
     [switch]$Debug,
@@ -45,7 +45,7 @@ Add-Type -AssemblyName System.Windows.Forms
 # Variable to sync between runspaces
 $sync = [Hashtable]::Synchronized(@{})
 $sync.PSScriptRoot = $PSScriptRoot
-$sync.version = "24.07.26"
+$sync.version = "24.07.25"
 $sync.configs = @{}
 $sync.ProcessRunning = $false
 


### PR DESCRIPTION
## Type of Change
- [x] Bug fix

## Description
Disables the Generate Sponsors Cronjob on Forks
At the moment, the workflow tries to run periodically on all up-to-date forks but fails because ${{ secrets.PAT }} is not configured. Depending on the Configuration of the User this results in failure E-Mails being sent to the user periodically. 

This change was directly taken from the PR #2402 by @wojsmol

## Impact
No more Email and Notification Spam for Contributors
 
## Issue related to PR

- Resolves #2468

## Additional Information
The original PR also disabled the Compile and Close Issue Action. I don't see why this would be necessary because these actions run without a problem. Therefore I omitted them from this PR