### PR TITLE
[OneDrive Removal fix] Leftover autostart key

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -2713,6 +2713,9 @@
       reg delete \"HKEY_USERS\\Default\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run\" /v \"OneDriveSetup\" /f
       reg unload \"hku\\Default\"
 
+      Write-Host \"Removing autostart key\"
+      reg delete \"HKEY_CURRENT_USERS\\Default\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run\" /v \"OneDrive\" /f
+
       Write-Host \"Removing startmenu entry\"
       Remove-Item -Force -ErrorAction SilentlyContinue \"$env:userprofile\\AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs\\OneDrive.lnk\"
 

--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -2714,7 +2714,7 @@
       reg unload \"hku\\Default\"
 
       Write-Host \"Removing autostart key\"
-      reg delete \"HKEY_CURRENT_USERS\\Default\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run\" /v \"OneDrive\" /f
+      reg delete \"HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Run\" /v \"OneDrive\" /f
 
       Write-Host \"Removing startmenu entry\"
       Remove-Item -Force -ErrorAction SilentlyContinue \"$env:userprofile\\AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs\\OneDrive.lnk\"


### PR DESCRIPTION
# Pull Request

## remove leftover autostart key for onedrive

## Type of Change
- [x] Hotfix

## Issue related to PR
- Resolves Issue mentioned in Community Discord Server

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
