### PR TITLE
[MicroWin] Remove test-path for issue fix

### DIFF
--- a/functions/public/Invoke-WPFMicrowin.ps1
+++ b/functions/public/Invoke-WPFMicrowin.ps1
@@ -263,10 +263,7 @@ public class PowerManagement {
             # reg delete "HKLM\zSOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Orchestrator\UScheduler\$_" /f | Out-Null
 
             # When in Offline Image
-            if (Test-Path "HKLM:\zSOFTWARE\Microsoft\WindowsUpdate\Orchestrator\UScheduler_Oobe\$_")
-            {
-                reg delete "HKLM\zSOFTWARE\Microsoft\WindowsUpdate\Orchestrator\UScheduler_Oobe\$_" /f | Out-Null
-            }
+            reg delete "HKLM\zSOFTWARE\Microsoft\WindowsUpdate\Orchestrator\UScheduler_Oobe\$_" /f | Out-Null
         }
 
         reg add "HKLM\zSOFTWARE\Microsoft\Windows\CurrentVersion\Search" /v "SearchboxTaskbarMode" /t REG_DWORD /d 0 /f


### PR DESCRIPTION
# Pull Request

## Title
(Same as title)

## Type of Change
- [X] Bug fix

## Description
This PR removes the Test-Path condition, which is the culprit for ISOs being double their initial size by including both the unmodified and modified install.wim files.

For example, when I implemented registry cmdlets for DISMTools, it took an insanely huge amount of attempts to unlock the registry, so I replaced them with REG commands.

[Link to DT commit](https://github.com/CodingWonders/DISMTools/pull/140/commits/02d5d2e4132df48982a0d7b7c1e4c36fec660949)

**In short:** *Using registry cmdlets for offline images holds "System" process file locks for an uncertain amount of time until they are released, at which point unmounting has failed. Forcing a manual release of the lock will crash the system.*

One reason to rant about PowerShell, I guess.

## Testing
It should finish successfully

## Impact
ISO files not being ludicrously huge

## Issue related to PR
- Aug. 19 Stream

## Additional Information
No documentation changes were required

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no errors/warnings/merge conflicts.
