### PR TITLE
fix "ToLower" method invocation failure

### DIFF
--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -416,7 +416,7 @@ $sync["SearchBar"].Add_TextChanged({
         # Retrieve the corresponding text block based on the generated name
         $textBlock = $sync[$textBlockName]
 
-        if ($CheckBox.Value.Content.ToLower().Contains($textToSearch)) {
+        if ($CheckBox.Value.Content.ToString().ToLower().Contains($textToSearch)) {
             $CheckBox.Value.Visibility = "Visible"
             $activeApplications += $sync.configs.applications.$checkboxName
             # Set the corresponding text block visibility


### PR DESCRIPTION
## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [x] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Fixed the following error by casting the content to string:
InvalidOperation at line 14824 
if ($CheckBox.Value.Content.ToLower().Contains($textToSearch)
Error: Method invocation failed because [System.Windows.Controls.TextBlock] does not contain a method named 'ToLower'.

## Testing
Tested against the same input given to the release version on powershell version 7.4.5

## Impact
Fixes an error displayed in the powershell

## Issue related to PR
- Resolves #

## Additional Information

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
