### PR TITLE
Fix Ultimate Performance power plan deactivation

### DIFF
--- a/functions/public/Invoke-WPFUltimatePerformance.ps1
+++ b/functions/public/Invoke-WPFUltimatePerformance.ps1
@@ -50,14 +50,14 @@ Function Invoke-WPFUltimatePerformance {
 
         } elseif ($State -eq "Disable") {
             # Check if the Ultimate Performance plan is installed by GUID
-            $installedPlan = powercfg -list | Select-String -Pattern $ultimateGUID
+            $installedPlan = (powercfg -list | Select-String -Pattern "ChrisTitus - Ultimate Power Plan").Line.Split()[3]
 
             if ($installedPlan) {
                 # Extract the GUID of the installed Ultimate Performance plan
                 $ultimatePlanGUID = $installedPlan.Line.Split()[3]
 
                 # Set a different power plan as active before deleting the Ultimate Performance plan
-                $balancedPlanGUID = (powercfg -list | Select-String -Pattern "Balanced").Line.Split()[3]
+                $balancedPlanGUID = 381b4222-f694-41f0-9685-ff5bb260df2e
                 powercfg -setactive $balancedPlanGUID
 
                 # Delete the Ultimate Performance plan by GUID


### PR DESCRIPTION
Changes made:

- Modified the script to directly target the "ChrisTitus - Ultimate Power Plan" instead of using the general Ultimate Performance GUID for checking and deleting.

- Updated the code to use the specific GUID (381b4222-f694-41f0-9685-ff5bb260df2e) for the Balanced power plan, ensuring compatibility across different Windows languages.

- This change eliminates dependency on the localized name of the Balanced plan, making the script more robust in diverse language environments.