### PR TITLE
[MicroWin] Fixed VMware network driver issues

### DIFF
--- a/functions/private/Invoke-WinUtilMicroWin-Helper.ps1
+++ b/functions/private/Invoke-WinUtilMicroWin-Helper.ps1
@@ -101,7 +101,9 @@ function Remove-Packages {
                 $_ -NotLike "*DesktopAppInstaller*" -AND
                 $_ -NotLike "*WebMediaExtensions*" -AND
                 $_ -NotLike "*WMIC*" -AND
-                $_ -NotLike "*UI.XaML*"
+                $_ -NotLike "*UI.XaML*" -AND
+                $_ -NotLike "*Ethernet*" -AND
+                $_ -NotLike "*Wifi*"
             }
 
         foreach ($pkg in $pkglist) {
@@ -143,7 +145,6 @@ function Remove-ProvisionedPackages() {
                 $_.PackageName -NotLike "*LanguageFeatures*" -and
                 $_.PackageName -NotLike "*Notepad*" -and
                 $_.PackageName -NotLike "*Printing*" -and
-                $_.PackageName -NotLike "*Wifi*" -and
                 $_.PackageName -NotLike "*Foundation*" -and
                 $_.PackageName -NotLike "*YourPhone*" -and
                 $_.PackageName -NotLike "*Xbox*" -and


### PR DESCRIPTION
# Pull Request

## Title
(Same as title)

## Type of Change
- [X] Bug fix

## Description
This PR fixes networking issues of MicroWin in VMware hypervisors. This involved excluding all Ethernet and Wi-Fi Features on Demand (FoDs) from package removal.

![MicroWin-2024-08-15-09-18-08](https://github.com/user-attachments/assets/bac900f6-fd13-499f-8df8-57de924ba158)

![MicroWin-2024-08-15-09-42-56](https://github.com/user-attachments/assets/2ac16dbb-6dfe-4f60-88fa-20e8c57710f6)

![DT_Ethernet](https://github.com/user-attachments/assets/279a2b86-2157-4c3d-8239-7afd12313ef1)

![DT_WiFi](https://github.com/user-attachments/assets/76b12cd9-735f-404d-9c06-4b5909554f14)

## Testing
Testing was performed against a Windows 11 23H2 image and concluded with no issues

## Impact
Network compatibility in VMware hypervisors

## Issue related to PR
None AFAIK

## Additional Information
No documentation changes were required

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no errors/warnings/merge conflicts.
