### PR TITLE
MicroWin: Stable Edge Removal

### DIFF
--- a/functions/public/Invoke-WPFMicrowin.ps1
+++ b/functions/public/Invoke-WPFMicrowin.ps1
@@ -174,12 +174,13 @@ public class PowerManagement {
             Remove-FileOrDirectory -pathToDelete "$($scratchDir)\Program Files\Windows Defender" -Directory
             Remove-FileOrDirectory -pathToDelete "$($scratchDir)\Program Files (x86)\Windows Defender"
         }
-        if (!$keepEdge) {
-            Write-Host "Removing Edge"
-            Remove-FileOrDirectory -pathToDelete "$($scratchDir)\Program Files (x86)\Microsoft" -mask "*edge*" -Directory
-            Remove-FileOrDirectory -pathToDelete "$($scratchDir)\Program Files\Microsoft" -mask "*edge*" -Directory
-            Remove-FileOrDirectory -pathToDelete "$($scratchDir)\Windows\SystemApps" -mask "*edge*" -Directory
-        }
+        # if (!$keepEdge) {
+        #     # this is destructive and might result in touching SystemApps is not recommended unless you going complete rogue on trimming edge and telemetry
+        #     Write-Host "Removing Edge"
+        #     Remove-FileOrDirectory -pathToDelete "$($scratchDir)\Program Files (x86)\Microsoft" -mask "*edge*" -Directory
+        #     Remove-FileOrDirectory -pathToDelete "$($scratchDir)\Program Files\Microsoft" -mask "*edge*" -Directory
+        #     Remove-FileOrDirectory -pathToDelete "$($scratchDir)\Windows\SystemApps" -mask "*edge*" -Directory
+        # }
 
         Remove-FileOrDirectory -pathToDelete "$($scratchDir)\Windows\DiagTrack" -Directory
         Remove-FileOrDirectory -pathToDelete "$($scratchDir)\Windows\InboxApps" -Directory
@@ -283,24 +284,56 @@ public class PowerManagement {
         reg add "HKLM\zSYSTEM\Setup\MoSetup" /v "AllowUpgradesWithUnsupportedTPMOrCPU" /t REG_DWORD /d 1 /f
 
         if (!$keepEdge) {
-            Write-Host "Removing Edge icon from taskbar"
-            reg delete "HKLM\zSOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Taskband" /v "Favorites" /f           >$null 2>&1
-            reg delete "HKLM\zSOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Taskband" /v "FavoritesChanges" /f   >$null 2>&1
-            reg delete "HKLM\zSOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Taskband" /v "Pinned" /f             >$null 2>&1
-            reg delete "HKLM\zSOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Taskband" /v "LayoutCycle" /f        >$null 2>&1
-            Write-Host "Edge icon removed from taskbar"
-            if (Test-Path "HKLM:\zSOFTWARE\WOW6432Node") {
-                # Remove leftovers of 64-bit installations
-                # ---
-                # Remove registry values first...
-                reg delete "HKLM\zSOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\Microsoft Edge" /va /f > $null 2>&1
-                reg delete "HKLM\zSOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\Microsoft Edge Update" /va /f > $null 2>&1
-                reg delete "HKLM\zSOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\Microsoft EdgeWebView" /va /f > $null 2>&1
-                # ...then the registry keys
-                reg delete "HKLM\zSOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\Microsoft Edge" /f > $null 2>&1
-                reg delete "HKLM\zSOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\Microsoft Edge Update" /f > $null 2>&1
-                reg delete "HKLM\zSOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\Microsoft EdgeWebView" /f > $null 2>&1
+            # Undo changes made by -> Dism Add-Edge Edge.wim (Trust Me: this is the non-destructive way to unintegrate Edge)
+
+            Write-Host "Removing Edge"
+
+            # Microsoft Edge
+            reg delete "HKLM\zSOFTWARE\Microsoft\Active Setup\Installed Components\{9459C573-B17A-45AE-9F64-1857B5D58CEE}" /f | Out-Null
+
+            reg delete "HKLM\zSOFTWARE\Wow6432Node\Microsoft\EdgeUpdate\Clients\{56EB18F8-B008-4CBD-B6D2-8C97FE7E9062}" /f | Out-Null
+            reg delete "HKLM\zSOFTWARE\Wow6432Node\Microsoft\EdgeUpdate\ClientState\{56EB18F8-B008-4CBD-B6D2-8C97FE7E9062}" /f | Out-Null
+
+            reg delete "HKLM\zSOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\Microsoft Edge" /f | Out-Null
+
+            if (Test-Path "$scratchDir\Program Files (x86)\Microsoft\Edge" -Type Container) {
+                Remove-Item "$scratchDir\Program Files (x86)\Microsoft\Edge" -Recurse -Force | Out-Null
             }
+
+            # Extra
+            reg delete "HKLM\zSOFTWARE\Microsoft\MicrosoftEdge" /f | Out-Null
+
+            # Microsoft EdgeWebView
+            reg delete "HKLM\zSOFTWARE\Wow6432Node\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}" /f | Out-Null
+            reg delete "HKLM\zSOFTWARE\Wow6432Node\Microsoft\EdgeUpdate\ClientState\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}" /f | Out-Null
+
+            reg delete "HKLM\zSOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\Microsoft EdgeWebView" /f | Out-Null
+
+            if (Test-Path "$scratchDir\Program Files (x86)\Microsoft\EdgeWebView" -Type Container) {
+                Remove-Item "$scratchDir\Program Files (x86)\Microsoft\EdgeWebView" -Recurse -Force | Out-Null
+            }
+
+            # Edge Core
+            if (Test-Path "$scratchDir\Program Files (x86)\Microsoft\EdgeCore" -Type Container) {
+                Remove-Item "$scratchDir\Program Files (x86)\Microsoft\EdgeCore" -Recurse -Force | Out-Null
+            }
+
+            # Microsoft Edge Update
+            reg delete "HKLM\zSOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\MicrosoftEdgeUpdate.exe" /f | Out-Null
+
+            reg delete "HKLM\zSOFTWARE\Wow6432Node\Microsoft\EdgeUpdate" /f | Out-Null
+            reg delete "HKLM\zSOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\Microsoft Edge Update" /f | Out-Null
+
+            # Microsoft Edge Update :: Services
+            reg delete "HKLM\zSYSTEM\ControlSet001\Services\edgeupdate" /f | Out-Null
+            reg delete "HKLM\zSYSTEM\ControlSet001\Services\edgeupdatem" /f | Out-Null
+
+            if (Test-Path "$scratchDir\Program Files (x86)\Microsoft\EdgeUpdate" -Type Container) {
+                Remove-Item "$scratchDir\Program Files (x86)\Microsoft\EdgeUpdate" -Recurse -Force | Out-Null
+            }
+
+            # Prevent EdgeChromium from Installing in the future
+            reg add "HKLM\zSOFTWARE\Microsoft\EdgeUpdate" /v "DoNotUpdateToEdgeWithChromium" /t REG_DWORD /d "1" /f | Out-Null
         }
 
         reg add "HKLM\zSOFTWARE\Microsoft\Windows\CurrentVersion\Search" /v "SearchboxTaskbarMode" /t REG_DWORD /d 0 /f


### PR DESCRIPTION
## Title
Stable Edge Removal - MicroWin

## Description
Undoes the official way of integrating Edge into ISOs

## Additional Information
- Doesn't break anything. If you install Edge later that's on you :P | use winutil tweaks in that case ;)
- Of Course it's so much better from doing inside the box.
- From the same author `Techie Jack` user who supplied the inbox removal fix :)

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
