### PR TITLE
Admin elevation when runs as regular user

### DIFF
--- a/scripts/start.ps1
+++ b/scripts/start.ps1
@@ -44,12 +44,23 @@ $sync.version = "#{replaceme}"
 $sync.configs = @{}
 $sync.ProcessRunning = $false
 
-# If script isn't running as admin, show error message and quit
-If (([Security.Principal.WindowsIdentity]::GetCurrent()).Owner.Value -ne "S-1-5-32-544") {
-    Write-Host "===========================================" -Foregroundcolor Red
-    Write-Host "-- Scripts must be run as Administrator ---" -Foregroundcolor Red
-    Write-Host "-- Right-Click Start -> Terminal(Admin) ---" -Foregroundcolor Red
-    Write-Host "===========================================" -Foregroundcolor Red
+if (!([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    Write-Output "Winutil needs to be run as Administrator. Attempting to relaunch."
+
+    $wtInstalled = Get-Command wt.exe -ErrorAction SilentlyContinue
+    $pwshInstalled = Get-Command pwsh -ErrorAction SilentlyContinue 
+    if ($pwshInstalled) {
+        $powershellcmd = "pwsh"
+    } else {
+        $powershellcmd = "powershell"
+    }
+    
+    if ($wtInstalled) {
+        Start-Process wt.exe -ArgumentList "new-tab $powershellcmd -ExecutionPolicy Bypass -Command `"irm https://christitus.com/win | iex`"" -Verb RunAs
+    } else {
+        Start-Process $powershellcmd -ArgumentList "-ExecutionPolicy Bypass -Command `"irm https://christitus.com/win | iex`"" -Verb RunAs
+    }
+
     break
 }
 


### PR DESCRIPTION
# Pull Request

## Title
Elevate Prompt to Admin so script can run

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [x] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [x] UI/UX improvement

## Description
Normally the script would exit if run as a normal user.

## Testing
Testing not done.

## Impact
This should check to see if Windows Terminal, Powershell 7, or Powershell is installed. It will adjust the run command based on the users system

## Additional Information
Currently another version done different in PR #2531 and wanted a simple approach for non-elevated runs

## Checklist
- [x ] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my own code.
- [x ] I have commented my code, particularly in hard-to-understand areas.
- [x ] I have made corresponding changes to the documentation.
- [ ] My changes generate no errors/warnings/merge conflicts.
