### PR TITLE
Fix Label in white theme

### DIFF
--- a/config/themes.json
+++ b/config/themes.json
@@ -35,7 +35,7 @@
         "LabelboxForegroundColor":  "#000000",
         "MainForegroundColor":  "#000000",
         "MainBackgroundColor":  "#FFFFFF",
-        "LabelBackgroundColor":  "#FAFAFA",
+        "LabelBackgroundColor":  "#FFFFFF",
         "LinkForegroundColor":  "#000000",
         "LinkHoverForegroundColor":  "#000000",
         "GroupBorderBackgroundColor":  "#000000",

--- a/config/themes.json
+++ b/config/themes.json
@@ -80,7 +80,7 @@
         "LabelboxForegroundColor":  "#000000",
         "MainForegroundColor":  "#000000",
         "MainBackgroundColor":  "#FFFFFF",
-        "LabelBackgroundColor":  "#FAFAFA",
+        "LabelBackgroundColor":  "#FFFFFF",
         "LinkForegroundColor":  "#000000",
         "LinkHoverForegroundColor":  "#000000",
         "GroupBorderBackgroundColor":  "#000000",


### PR DESCRIPTION
# Pull Request

## Fix Label in white theme

## Type of Change
- [x] UI/UX improvement

## Description
never use light mode, but for testing or on new systems I have to deal with it. I wonder why the background of the label is a tiny bit darker than the rest of the utility.

Did just catch it again and don't have any PR or stashed changes in that regard, therefore the individual PR.


<details>
<summary>old preview (attention, you may get blinded)</summary>
<br>

![image](https://github.com/user-attachments/assets/bf6f2b2a-e21f-430a-a8e6-6a041d164789)
</details>

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
