### PR TITLE
[fix compile] winutil used by another process

### DIFF
--- a/Compile.ps1
+++ b/Compile.ps1
@@ -5,7 +5,7 @@ param (
     [string]$Arguments
 )
 
-$getwinutil = (Get-Item ".\winutil.ps1") -ErrorAction SilentlyContinue
+$getwinutil = (Get-Item ".\winutil.ps1" -ErrorAction SilentlyContinue)
 if ($getwinutil.IsReadOnly) {
     Remove-Item ".\winutil.ps1" -Force
 }

--- a/Compile.ps1
+++ b/Compile.ps1
@@ -5,8 +5,7 @@ param (
     [string]$Arguments
 )
 
-$getwinutil = (Get-Item ".\winutil.ps1" -ErrorAction SilentlyContinue)
-if ($getwinutil.IsReadOnly) {
+if ((Get-Item ".\winutil.ps1" -ErrorAction SilentlyContinue).IsReadOnly) {
     Remove-Item ".\winutil.ps1" -Force
 }
 

--- a/Compile.ps1
+++ b/Compile.ps1
@@ -5,7 +5,8 @@ param (
     [string]$Arguments
 )
 
-if ((Get-Item ".\winutil.ps1").IsReadOnly) {
+$getwinutil = (Get-Item ".\winutil.ps1") -ErrorAction SilentlyContinue
+if ($getwinutil.IsReadOnly) {
     Remove-Item ".\winutil.ps1" -Force
 }
 

--- a/Compile.ps1
+++ b/Compile.ps1
@@ -4,6 +4,11 @@ param (
     [switch]$SkipPreprocessing,
     [string]$Arguments
 )
+
+if ((Get-Item ".\winutil.ps1").IsReadOnly) {
+    Remove-Item ".\winutil.ps1" -Force
+}
+
 $OFS = "`r`n"
 $scriptname = "winutil.ps1"
 $workingdir = $PSScriptRoot


### PR DESCRIPTION
# Pull Request

<!--Before you make this PR have you followed the docs here? - https://christitustech.github.io/winutil/contribute/ -->

## [fix compile] winutil used by another process

## Type of Change
- [x] Bug fix


## Description
<!--[Provide a detailed explanation of the changes you have made. Include the reasons behind these changes and any relevant context. Link any related issues.]-->
I am having the issue on some machines (where I sadly have to use onedrive) where onedrive process blocks the compile script from writing into winutil.ps1. But that happens at the end of the script meaning I am waiting for the compile to end just for it to error out on me after generating everything..
- remove winutil.ps1 if it is readonly (also works if another process is using it) to minimize failed compilations.

## Testing
<!--[Detail the testing you have performed to ensure that these changes function as intended. Include information about any added tests.]-->
- worked for me now

### Issue in question
![image](https://github.com/user-attachments/assets/3ccf3b94-e21b-4484-bcfb-26a698d9ea71)


## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
