### PR TITLE
Correct for winget Google.GoogleDrive

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -797,7 +797,7 @@
         "content": "Google Drive",
         "description": "File syncing across devices all tied to your google account",
         "link": "https://www.google.com/drive/",
-        "winget": "Google.Drive"
+        "winget": "Google.GoogleDrive"
     },
     "gpuz": {
         "category": "Utilities",


### PR DESCRIPTION
Correct for winget Google.GoogleDrive

# Pull Request
## Title - Correct for winget `Google.GoogleDrive`

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Winget install Google.Drive is incorrect, it should be Google.GoogleDrive

## Issue related to PR
<!--[What issue/discussion is related to this PR (if any)]-->
- Resolves #2702 
