### PR TITLE
Fix the configuration file import feature in the Invoke-WPFImpex function

### DIFF
--- a/functions/public/Invoke-WPFImpex.ps1
+++ b/functions/public/Invoke-WPFImpex.ps1
@@ -57,6 +57,7 @@ function Invoke-WPFImpex {
             }
         }
 
+        $flattenedJson = [string]$flattenedJson
         Invoke-WPFPresets -preset $flattenedJson -imported $true
     }
 }


### PR DESCRIPTION
# Pull Request

## Title
Fix the configuration file import feature in the Invoke-WPFImpex function

## Type of Change
- [x] Bug fix
- [x] UI/UX improvement

## Description
This PR addresses an issue with the `Invoke-WPFImpex` function in `winutil.ps1`.
Recent changes to `Invoke-WPFImpex` require explicit string conversion for the `$flattenedJson` parameter.
The conversion was previously handled implicitly, but it now needs to be explicitly converted to ensure correct processing.

## Testing
* Validated that the `$flattenedJson` parameter is now correctly processed as a string.
* Confirmed that configuration imports are successful with the updated function.

## Impact
* Ensures that the `$flattenedJson` parameter is handled correctly as a string, preventing errors during configuration imports.

## Issues related to PR
* Fixes #2657 

## Additional Information
* None.

## Screenshots
### Before Fix
![BeforeFix_1](https://github.com/user-attachments/assets/d83d15e6-5860-42c4-94be-972896762244)
![BeforeFix_2](https://github.com/user-attachments/assets/dfe489fe-a677-4130-80f2-a7eca405f1ab)

### After Fix
![AfterFix_1](https://github.com/user-attachments/assets/74990bbe-d279-44d8-91e6-c59d9de4004e)
![AfterFix_2](https://github.com/user-attachments/assets/edbe1299-f1a0-4e17-86e0-858e565ddd2d)

## Checklist
- [x] My code follows the project's coding and style guidelines.
- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.