### PR TITLE
[MicroWin] Add try-catch block for AppX packages

### DIFF
--- a/functions/private/Invoke-WinUtilMicroWin-Helper.ps1
+++ b/functions/private/Invoke-WinUtilMicroWin-Helper.ps1
@@ -132,42 +132,49 @@ function Remove-ProvisionedPackages() {
         .EXAMPLE
         Remove-ProvisionedPackages
     #>
-    $appxProvisionedPackages = Get-AppxProvisionedPackage -Path "$($scratchDir)" | Where-Object    {
-            $_.PackageName -NotLike "*AppInstaller*" -AND
-            $_.PackageName -NotLike "*Store*" -and
-            $_.PackageName -NotLike "*dism*" -and
-            $_.PackageName -NotLike "*Foundation*" -and
-            $_.PackageName -NotLike "*FodMetadata*" -and
-            $_.PackageName -NotLike "*LanguageFeatures*" -and
-            $_.PackageName -NotLike "*Notepad*" -and
-            $_.PackageName -NotLike "*Printing*" -and
-            $_.PackageName -NotLike "*Wifi*" -and
-            $_.PackageName -NotLike "*Foundation*" -and
-            $_.PackageName -NotLike "*YourPhone*" -and
-            $_.PackageName -NotLike "*Xbox*" -and
-            $_.PackageName -NotLike "*WindowsTerminal*" -and
-            $_.PackageName -NotLike "*Calculator*" -and
-            $_.PackageName -NotLike "*Photos*" -and
-            $_.PackageName -NotLike "*VCLibs*" -and
-            $_.PackageName -NotLike "*Paint*" -and
-            $_.PackageName -NotLike "*Gaming*" -and
-            $_.PackageName -NotLike "*Extension*" -and
-            $_.PackageName -NotLike "*SecHealthUI*"
-
+    try
+    {
+        $appxProvisionedPackages = Get-AppxProvisionedPackage -Path "$($scratchDir)" | Where-Object {
+                $_.PackageName -NotLike "*AppInstaller*" -AND
+                $_.PackageName -NotLike "*Store*" -and
+                $_.PackageName -NotLike "*dism*" -and
+                $_.PackageName -NotLike "*Foundation*" -and
+                $_.PackageName -NotLike "*FodMetadata*" -and
+                $_.PackageName -NotLike "*LanguageFeatures*" -and
+                $_.PackageName -NotLike "*Notepad*" -and
+                $_.PackageName -NotLike "*Printing*" -and
+                $_.PackageName -NotLike "*Wifi*" -and
+                $_.PackageName -NotLike "*Foundation*" -and
+                $_.PackageName -NotLike "*YourPhone*" -and
+                $_.PackageName -NotLike "*Xbox*" -and
+                $_.PackageName -NotLike "*WindowsTerminal*" -and
+                $_.PackageName -NotLike "*Calculator*" -and
+                $_.PackageName -NotLike "*Photos*" -and
+                $_.PackageName -NotLike "*VCLibs*" -and
+                $_.PackageName -NotLike "*Paint*" -and
+                $_.PackageName -NotLike "*Gaming*" -and
+                $_.PackageName -NotLike "*Extension*" -and
+                $_.PackageName -NotLike "*SecHealthUI*"
         }
 
-    $counter = 0
-    foreach ($appx in $appxProvisionedPackages) {
-        $status = "Removing Provisioned $($appx.PackageName)"
-        Write-Progress -Activity "Removing Provisioned Apps" -Status $status -PercentComplete ($counter++/$appxProvisionedPackages.Count*100)
-        try {
-            Remove-AppxProvisionedPackage -Path "$scratchDir" -PackageName $appx.PackageName -ErrorAction SilentlyContinue
-        } catch {
-            Write-Host "Application $($appx.PackageName) could not be removed"
-            continue
+        $counter = 0
+        foreach ($appx in $appxProvisionedPackages) {
+            $status = "Removing Provisioned $($appx.PackageName)"
+            Write-Progress -Activity "Removing Provisioned Apps" -Status $status -PercentComplete ($counter++/$appxProvisionedPackages.Count*100)
+            try {
+                Remove-AppxProvisionedPackage -Path "$scratchDir" -PackageName $appx.PackageName -ErrorAction SilentlyContinue
+            } catch {
+                Write-Host "Application $($appx.PackageName) could not be removed"
+                continue
+            }
         }
+        Write-Progress -Activity "Removing Provisioned Apps" -Status "Ready" -Completed
     }
-    Write-Progress -Activity "Removing Provisioned Apps" -Status "Ready" -Completed
+    catch
+    {
+        # This can happen if getting AppX packages fails
+        Write-Host "Unable to get information about the AppX packages. MicroWin processing will continue, but AppX packages will not be processed"
+    }
 }
 
 function Copy-ToUSB([string]$fileToCopy) {


### PR DESCRIPTION
# Pull Request

## Title
(Same as title, but with MicroWin prepended to avoid confusion with other PRs)

## Type of Change
- [X] Bug fix

## Description
This PR reinstates error handling for the AppX package removal function, which had been removed during the live stream on 13 August

## Testing
AppX package removal still works

## Impact
Reliability improvements

## Issue related to PR
No issue. That's why I made this change - to prevent such issues from being reported

## Additional Information
No documentation changes

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no errors/warnings/merge conflicts.
