### PR TITLE
Small patches for `main.ps1` script

### DIFF
--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -95,12 +95,6 @@ try {
     Write-Host "Unable to load Windows.Markup.XamlReader. Double-check syntax and ensure .net is installed."
 }
 
-# Load the configuration files
-#Invoke-WPFUIElements -configVariable $sync.configs.nav -targetGridName "WPFMainGrid"
-Invoke-WPFUIElements -configVariable $sync.configs.applications -targetGridName "appspanel" -columncount 5
-Invoke-WPFUIElements -configVariable $sync.configs.tweaks -targetGridName "tweakspanel" -columncount 2
-Invoke-WPFUIElements -configVariable $sync.configs.feature -targetGridName "featurespanel" -columncount 2
-
 if (-NOT ($readerOperationSuccessful)) {
     Write-Host "Failed to parse xaml content using Windows.Markup.XamlReader's Load Method." -ForegroundColor Red
     Write-Host "Quitting winutil..." -ForegroundColor Red
@@ -109,6 +103,12 @@ if (-NOT ($readerOperationSuccessful)) {
     [System.GC]::Collect()
     exit 1
 }
+
+# Load the configuration files
+#Invoke-WPFUIElements -configVariable $sync.configs.nav -targetGridName "WPFMainGrid"
+Invoke-WPFUIElements -configVariable $sync.configs.applications -targetGridName "appspanel" -columncount 5
+Invoke-WPFUIElements -configVariable $sync.configs.tweaks -targetGridName "tweakspanel" -columncount 2
+Invoke-WPFUIElements -configVariable $sync.configs.feature -targetGridName "featurespanel" -columncount 2
 
 #===========================================================================
 # Store Form Objects In PowerShell

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -85,14 +85,14 @@ try {
     $sync["Form"] = [Windows.Markup.XamlReader]::Load( $reader )
     $readerOperationSuccessful = $true
 } catch [System.Management.Automation.MethodInvocationException] {
-    Write-Warning "We ran into a problem with the XAML code.  Check the syntax for this control..."
+    Write-Host "We ran into a problem with the XAML code.  Check the syntax for this control..." -ForegroundColor Red
     Write-Host $error[0].Exception.Message -ForegroundColor Red
 
     If ($error[0].Exception.Message -like "*button*") {
-        write-warning "Ensure your &lt;button in the `$inputXML does NOT have a Click=ButtonClick property.  PS can't handle this`n`n`n`n"
+        write-Host "Ensure your &lt;button in the `$inputXML does NOT have a Click=ButtonClick property.  PS can't handle this`n`n`n`n" -ForegroundColor Red
     }
 } catch {
-    Write-Host "Unable to load Windows.Markup.XamlReader. Double-check syntax and ensure .net is installed."
+    Write-Host "Unable to load Windows.Markup.XamlReader. Double-check syntax and ensure .net is installed." -ForegroundColor Red
 }
 
 if (-NOT ($readerOperationSuccessful)) {


### PR DESCRIPTION
## Type of Change
- [x] Hotfix

## Description
- Changing the order of operation in `main.ps1` script, where it'll check if XAML parsing was successful or not, before continuing on with UI Dynamic Generation. ( commit 32877fe200dbc2e08866a8a7e28e510444459518 )
- Use `Write-Host` instead of `Write-Warning` or even `Write-Error` because it can be ignored sometimes because of Runspaces and older ps shell environments (e.g. PowerShell 5). ( commit 0c4c4835dfa9d8841f0e6c8a7aac40db1e1bee2c )

## Testing
tested the changes, and everything works as intended.

## Impact
It'll fail fast/gracefully upon unsuccessful parsing of XAML, which'll speedup development a bit (not that much, but it can add up overtime), beside that it won't effect End Users.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
