### PR TITLE
Add `-Force` flag for proper Hidden File detection in Invoke-Preprocessing

### DIFF
--- a/tools/Invoke-Preprocessing.ps1
+++ b/tools/Invoke-Preprocessing.ps1
@@ -77,7 +77,7 @@
         for ($i = 0; $i -lt $count; $i++) {
             $excludedFile = $ExcludedFiles[$i]
             $filePath = "$(($WorkingDir -replace ('\\$', '')) + '\' + ($excludedFile -replace ('\.\\', '')))"
-            if (-NOT (Get-ChildItem -Recurse -Path "$filePath" -File)) {
+            if (-NOT (Get-ChildItem -Recurse -Path "$filePath" -File -Force)) {
                 $failedFilesList += "'$filePath', "
             }
         }
@@ -87,7 +87,8 @@
         }
     }
 
-    $files = Get-ChildItem $WorkingDir -Recurse -Exclude $ExcludedFiles -File
+    $files = Get-ChildItem $WorkingDir -Recurse -Exclude $ExcludedFiles -File -Force
+
     $numOfFiles = $files.Count
 
     if ($numOfFiles -eq 0) {


### PR DESCRIPTION
# Pull Request

<!--Before you make this PR have you followed the docs here? - https://christitustech.github.io/winutil/contribute/ -->

## Title
Added the `-Force` flag to the `Get-ChildItem` functions called at lines 80 and 90. 
## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
This allows Preprocessing to properly detect hidden files in the directory. This prevents errors that I saw when running `Compile.ps1`, where the files .gitatrributes and .gitignore where not detected and caused `Compile.ps1` to exit.

## Testing
Tested compile before and after changes, and observed correct compilation behavior. 

## Impact
This should improve consistency with compiles across systems. 

## Issue related to PR
N/A

## Additional Information
N/A

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
