### PR TITLE
Fix BSoD Tweak

### DIFF
--- a/functions/private/Get-WinUtilToggleStatus.ps1
+++ b/functions/private/Get-WinUtilToggleStatus.ps1
@@ -140,8 +140,9 @@ Function Get-WinUtilToggleStatus {
         }
     }
     if ($ToggleSwitch -eq "WPFToggleDetailedBSoD") {
-        $DetailedBSoD = (Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\CrashControl').DisplayParameters
-        if($DetailedBSoD -eq 0) {
+        $DetailedBSoD1 = (Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\CrashControl').DisplayParameters
+        $DetailedBSoD2 = (Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\CrashControl').DisableEmoticon
+        if (($DetailedBSoD1 -eq 0) -or ($DetailedBSoD2 -eq 0) -or !$DetailedBSoD1 -or !$DetailedBSoD2) {
             return $false
         } else {
             return $true

--- a/functions/private/Invoke-WinUtilDetailedBSoD.ps1
+++ b/functions/private/Invoke-WinUtilDetailedBSoD.ps1
@@ -18,6 +18,10 @@ Function Invoke-WinUtilDetailedBSoD {
         }
 
         $Path = "HKLM:\SYSTEM\CurrentControlSet\Control\CrashControl"
+        $dwords = ("DisplayParameters", "DisableEmoticon")
+        foreach ($name in $dwords) {
+            Set-ItemProperty -Path $Path -Name $name -Value $value
+        }
         Set-ItemProperty -Path $Path -Name DisplayParameters -Value $value
     } catch [System.Security.SecurityException] {
         Write-Warning "Unable to set $Path\$Name to $Value due to a Security Exception"


### PR DESCRIPTION
# Pull Request

## Fix BSoD Tweak

## Type of Change
- [x] Bug fix

## Description
- Did not notice the issue because the key already existed on my machine, if the key does not yet exist it still sais it is enabled even tho it is not.
- Added disable emoticon (smily)

## Testing
worked (tested correctly this time)

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
