### PR TITLE
Roll back WicroWin-Helper

### DIFF
--- a/functions/private/Invoke-WinUtilMicroWin-Helper.ps1
+++ b/functions/private/Invoke-WinUtilMicroWin-Helper.ps1
@@ -146,15 +146,11 @@ function Remove-ProvisionedPackages() {
                 $_.PackageName -NotLike "*Notepad*" -and
                 $_.PackageName -NotLike "*Printing*" -and
                 $_.PackageName -NotLike "*Foundation*" -and
-                $_.PackageName -NotLike "*YourPhone*" -and
-                $_.PackageName -NotLike "*Xbox*" -and
                 $_.PackageName -NotLike "*WindowsTerminal*" -and
                 $_.PackageName -NotLike "*Calculator*" -and
                 $_.PackageName -NotLike "*Photos*" -and
                 $_.PackageName -NotLike "*VCLibs*" -and
                 $_.PackageName -NotLike "*Paint*" -and
-                $_.PackageName -NotLike "*Gaming*" -and
-                $_.PackageName -NotLike "*Extension*" -and
                 $_.PackageName -NotLike "*SecHealthUI*"
         }
 


### PR DESCRIPTION
As you mentioned on the latest stream. Let's keep the MicroWin version as "normal" but without bloat. Xbox and Gaming is bloat - if gamers want to install them. they can...