### PR TITLE
Remove redundant options in the template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,4 @@
-# Pull Request
-
 <!--Before you make this PR have you followed the docs here? - https://christitustech.github.io/winutil/contribute/ -->
-
-## Title
-<!--[Provide a succinct and descriptive title for the pull request.]-->
 
 ## Type of Change
 - [ ] New feature


### PR DESCRIPTION
## Type of Change
- [x] Refactoring

## Description
Removes "Pull Request" and "Title" as both of them are redundant & the title is already specified when you make a pull request + their is no reason to have "Pull Request" at the top of the template IMO.

Duplicate of [#277](https://github.com/ChrisTitusTech/linutil/pull/277)

## Impact
Makes the template easier to work with when making a PR

## Checklist
- [x] My changes generate no errors/warnings/merge conflicts.