### PR TITLE
Fix the way arguments are passed to the runspace

### DIFF
--- a/functions/public/Invoke-WPFInstall.ps1
+++ b/functions/public/Invoke-WPFInstall.ps1
@@ -20,7 +20,7 @@ function Invoke-WPFInstall {
         return
     }
     $ChocoPreference = $($sync.WPFpreferChocolatey.IsChecked)
-    Invoke-WPFRunspace -ArgumentList $PackagesToInstall,$ChocoPreference -DebugPreference $DebugPreference -ScriptBlock {
+    $installHandle = Invoke-WPFRunspace -ParameterList @(("PackagesToInstall", $PackagesToInstall),("ChocoPreference", $ChocoPreference)) -DebugPreference $DebugPreference -ScriptBlock {
         param($PackagesToInstall, $ChocoPreference, $DebugPreference)
         if ($PackagesToInstall.count -eq 1) {
             $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -state "Indeterminate" -value 0.01 -overlay "logo" })

--- a/functions/public/Invoke-WPFRunspace.ps1
+++ b/functions/public/Invoke-WPFRunspace.ps1
@@ -10,18 +10,24 @@ function Invoke-WPFRunspace {
 
     .PARAMETER ArgumentList
         A list of arguments to pass to the runspace
-
+    
+    .PARAMETER ParameterList
+        A list of named parameters that should be provided. 
     .EXAMPLE
         Invoke-WPFRunspace `
             -ScriptBlock $sync.ScriptsInstallPrograms `
             -ArgumentList "Installadvancedip,Installbitwarden" `
 
+        Invoke-WPFRunspace`
+            -ScriptBlock $sync.ScriptsInstallPrograms `
+            -ParameterList @(("PackagesToInstall", @("Installadvancedip,Installbitwarden")),("ChocoPreference", $true))
     #>
 
     [CmdletBinding()]
     Param (
         $ScriptBlock,
         $ArgumentList,
+        $ParameterList,
         $DebugPreference
     )
 
@@ -30,8 +36,10 @@ function Invoke-WPFRunspace {
 
     # Add Scriptblock and Arguments to runspace
     $script:powershell.AddScript($ScriptBlock)
-    foreach ($Argument in $ArgumentList) {
-        $script:powershell.AddArgument($Argument)
+    $script:powershell.AddArgument($ArgumentList)
+    
+    foreach ($parameter in $ParameterList){
+        $script:powershell.AddParameter($parameter[0], $parameter[1])
     }
     $script:powershell.AddArgument($DebugPreference)  # Pass DebugPreference to the script block
     $script:powershell.RunspacePool = $sync.runspace

--- a/functions/public/Invoke-WPFUnInstall.ps1
+++ b/functions/public/Invoke-WPFUnInstall.ps1
@@ -30,7 +30,7 @@ function Invoke-WPFUnInstall {
     if($confirm -eq "No") {return}
     $ChocoPreference = $($sync.WPFpreferChocolatey.IsChecked)
 
-    Invoke-WPFRunspace -ArgumentList $PackagesToInstall, $ChocoPreference -DebugPreference $DebugPreference -ScriptBlock {
+    Invoke-WPFRunspace -ArgumentList @(("PackagesToInstall", $PackagesToInstall),("ChocoPreference", $ChocoPreference)) -DebugPreference $DebugPreference -ScriptBlock {
         param($PackagesToInstall, $ChocoPreference, $DebugPreference)
         if ($PackagesToInstall.count -eq 1) {
             $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -state "Indeterminate" -value 0.01 -overlay "logo" })

--- a/functions/public/Invoke-WPFtweaksbutton.ps1
+++ b/functions/public/Invoke-WPFtweaksbutton.ps1
@@ -24,8 +24,12 @@ function Invoke-WPFtweaksbutton {
 
   Write-Debug "Number of tweaks to process: $($Tweaks.Count)"
 
-  Invoke-WPFRunspace -ArgumentList $Tweaks -DebugPreference $DebugPreference -ScriptBlock {
-    param($Tweaks, $DebugPreference)
+  # The leading "," in the ParameterList is nessecary because we only provide one argument and powershell cannot be convinced that we want a nested loop with only one argument otherwise
+  $tweaksHandle = Invoke-WPFRunspace -ParameterList @(,("tweaks",$tweaks)) -DebugPreference $DebugPreference -ScriptBlock {
+    param(
+      $tweaks,
+      $DebugPreference
+      )
     Write-Debug "Inside Number of tweaks to process: $($Tweaks.Count)"
 
     $sync.ProcessRunning = $true
@@ -38,8 +42,9 @@ function Invoke-WPFtweaksbutton {
     # Execute other selected tweaks
 
     for ($i = 0; $i -lt $Tweaks.Count; $i++) {
-      Set-WinUtilProgressBar -Label "Applying $($tweaks[$i])" -Percent ($i / $Tweaks.Count * 100)
-      Invoke-WinUtilTweaks $tweaks[$i]$sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -value ($i/$Tweaks.Count) })
+      Set-WinUtilProgressBar -Label "Applying $($tweaks[$i])" -Percent ($i / $tweaks.Count * 100)
+      Invoke-WinUtilTweaks $tweaks[$i]
+      $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -value ($i/$Tweaks.Count) })
     }
     Set-WinUtilProgressBar -Label "Tweaks finished" -Percent 100
     $sync.ProcessRunning = $false


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://christitustech.github.io/winutil/contribute/ -->

## Type of Change
- [x] Hotfix

## Description
This is my take on fixing the Runspace problem where the arguments would be interpreted as a string instead of a list and couldn't be distinguished between the parameters of the function.
I added a new -ParameterList option to provide the parameter Name as well as the content and reverted the -ArgumentList to the old logic for backwards compatibility


## Testing
I tested installs/uninstalls of programs and tweaks but not much else.

