### PR TITLE
[MicroWin] Don't disable already disabled features

### DIFF
--- a/functions/private/Invoke-WinUtilMicroWin-Helper.ps1
+++ b/functions/private/Invoke-WinUtilMicroWin-Helper.ps1
@@ -37,23 +37,24 @@ function Remove-Features() {
             Remove-Features
     #>
     try {
-        $featlist = (Get-WindowsOptionalFeature -Path $scratchDir).FeatureName
+        $featlist = (Get-WindowsOptionalFeature -Path $scratchDir)
 
         $featlist = $featlist | Where-Object {
-            $_ -NotLike "*Defender*" -AND
-            $_ -NotLike "*Printing*" -AND
-            $_ -NotLike "*TelnetClient*" -AND
-            $_ -NotLike "*PowerShell*" -AND
-            $_ -NotLike "*NetFx*" -AND
-            $_ -NotLike "*Media*" -AND
-            $_ -NotLike "*NFS*"
+            $_.FeatureName -NotLike "*Defender*" -AND
+            $_.FeatureName -NotLike "*Printing*" -AND
+            $_.FeatureName -NotLike "*TelnetClient*" -AND
+            $_.FeatureName -NotLike "*PowerShell*" -AND
+            $_.FeatureName -NotLike "*NetFx*" -AND
+            $_.FeatureName -NotLike "*Media*" -AND
+            $_.FeatureName -NotLike "*NFS*" -AND
+            $_.State -ne "Disabled"
         }
 
         foreach($feature in $featlist) {
-            $status = "Removing feature $feature"
+            $status = "Removing feature $($feature.FeatureName)"
             Write-Progress -Activity "Removing features" -Status $status -PercentComplete ($counter++/$featlist.Count*100)
-            Write-Debug "Removing feature $feature"
-            Disable-WindowsOptionalFeature -Path "$scratchDir" -FeatureName $feature -Remove  -ErrorAction SilentlyContinue -NoRestart
+            Write-Debug "Removing feature $($feature.FeatureName)"
+            Disable-WindowsOptionalFeature -Path "$scratchDir" -FeatureName $($feature.FeatureName) -Remove  -ErrorAction SilentlyContinue -NoRestart
         }
         Write-Progress -Activity "Removing features" -Status "Ready" -Completed
         Write-Host "You can re-enable the disabled features at any time, using either Windows Update or the SxS folder in <installation media>\Sources."


### PR DESCRIPTION
# Pull Request

## Type of Change
- [X] New feature

## Description
This PR excludes features that are already disabled in the image. It's nothing but a timesaver, especially for less powerful systems:

![powershell_ih7o6evZgx](https://github.com/user-attachments/assets/aa860d14-ecee-405c-9538-6d56135be07b)

**EDIT:** Some (raw) benchmarks of the latest version and the one with this change:

- Latest Version: 51:17.55
- This PR: 39:07.56

**The benchmarks were performed on a dual-core system, with a couple of applications running. The time taken was measured manually. These values are subject to change depending on your hardware or software configuration.**

## Testing
Testing was performed on a Windows 11 23H2 image and concluded with no issues. No differences were present across the current method and this one after grabbing the feature listings. Below are the actual differences of both reports:

![Code_DdMh48qRcv](https://github.com/user-attachments/assets/c7265a30-c5a1-4bfa-89cf-95d50a04cb8e)

- `experimental_features_report.md` contains feature listings of a Windows image after running a MicroWin experiment with package listings reversed, but with no changes to feature disablement
- `timesaver_features_report.md` contains feature listings of a Windows image after running this change

## Impact
Less time to be spent disabling features

## Issue related to PR
None

## Additional Information
No documentation changes were necessary, but please test this for any issues present that I may not know of

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no errors/warnings/merge conflicts.
