### PR TITLE
Request the Ultimate Power Plan in the Tweaks tab.

### DIFF
--- a/utilmatepowerplan-fix.ps1
+++ b/utilmatepowerplan-fix.ps1
@@ -1,0 +1,60 @@
+# PowerShell script to fix the power plan applied across all languages based on the GUID of the new power plan.
+# This is necessary because when Windows is in a different language, the power plan might not be applied correctly.
+# This script changes the name and description of the power plan.
+#Video : https://youtu.be/00aUECZNvbA
+
+# ID of the plan to duplicate
+$sourceGUID = "e9a42b02-d5df-448d-aa00-03f14749eb61"
+$guid = $null
+$nameFromFile = "ChrisTitus - Ultimate Power Plan"
+$description = "Ultimate Power Plan , added via WinUtils"
+
+$scriptPath = $MyInvocation.MyCommand.Path
+$directoryPath = Split-Path -Path $scriptPath -Parent
+
+$guidFilePath = Join-Path -Path $directoryPath -ChildPath "guid.txt"
+
+$duplicateOutput = powercfg /duplicatescheme $sourceGUID
+
+try {
+    $duplicateOutput | Out-File -FilePath $guidFilePath -Append -Encoding utf8 -Force
+
+    Write-Output "The output of 'powercfg /duplicatescheme' has been added to $guidFilePath."
+} catch {
+    Write-Error "Error writing to the file: $_"
+}
+$content = Get-Content -Path $guidFilePath -Encoding utf8
+
+# Extract the GUID from the content
+foreach ($line in $content) {
+    if ($line -match "GUID du mode de gestion de l'alimentation\s*:\s*([a-fA-F0-9\-]+)") {
+        $guid = $matches[1]
+        # Write the GUID to guid.txt (overwrite existing content)
+        $guid | Out-File -FilePath $guidFilePath -Encoding utf8 -Force
+
+        Write-Output "GUID: $guid has been saved to $guidFilePath"
+    }
+}
+
+if (-not $guid) {
+    Write-Output "No GUID found in $guidFilePath. Check the content format."
+}
+
+# Execute commands to change the plan name and set the plan as active
+try {
+    if ($guid) {
+        # Change the name of the power plan and set its description
+        $changeNameOutput = powercfg /changename $guid "$nameFromFile" "$description"
+        Write-Output "The power plan name and description have been changed. Output:"
+        Write-Output $changeNameOutput
+
+        # Set the power plan as active
+        $setActiveOutput = powercfg /setactive $guid
+        Write-Output "The power plan has been set as active. Output:"
+        Write-Output $setActiveOutput
+    } else {
+        Write-Output "GUID is missing. Ensure that guid.txt contains the necessary information."
+    }
+} catch {
+    Write-Error "Error executing powercfg commands: $_"
+}

--- a/utilmatepowerplan-fix.ps1
+++ b/utilmatepowerplan-fix.ps1
@@ -1,43 +1,25 @@
-# PowerShell script to fix the power plan applied across all languages based on the GUID of the new power plan.
-# This is necessary because when Windows is in a different language, the power plan might not be applied correctly.
-# This script changes the name and description of the power plan.
-#Video : https://youtu.be/00aUECZNvbA
-
 # ID of the plan to duplicate
 $sourceGUID = "e9a42b02-d5df-448d-aa00-03f14749eb61"
-$guid = $null
-$nameFromFile = "ChrisTitus - Ultimate Power Plan"
-$description = "Ultimate Power Plan , added via WinUtils"
 
-$scriptPath = $MyInvocation.MyCommand.Path
-$directoryPath = Split-Path -Path $scriptPath -Parent
-
-$guidFilePath = Join-Path -Path $directoryPath -ChildPath "guid.txt"
-
+# Duplicate the power plan
 $duplicateOutput = powercfg /duplicatescheme $sourceGUID
 
-try {
-    $duplicateOutput | Out-File -FilePath $guidFilePath -Append -Encoding utf8 -Force
+$guid = $null
+$nameFromFile = "ChrisTitus - Ultimate Power Plan"
+$description = "Ultimate Power Plan, added via WinUtils"
 
-    Write-Output "The output of 'powercfg /duplicatescheme' has been added to $guidFilePath."
-} catch {
-    Write-Error "Error writing to the file: $_"
-}
-$content = Get-Content -Path $guidFilePath -Encoding utf8
-
-# Extract the GUID from the content
-foreach ($line in $content) {
+# Extract the GUID directly from the duplicateOutput
+foreach ($line in $duplicateOutput) {
     if ($line -match "GUID du mode de gestion de l'alimentation\s*:\s*([a-fA-F0-9\-]+)") {
         $guid = $matches[1]
-        # Write the GUID to guid.txt (overwrite existing content)
-        $guid | Out-File -FilePath $guidFilePath -Encoding utf8 -Force
-
-        Write-Output "GUID: $guid has been saved to $guidFilePath"
+        Write-Output "GUID: $guid has been extracted and stored in the variable."
+        break
     }
 }
 
 if (-not $guid) {
-    Write-Output "No GUID found in $guidFilePath. Check the content format."
+    Write-Output "No GUID found in the duplicateOutput. Check the output format."
+    exit 1
 }
 
 # Execute commands to change the plan name and set the plan as active
@@ -53,7 +35,7 @@ try {
         Write-Output "The power plan has been set as active. Output:"
         Write-Output $setActiveOutput
     } else {
-        Write-Output "GUID is missing. Ensure that guid.txt contains the necessary information."
+        Write-Output "GUID is missing. Ensure that the GUID was properly extracted."
     }
 } catch {
     Write-Error "Error executing powercfg commands: $_"


### PR DESCRIPTION
# Powerplan improvement 

The issue appears to be related to the Windows language. I've noticed that the Ultimate Power Plan doesn't activate automatically because its name varies across different Windows languages.

I've created a small script that may help. It retrieves the GUID we just created, applies it, and changes the name and description simultaneously.

- [A video that shows the current power plan application method and the new one.](https://youtu.be/00aUECZNvbA)
## Script info
- [x] Import the power plan using the GUID (same as the one for the Ultimate Power Plan).
- [x] Create a file named "guid.txt" to save the GUID of the added power plan.
- [x] Customize the name and description of the power plan.
- [x] Apply the power plan using its GUID.