### PR TITLE
Simplify WinUtil Directory Creation in 'main.ps1' script

### DIFF
--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -450,9 +450,7 @@ $winutildir = @{}
 
 # Set the path for the winutil directory
 $winutildir["path"] = "$env:LOCALAPPDATA\winutil\"
-if (-NOT (Test-Path -Path $winutildir["path"])) {
-    New-Item -Path $winutildir["path"] -ItemType Directory
-}
+[System.IO.Directory]::CreateDirectory("$winutildir") | Out-Null
 
 # Set the path for the logo and checkmark images
 $winutildir["logo.png"] = $winutildir["path"] + "cttlogo.png"
@@ -460,7 +458,6 @@ $winutildir["logo.ico"] = $winutildir["path"] + "cttlogo.ico"
 if (-NOT (Test-Path -Path $winutildir["logo.png"])) {
     Invoke-WebRequest -Uri "https://christitus.com/images/logo-full.png" -OutFile $winutildir["logo.png"]
 }
-
 if (-NOT (Test-Path -Path $winutildir["logo.ico"])) {
     ConvertTo-Icon -bitmapPath $winutildir["logo.png"] -iconPath $winutildir["logo.ico"]
 }


### PR DESCRIPTION
## Type of Change
- [x] Hotfix

## Description
Simplify WinUtil Directory Creation in 'main.ps1' script by using C# 'CreateDirectory' Method which checks and creates the provided Directory Path

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
