### PR TITLE
Fixes, improvements + Auto Window handling

### DIFF
--- a/Compile.ps1
+++ b/Compile.ps1
@@ -2,7 +2,7 @@ param (
     [switch]$Debug,
     [switch]$Run,
     [switch]$SkipPreprocessing,
-    [string]$arg
+    [string]$Arguments
 )
 $OFS = "`r`n"
 $scriptname = "winutil.ps1"
@@ -119,7 +119,7 @@ catch {
 Write-Progress -Activity "Validating" -Completed
 
 if ($run) {
-    $script = "& '$workingdir\$scriptname' $arg"
+    $script = "& '$workingdir\$scriptname' $Arguments"
 
     $powershellcmd = if (Get-Command pwsh -ErrorAction SilentlyContinue) { "pwsh" } else { "powershell" }
     $processCmd = if (Get-Command wt.exe -ErrorAction SilentlyContinue) { "wt.exe" } else { $powershellcmd }

--- a/Compile.ps1
+++ b/Compile.ps1
@@ -1,7 +1,8 @@
 param (
     [switch]$Debug,
     [switch]$Run,
-    [switch]$SkipPreprocessing
+    [switch]$SkipPreprocessing,
+    [string]$args
 )
 $OFS = "`r`n"
 $scriptname = "winutil.ps1"
@@ -116,6 +117,19 @@ catch {
     Write-Host "$($Error[0])" -ForegroundColor Red
 }
 Write-Progress -Activity "Validating" -Completed
+
+if ($run) {
+    $script = "& { & '$($workingdir)\$($scriptname)' $($args) }"
+
+    $powershellcmd = if (Get-Command pwsh -ErrorAction SilentlyContinue) { "pwsh" } else { "powershell" }
+    $processCmd = if (Get-Command wt.exe -ErrorAction SilentlyContinue) { "wt.exe" } else { $powershellcmd }
+
+    Start-Process $processCmd -ArgumentList "$powershellcmd -NoProfile -Command $script"
+
+    break
+}
+
+
 
 if ($run) {
     try {

--- a/Compile.ps1
+++ b/Compile.ps1
@@ -2,7 +2,7 @@ param (
     [switch]$Debug,
     [switch]$Run,
     [switch]$SkipPreprocessing,
-    [string]$args
+    [string]$arg
 )
 $OFS = "`r`n"
 $scriptname = "winutil.ps1"
@@ -119,7 +119,7 @@ catch {
 Write-Progress -Activity "Validating" -Completed
 
 if ($run) {
-    $script = "& { & '$($workingdir)\$($scriptname)' $($args) }"
+    $script = "& '$workingdir\$scriptname' $arg"
 
     $powershellcmd = if (Get-Command pwsh -ErrorAction SilentlyContinue) { "pwsh" } else { "powershell" }
     $processCmd = if (Get-Command wt.exe -ErrorAction SilentlyContinue) { "wt.exe" } else { $powershellcmd }
@@ -127,15 +127,4 @@ if ($run) {
     Start-Process $processCmd -ArgumentList "$powershellcmd -NoProfile -Command $script"
 
     break
-}
-
-
-
-if ($run) {
-    try {
-        Start-Process -FilePath "pwsh" -ArgumentList "$workingdir\$scriptname"
-    } catch {
-        Start-Process -FilePath "powershell" -ArgumentList "$workingdir\$scriptname"
-    }
-
 }

--- a/config/themes.json
+++ b/config/themes.json
@@ -6,7 +6,7 @@
         "CustomDialogWidth":          "400",
         "CustomDialogHeight":         "200",
 
-        "FontSize":         "14",
+        "FontSize":         "12",
         "FontFamily":       "Arial",
         "FontSizeHeading":  "16",
         "HeaderFontFamily": "Consolas, Monaco",

--- a/config/themes.json
+++ b/config/themes.json
@@ -26,6 +26,7 @@
         "CloseIconFontSize":      "18",
 
         "MicroWinLogoSize": "10",
+        "MicrowinCheckBoxMargin": "-10,5,0,0",
 
         "ProgressBarForegroundColor": "#FFAC1C",
         "ProgressBarBackgroundColor": "Transparent",

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -246,6 +246,14 @@ $sync["Form"].Add_MouseLeftButtonDown({
     $sync["Form"].DragMove()
 })
 
+$sync["Form"].Add_MouseDoubleClick({
+    if ($sync["Form"].WindowState -eq [Windows.WindowState]::Normal) {
+        $sync["Form"].WindowState = [Windows.WindowState]::Maximized;
+    } else {
+        $sync["Form"].WindowState = [Windows.WindowState]::Normal;
+    }
+})
+
 $sync["Form"].Add_Deactivated({
     Write-Debug "WinUtil lost focus"
     if ($sync["SettingsPopup"].IsOpen) {

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -246,14 +246,6 @@ $sync["Form"].Add_MouseLeftButtonDown({
     $sync["Form"].DragMove()
 })
 
-$sync["Form"].Add_MouseDoubleClick({
-    if ($sync["Form"].WindowState -eq [Windows.WindowState]::Normal) {
-        $sync["Form"].WindowState = [Windows.WindowState]::Maximized;
-    } else {
-        $sync["Form"].WindowState = [Windows.WindowState]::Normal;
-    }
-})
-
 $sync["Form"].Add_Deactivated({
     Write-Debug "WinUtil lost focus"
     if ($sync["SettingsPopup"].IsOpen) {
@@ -437,6 +429,12 @@ $sync["SearchBar"].Add_TextChanged({
     foreach ($category in $inactiveCategories) {
         $sync[$category].Visibility = "Collapsed"
     }
+})
+
+$sync["Form"].Add_Loaded({
+    param($e)
+    $sync["Form"].MaxWidth = [Double]::PositiveInfinity
+    $sync["Form"].MaxHeight = [Double]::PositiveInfinity
 })
 
 # Initialize the hashtable

--- a/scripts/start.ps1
+++ b/scripts/start.ps1
@@ -5,6 +5,7 @@
     GitHub         : https://github.com/ChrisTitusTech
     Version        : #{replaceme}
 #>
+
 param (
     [switch]$Debug,
     [string]$Config,
@@ -31,7 +32,7 @@ $dateTime = Get-Date -Format "yyyy-MM-dd_HH-mm-ss"
 
 $logdir = "$env:localappdata\winutil\logs"
 [System.IO.Directory]::CreateDirectory("$logdir")
-Start-Transcript -Path "$logdir\winutil_$dateTime.log" -Append
+Start-Transcript -Path "$logdir\winutil_$dateTime.log" -Append -NoClobber | Out-Null
 
 # Load DLLs
 Add-Type -AssemblyName PresentationFramework
@@ -46,8 +47,22 @@ $sync.ProcessRunning = $false
 
 if (!([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
     Write-Output "Winutil needs to be run as Administrator. Attempting to relaunch."
+    $argList = @()
 
-    $script = if ($MyInvocation.MyCommand.Path) { "& '" + $MyInvocation.MyCommand.Path + "'" } else { "irm 'https://github.com/ChrisTitusTech/winutil/releases/latest/download/winutil.ps1' | iex"}
+    $PSBoundParameters.GetEnumerator() | ForEach-Object {
+        $argList += if ($_.Value -is [switch] -and $_.Value) {
+            "-$($_.Key)"
+        } elseif ($_.Value) {
+            "-$($_.Key) `"$($_.Value)`""
+        }
+    }
+
+    $script = if ($MyInvocation.MyCommand.Path) {
+        "& { & '$($MyInvocation.MyCommand.Path)' $argList }"
+    } else {
+        "iex '& { $(irm https://github.com/ChrisTitusTech/winutil/releases/latest/download/winutil.ps1) } $argList'"
+    }
+
     $powershellcmd = if (Get-Command pwsh -ErrorAction SilentlyContinue) { "pwsh" } else { "powershell" }
     $processCmd = if (Get-Command wt.exe -ErrorAction SilentlyContinue) { "wt.exe" } else { $powershellcmd }
 

--- a/scripts/start.ps1
+++ b/scripts/start.ps1
@@ -28,12 +28,6 @@ if ($Run) {
     $PARAM_RUN = $true
 }
 
-$dateTime = Get-Date -Format "yyyy-MM-dd_HH-mm-ss"
-
-$logdir = "$env:localappdata\winutil\logs"
-[System.IO.Directory]::CreateDirectory("$logdir")
-Start-Transcript -Path "$logdir\winutil_$dateTime.log" -Append -NoClobber | Out-Null
-
 # Load DLLs
 Add-Type -AssemblyName PresentationFramework
 Add-Type -AssemblyName System.Windows.Forms
@@ -70,6 +64,12 @@ if (!([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]:
 
     break
 }
+
+$dateTime = Get-Date -Format "yyyy-MM-dd_HH-mm-ss"
+
+$logdir = "$env:localappdata\winutil\logs"
+[System.IO.Directory]::CreateDirectory("$logdir") | Out-Null
+Start-Transcript -Path "$logdir\winutil_$dateTime.log" -Append -NoClobber | Out-Null
 
 # Set PowerShell window title
 $Host.UI.RawUI.WindowTitle = $myInvocation.MyCommand.Definition + "(Admin)"

--- a/windev.ps1
+++ b/windev.ps1
@@ -14,8 +14,15 @@
 
 if (!([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
     Write-Output "Winutil needs to be run as Administrator. Attempting to relaunch."
+    # Capture all the arguments passed to the script
+    $argList = $args -join ' '
 
-    $script = if ($MyInvocation.MyCommand.Path) { "& '" + $MyInvocation.MyCommand.Path + "'" } else { "irm 'https://github.com/ChrisTitusTech/winutil/raw/main/windev.ps1' | iex"}
+    $script = if ($MyInvocation.MyCommand.Path) {
+        "& { & '$($MyInvocation.MyCommand.Path)' $argList }"
+    } else {
+        "iex '& { $(irm https://github.com/ChrisTitusTech/winutil/raw/main/windev.ps1) } $argList'"
+    }
+
     $powershellcmd = if (Get-Command pwsh -ErrorAction SilentlyContinue) { "pwsh" } else { "powershell" }
     $processCmd = if (Get-Command wt.exe -ErrorAction SilentlyContinue) { "wt.exe" } else { $powershellcmd }
 
@@ -46,9 +53,9 @@ function RedirectToLatestPreRelease {
         Write-Host "Using latest Full Release"
         $url = "https://github.com/ChrisTitusTech/winutil/releases/latest/download/winutil.ps1"
     }
-    Invoke-RestMethod $url | Invoke-Expression
+
+    iex "& { $(irm $url) } $argList"
 }
 
 # Call the redirect function
-
 RedirectToLatestPreRelease

--- a/xaml/inputXML.xaml
+++ b/xaml/inputXML.xaml
@@ -693,10 +693,10 @@
             </ToggleButton>
             <Grid Background="{MainBackgroundColor}" ShowGridLines="False" Width="Auto" Height="Auto" HorizontalAlignment="Stretch">
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*"/>
-                    <ColumnDefinition Width="*"/>
-                    <ColumnDefinition Width="50px"/>
-                    <ColumnDefinition Width="50px"/>
+                    <ColumnDefinition Width="*"/> <!-- Main content area -->
+                    <ColumnDefinition Width="Auto"/> <!-- Space for options button -->
+                    <ColumnDefinition Width="Auto"/> <!-- Space for close button -->
+                    <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
 
                 <!--
@@ -779,7 +779,7 @@
                     FontSize="{SettingsIconFontSize}"
                     Width="{IconButtonSize}" Height="{IconButtonSize}"
                     HorizontalAlignment="Right" VerticalAlignment="Top"
-                    Margin="0,5,0,0"
+                    Margin="5,5,5,0"
                     FontFamily="Segoe MDL2 Assets"
                     Content="&#xE713;"/>
                 <Popup Grid.Column="2" Name="SettingsPopup"

--- a/xaml/inputXML.xaml
+++ b/xaml/inputXML.xaml
@@ -987,7 +987,7 @@
                             <TextBlock Margin="6" Padding="1" TextWrapping="Wrap">Choose Windows SKU</TextBlock>
                             <ComboBox x:Name = "MicrowinWindowsFlavors" Margin="1" />
                             <Rectangle Fill="{MainForegroundColor}" Height="2" HorizontalAlignment="Stretch" Margin="0,10,0,10"/>
-                            <CheckBox Name="MicrowinInjectDrivers" Content="Inject drivers (I KNOW WHAT I'M DOING)" Margin="-10,5,0,0" IsChecked="False" ToolTip="Path to unpacked drivers all sys and inf files for devices that need drivers"/>
+                            <CheckBox Name="MicrowinInjectDrivers" Content="Inject drivers (I KNOW WHAT I'M DOING)" Margin="{CheckBoxMargin}" IsChecked="False" ToolTip="Path to unpacked drivers all sys and inf files for devices that need drivers"/>
                             <TextBox Name="MicrowinDriverLocation" Background="Transparent" BorderThickness="1" BorderBrush="{MainForegroundColor}"
                                 Margin="6"
                                 Text=""

--- a/xaml/inputXML.xaml
+++ b/xaml/inputXML.xaml
@@ -935,12 +935,12 @@
                         HorizontalAlignment="Stretch">
                     <StackPanel Name="MicrowinMain" Background="{MainBackgroundColor}" SnapsToDevicePixels="True" Grid.Column="0" Grid.Row="0">
                         <StackPanel Background="Transparent" SnapsToDevicePixels="True" Margin="1">
-                            <CheckBox x:Name="WPFMicrowinDownloadFromGitHub" Content="Download oscdimg.exe from CTT Github repo" IsChecked="False" Margin="{CheckBoxMargin}" />
+                            <CheckBox x:Name="WPFMicrowinDownloadFromGitHub" Content="Download oscdimg.exe from CTT Github repo" IsChecked="False" Margin="{MicrowinCheckBoxMargin}" />
                             <TextBlock Margin="5" Padding="1" TextWrapping="Wrap" Foreground="{ComboBoxForegroundColor}">
                                 Choose a Windows ISO file that you've downloaded <LineBreak/>
                                 Check the status in the console
                             </TextBlock>
-                            <CheckBox x:Name="WPFMicrowinISOScratchDir" Content="Use ISO directory for ScratchDir " IsChecked="False" Margin="{CheckBoxMargin}"
+                            <CheckBox x:Name="WPFMicrowinISOScratchDir" Content="Use ISO directory for ScratchDir " IsChecked="False" Margin="{MicrowinCheckBoxMargin}"
                                 ToolTip="Use ISO directory for ScratchDir " />
                             <Grid>
                             <Grid.ColumnDefinitions>
@@ -987,7 +987,7 @@
                             <TextBlock Margin="6" Padding="1" TextWrapping="Wrap">Choose Windows SKU</TextBlock>
                             <ComboBox x:Name = "MicrowinWindowsFlavors" Margin="1" />
                             <Rectangle Fill="{MainForegroundColor}" Height="2" HorizontalAlignment="Stretch" Margin="0,10,0,10"/>
-                            <CheckBox Name="MicrowinInjectDrivers" Content="Inject drivers (I KNOW WHAT I'M DOING)" Margin="{CheckBoxMargin}" IsChecked="False" ToolTip="Path to unpacked drivers all sys and inf files for devices that need drivers"/>
+                            <CheckBox Name="MicrowinInjectDrivers" Content="Inject drivers (I KNOW WHAT I'M DOING)" Margin="{MicrowinCheckBoxMargin}" IsChecked="False" ToolTip="Path to unpacked drivers all sys and inf files for devices that need drivers"/>
                             <TextBox Name="MicrowinDriverLocation" Background="Transparent" BorderThickness="1" BorderBrush="{MainForegroundColor}"
                                 Margin="6"
                                 Text=""
@@ -996,9 +996,9 @@
                                 Foreground="{LabelboxForegroundColor}"
                                 ToolTip="Path to unpacked drivers all sys and inf files for devices that need drivers"
                             />
-                            <CheckBox Name="MicrowinImportDrivers" Content="Import drivers from current system" Margin="{CheckBoxMargin}" IsChecked="False" ToolTip="Export all third-party drivers from your system and inject them to the MicroWin image"/>
+                            <CheckBox Name="MicrowinImportDrivers" Content="Import drivers from current system" Margin="{MicrowinCheckBoxMargin}" IsChecked="False" ToolTip="Export all third-party drivers from your system and inject them to the MicroWin image"/>
                             <Rectangle Fill="{MainForegroundColor}" Height="2" HorizontalAlignment="Stretch" Margin="0,10,0,10"/>
-                            <CheckBox Name="WPFMicrowinCopyToUsb" Content="Copy to Ventoy" Margin="{CheckBoxMargin}" IsChecked="False" ToolTip="Copy to USB disk with a label Ventoy"/>
+                            <CheckBox Name="WPFMicrowinCopyToUsb" Content="Copy to Ventoy" Margin="{MicrowinCheckBoxMargin}" IsChecked="False" ToolTip="Copy to USB disk with a label Ventoy"/>
                             <Rectangle Fill="{MainForegroundColor}" Height="2" HorizontalAlignment="Stretch" Margin="0,10,0,10"/>
                             <TextBlock Margin="6" Padding="1" TextWrapping="Wrap"><Bold>Custom user settings (leave empty for default user)</Bold></TextBlock>
                             <TextBlock Margin="6" Padding="1" TextWrapping="Wrap">User name (20 characters max.):</TextBlock>

--- a/xaml/inputXML.xaml
+++ b/xaml/inputXML.xaml
@@ -11,7 +11,7 @@
         WindowStyle="None"
         Width="Auto"
         Height="Auto"
-        MaxWidth="1380"
+        MaxWidth="1280"
         MaxHeight="800"
         Title="Chris Titus Tech's Windows Utility">
     <WindowChrome.WindowChrome>

--- a/xaml/inputXML.xaml
+++ b/xaml/inputXML.xaml
@@ -875,7 +875,7 @@
                             </Border>
                         </Grid>
                     </ScrollViewer>
-                    <Border Grid.Row="1" Background="{MainBackgroundColor}" BorderBrush="Gray" BorderThickness="1" CornerRadius="5" HorizontalAlignment="Stretch" Padding="10">
+                    <Border Grid.Row="1" Background="{MainBackgroundColor}" BorderBrush="{BorderColor}" BorderThickness="1" CornerRadius="5" HorizontalAlignment="Stretch" Padding="10">
                         <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" VerticalAlignment="Center" Grid.Column="0">
                             <Button Name="WPFTweaksbutton" Content="Run Tweaks" Margin="5"/>
                             <Button Name="WPFUndoall" Content="Undo Selected Tweaks" Margin="5"/>

--- a/xaml/inputXML.xaml
+++ b/xaml/inputXML.xaml
@@ -9,7 +9,11 @@
         WindowStartupLocation="CenterScreen"
         UseLayoutRounding="True"
         WindowStyle="None"
-        Title="Chris Titus Tech's Windows Utility" Height="800" Width="1280">
+        Width="Auto"
+        Height="Auto"
+        MaxWidth="1380"
+        MaxHeight="800"
+        Title="Chris Titus Tech's Windows Utility">
     <WindowChrome.WindowChrome>
         <WindowChrome CaptionHeight="0" CornerRadius="10"/>
     </WindowChrome.WindowChrome>
@@ -722,7 +726,8 @@
                     VerticalAlignment="Center" HorizontalAlignment="Left"
                     FontFamily="Segoe MDL2 Assets"
                     FontSize="{IconFontSize}"
-                    Margin="180,0,0,0">&#xE721;</TextBlock>
+                    Margin="180,0,0,0">&#xE721;
+                </TextBlock>
                 <!--
                   TODO:
                     Make this ClearButton Positioning react to
@@ -734,7 +739,8 @@
                     VerticalAlignment="Center" HorizontalAlignment="Left"
                     Name="SearchBarClearButton"
                     Style="{StaticResource SearchBarClearButtonStyle}"
-                    Margin="210,0,0,0" Visibility="Collapsed"/>
+                    Margin="210,0,0,0" Visibility="Collapsed">
+                </Button>
 
                 <ProgressBar
                     Grid.Column="1"
@@ -773,7 +779,7 @@
                     FontSize="{SettingsIconFontSize}"
                     Width="{IconButtonSize}" Height="{IconButtonSize}"
                     HorizontalAlignment="Right" VerticalAlignment="Top"
-                    Margin="0,5,5,0"
+                    Margin="0,5,0,0"
                     FontFamily="Segoe MDL2 Assets"
                     Content="&#xE713;"/>
                 <Popup Grid.Column="2" Name="SettingsPopup"
@@ -869,19 +875,11 @@
                             </Border>
                         </Grid>
                     </ScrollViewer>
-                    <Border Grid.Row="1" Background="{MainBackgroundColor}" BorderBrush="{BorderColor}" BorderThickness="1" CornerRadius="5" HorizontalAlignment="Stretch" Padding="10">
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="1*" />
-                                <ColumnDefinition Width="1*" />
-                            </Grid.ColumnDefinitions>
-
-                            <!-- Buttons on the left half -->
-                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" VerticalAlignment="Center" Grid.Column="0">
-                                <Button Name="WPFTweaksbutton" Content="Run Tweaks" Margin="5"/>
-                                <Button Name="WPFUndoall" Content="Undo Selected Tweaks" Margin="5"/>
-                            </StackPanel>
-                        </Grid>
+                    <Border Grid.Row="1" Background="{MainBackgroundColor}" BorderBrush="Gray" BorderThickness="1" CornerRadius="5" HorizontalAlignment="Stretch" Padding="10">
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" VerticalAlignment="Center" Grid.Column="0">
+                            <Button Name="WPFTweaksbutton" Content="Run Tweaks" Margin="5"/>
+                            <Button Name="WPFUndoall" Content="Undo Selected Tweaks" Margin="5"/>
+                        </StackPanel>
                     </Border>
                 </Grid>
             </TabItem>


### PR DESCRIPTION
# Pull Request

<!--Before you make this PR have you followed the docs here? - https://christitustech.github.io/winutil/contribute/ -->

## Refractor Fixes Correct Window handling

## Type of Change
- [x] Hotfix
- [x] UI/UX improvement

## Description
<!--[Provide a detailed explanation of the changes you have made. Include the reasons behind these changes and any relevant context. Link any related issues.]-->
- Add auto size handling of window, but with a max size cap, that will be removed once the window is shown so the user can resize the window as wished. Window should on run never be to big for the screen again.

- change fontsize back to something lower to display content of winutil correctly, it was only changed bc og-mrk's branch was a bit older, meaning it had older values.
- Added Custom Margin for Microwin Checkboxes because their label cuts off if used withnormal margin.
- fixed layouting of fixed tweaks buttons to not cut off in the center and truly work on a mobile resolution
- add args param for compile script, which passes args to winutil
- improve run action in compile script
- move logs to after admin elevation
- fix left nav side being to big and cutting stuff off:
![image](https://github.com/user-attachments/assets/b4818220-4f96-4b82-84dc-df621cc208dd)

- closes #2625 

## Testing
- tested, local tests worked.
- Did not test the argument passing using the one-liner! Will probs have to be tested on pre-release.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
