### PR TITLE
Edge removal improvements

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -2561,15 +2561,10 @@
     "panel": "1",
     "Order": "a029_",
     "InvokeScript": [
-      "
-      Uninstall-WinUtilEdgeBrowser
-      "
+      "Uninstall-WinUtilEdgeBrowser -action \"Uninstall\""
     ],
     "UndoScript": [
-      "
-      Write-Host \"Install Microsoft Edge\"
-      Start-Process -FilePath winget -ArgumentList \"install --force -e --accept-source-agreements --accept-package-agreements --silent Microsoft.Edge \" -NoNewWindow -Wait
-      "
+      "Uninstall-WinUtilEdgeBrowser -action \"Install\""
     ],
     "link": "https://christitustech.github.io/winutil/dev/tweaks/z--Advanced-Tweaks---CAUTION/RemoveEdge"
   },

--- a/functions/private/Uninstall-WinUtilEdgeBrowser.ps1
+++ b/functions/private/Uninstall-WinUtilEdgeBrowser.ps1
@@ -118,7 +118,7 @@ Function Uninstall-WinUtilEdgeBrowser {
         $tempEdgePath = "$env:TEMP\MicrosoftEdgeSetup.exe"
 
         try {
-            write-host "Installing Edge"
+            write-host "Installing Edge ..."
             Invoke-WebRequest -Uri "https://go.microsoft.com/fwlink/?linkid=2109047&Channel=Stable&language=en&consent=1" -OutFile $tempEdgePath
             Start-Process -FilePath $tempEdgePath -ArgumentList "/silent /install" -Wait
             Remove-item $tempEdgePath

--- a/functions/private/Uninstall-WinUtilEdgeBrowser.ps1
+++ b/functions/private/Uninstall-WinUtilEdgeBrowser.ps1
@@ -119,7 +119,7 @@ Function Uninstall-WinUtilEdgeBrowser {
 
         write-host "Installing Edge"
         Invoke-WebRequest -Uri "https://go.microsoft.com/fwlink/?linkid=2109047&Channel=Stable&language=en&consent=1" -OutFile $tempEdgePath
-        Start-Process -FilePath $tempEdgePath
+        Start-Process -FilePath $tempEdgePath -ArgumentList "/silent /install" -Wait
         Remove-item $tempEdgePath
     }
 

--- a/functions/private/Uninstall-WinUtilEdgeBrowser.ps1
+++ b/functions/private/Uninstall-WinUtilEdgeBrowser.ps1
@@ -117,10 +117,15 @@ Function Uninstall-WinUtilEdgeBrowser {
     function Install-Edge {
         $tempEdgePath = "$env:TEMP\MicrosoftEdgeSetup.exe"
 
-        write-host "Installing Edge"
-        Invoke-WebRequest -Uri "https://go.microsoft.com/fwlink/?linkid=2109047&Channel=Stable&language=en&consent=1" -OutFile $tempEdgePath
-        Start-Process -FilePath $tempEdgePath -ArgumentList "/silent /install" -Wait
-        Remove-item $tempEdgePath
+        try {
+            write-host "Installing Edge"
+            Invoke-WebRequest -Uri "https://go.microsoft.com/fwlink/?linkid=2109047&Channel=Stable&language=en&consent=1" -OutFile $tempEdgePath
+            Start-Process -FilePath $tempEdgePath -ArgumentList "/silent /install" -Wait
+            Remove-item $tempEdgePath
+            write-host "Edge Installed Successfully"
+        } catch {
+            write-host "Failed to install Edge"
+        }
     }
 
     if ($action -eq "Install") {


### PR DESCRIPTION
# Pull Request

## Edge removal improvements

## Type of Change
- [x] Refactoring
- [x] Hotfix

## Description
- added working logic to reinstall MS Edge
- added logic to remove more reg keys on removal
  - with those two reg removals edge does not give the big annoying welcome back screen but a "better" (still annoying) popup. It also offers a more clean uninstallation.
- fixed "open with" context menu having broken edge option bc MS Edge can't make a working uninstaller.
![Screenshot 2024-08-08 111912](https://github.com/user-attachments/assets/d9055081-f024-4984-91e6-4000d769bebc)

## Testing
changes were tested on vm, run & undo work without sys/ep restart needed

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
