### PR TITLE
Make "Download" a Link to Download the Latest Windows 11 ISO

### DIFF
--- a/xaml/inputXML.xaml
+++ b/xaml/inputXML.xaml
@@ -950,8 +950,7 @@
                                 <LineBreak/>
 
                                 <Bold>INSTRUCTIONS</Bold> <LineBreak/>
-                                - Download the latest Windows 11 image from Microsoft <LineBreak/>
-                                LINK: https://www.microsoft.com/software-download/windows11 <LineBreak/>
+                                - <TextBlock Name="Win11DownloadLink" Style="{StaticResource HoverTextBlockStyle}" ToolTip="https://www.microsoft.com/software-download/windows11">Download</TextBlock> the latest Windows 11 image from Microsoft <LineBreak/>
                                 May take several minutes to process the ISO depending on your machine and connection <LineBreak/>
                                 - Put it somewhere on the C:\ drive so it is easily accessible <LineBreak/>
                                 - Launch WinUtil and MicroWin  <LineBreak/>


### PR DESCRIPTION
# Pull Request

## Title
Provide a direct link to the Windows 11 ISO download page

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [x] UI/UX improvement

## Description
Removed the full link text to the Windows 11 ISO download site on the MicroWin tab and replaced it by making `Download` a direct link.

## Testing
Tested by running `Compil;e.ps1 -run` and verifying clicking the link navigates to `https://www.microsoft.com/software-download/windows11`.

## Impact
Adds convenience of a click over having to reference the text to enter the URL correctly (copy was not supported in the via text).

## Issue related to PR
[What issue/discussion is related to this PR (if any)]
- Resolves #2573 

## Additional Information
N/A

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
