### PR TITLE
Ultimate Performance via GUID rather than name

### DIFF
--- a/functions/public/Invoke-WPFUltimatePerformance.ps1
+++ b/functions/public/Invoke-WPFUltimatePerformance.ps1
@@ -2,43 +2,65 @@ Function Invoke-WPFUltimatePerformance {
     <#
 
     .SYNOPSIS
-        Creates or removes the Ultimate Performance power scheme
+        Enables or disables the Ultimate Performance power scheme based on its GUID.
 
     .PARAMETER State
-        Indicates whether to enable or disable the Ultimate Performance power scheme
+        Specifies whether to "Enable" or "Disable" the Ultimate Performance power scheme.
 
     #>
     param($State)
+
     try {
-        # Check if Ultimate Performance plan is installed
-        $ultimatePlan = powercfg -list | Select-String -Pattern "Ultimate Performance"
-        if($state -eq "Enable") {
-            if ($ultimatePlan) {
-                Write-Host "Ultimate Performance plan is already installed."
-            } else {
-                Write-Host "Installing Ultimate Performance plan..."
-                powercfg -duplicatescheme e9a42b02-d5df-448d-aa00-03f14749eb61
-                Write-Host "> Ultimate Performance plan installed."
+        # GUID of the Ultimate Performance power plan
+        $ultimateGUID = "e9a42b02-d5df-448d-aa00-03f14749eb61"
+
+        if ($State -eq "Enable") {
+            # Duplicate the Ultimate Performance power plan using its GUID
+            $duplicateOutput = powercfg /duplicatescheme $ultimateGUID
+
+            $guid = $null
+            $nameFromFile = "ChrisTitus - Ultimate Power Plan"
+            $description = "Ultimate Power Plan, added via WinUtils"
+
+            # Extract the new GUID from the duplicateOutput
+            foreach ($line in $duplicateOutput) {
+                if ($line -match "GUID du mode de gestion de l'alimentation\s*:\s*([a-fA-F0-9\-]+)") {
+                    $guid = $matches[1]
+                    Write-Output "GUID: $guid has been extracted and stored in the variable."
+                    break
+                }
             }
 
-            # Set the Ultimate Performance plan as active
-            $ultimatePlanGUID = (powercfg -list | Select-String -Pattern "Ultimate Performance").Line.Split()[3]
-            powercfg -setactive $ultimatePlanGUID
+            if (-not $guid) {
+                Write-Output "No GUID found in the duplicateOutput. Check the output format."
+                exit 1
+            }
 
-            Write-Host "Ultimate Performance plan is now active."
+            # Change the name of the power plan and set its description
+            $changeNameOutput = powercfg /changename $guid "$nameFromFile" "$description"
+            Write-Output "The power plan name and description have been changed. Output:"
+            Write-Output $changeNameOutput
 
+            # Set the duplicated Ultimate Performance plan as active
+            $setActiveOutput = powercfg /setactive $guid
+            Write-Output "The power plan has been set as active. Output:"
+            Write-Output $setActiveOutput
 
-        }
-        elseif($state -eq "Disable") {
-            if ($ultimatePlan) {
-                # Extract the GUID of the Ultimate Performance plan
-                $ultimatePlanGUID = $ultimatePlan.Line.Split()[3]
+            Write-Host "> Ultimate Performance plan installed and set as active."
+
+        } elseif ($State -eq "Disable") {
+            # Check if the Ultimate Performance plan is installed by GUID
+            $installedPlan = powercfg -list | Select-String -Pattern $ultimateGUID
+
+            if ($installedPlan) {
+                # Extract the GUID of the installed Ultimate Performance plan
+                $ultimatePlanGUID = $installedPlan.Line.Split()[3]
 
                 # Set a different power plan as active before deleting the Ultimate Performance plan
                 $balancedPlanGUID = (powercfg -list | Select-String -Pattern "Balanced").Line.Split()[3]
                 powercfg -setactive $balancedPlanGUID
 
-                # Delete the Ultimate Performance plan
+                # Delete the Ultimate Performance plan by GUID
                 powercfg -delete $ultimatePlanGUID
 
                 Write-Host "Ultimate Performance plan has been uninstalled."
@@ -48,6 +70,6 @@ Function Invoke-WPFUltimatePerformance {
             }
         }
     } catch {
-        Write-Warning $psitem.Exception.Message
+        Write-Error "Error occurred: $_"
     }
 }

--- a/functions/public/Invoke-WPFUltimatePerformance.ps1
+++ b/functions/public/Invoke-WPFUltimatePerformance.ps1
@@ -24,11 +24,12 @@ Function Invoke-WPFUltimatePerformance {
 
             # Extract the new GUID from the duplicateOutput
             foreach ($line in $duplicateOutput) {
-                if ($line -match "GUID du mode de gestion de l'alimentation\s*:\s*([a-fA-F0-9\-]+)") {
-                    $guid = $matches[1]
+                if ($line -match "\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b") {
+                    $guid = $matches[0]  # $matches[0] will contain the first match, which is the GUID
                     Write-Output "GUID: $guid has been extracted and stored in the variable."
                     break
                 }
+            }
             }
 
             if (-not $guid) {


### PR DESCRIPTION
# Powerplan improvement 

The issue appears to be related to the Windows language. I've noticed that the Ultimate Power Plan doesn't activate automatically because its name varies across different Windows languages.

I've created a small script that may help. It retrieves the GUID we just created, applies it, and changes the name and description simultaneously.


## Script info

- [x] Import the power plan using the GUID (same as the one for the Ultimate Power Plan).
- [x] Customize the name and description of the power plan.
- [x] Apply the power plan using its GUID.

## Final render 
![image](https://github.com/user-attachments/assets/26f536d8-4d16-415e-90bf-a88c53f71faa)
