### PR TITLE
EP refresh

### DIFF
--- a/functions/private/Invoke-WinUtilDarkMode.ps1
+++ b/functions/private/Invoke-WinUtilDarkMode.ps1
@@ -21,6 +21,7 @@ Function Invoke-WinUtilDarkMode {
         $Path = "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Themes\Personalize"
         Set-ItemProperty -Path $Path -Name AppsUseLightTheme -Value $DarkMoveValue
         Set-ItemProperty -Path $Path -Name SystemUsesLightTheme -Value $DarkMoveValue
+        Invoke-WinUtilExplorerRefresh
     } catch [System.Security.SecurityException] {
         Write-Warning "Unable to set $Path\$Name to $Value due to a Security Exception"
     } catch [System.Management.Automation.ItemNotFoundException] {

--- a/functions/private/Invoke-WinUtilExplorerRefresh.ps1
+++ b/functions/private/Invoke-WinUtilExplorerRefresh.ps1
@@ -1,0 +1,33 @@
+function Invoke-WinUtilExplorerRefresh {
+    <#
+    .SYNOPSIS
+        Refreshes the Windows Explorer
+    #>
+
+    Invoke-WPFRunspace -DebugPreference $DebugPreference -ScriptBlock {
+        # Send the WM_SETTINGCHANGE message to all windows
+        Add-Type -TypeDefinition @"
+using System;
+using System.Runtime.InteropServices;
+public class Win32 {
+    [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = false)]
+    public static extern IntPtr SendMessageTimeout(
+        IntPtr hWnd,
+        uint Msg,
+        IntPtr wParam,
+        string lParam,
+        uint fuFlags,
+        uint uTimeout,
+        out IntPtr lpdwResult);
+}
+"@
+
+        $HWND_BROADCAST = [IntPtr]0xffff
+        $WM_SETTINGCHANGE = 0x1A
+        $SMTO_ABORTIFHUNG = 0x2
+        $timeout = 100
+
+        # Send the broadcast message to all windows
+        [Win32]::SendMessageTimeout($HWND_BROADCAST, $WM_SETTINGCHANGE, [IntPtr]::Zero, "ImmersiveColorSet", $SMTO_ABORTIFHUNG, $timeout, [ref]([IntPtr]::Zero))
+    }
+}


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://christitustech.github.io/winutil/contribute/ -->

## Type of Change
- [x] New feature

## Description
<!--[Provide a detailed explanation of the changes you have made. Include the reasons behind these changes and any relevant context. Link any related issues.]-->
Instead of restarting explorer, we could "refresh" it. For example when changing settings in the settings app it does not restart the explorer process, but still works fine. I am trying to recreate that.
- Added Explorer Refresh to Dark mode toggle
- This method does not work for heavyer stuff like window snapping, but I am passively searching for an alternative that works for everything (or atleast more)

## Testing
<!--[Detail the testing you have performed to ensure that these changes function as intended. Include information about any added tests.]-->
- test worked fine

## Additional Information
<!--[Any additional information that reviewers should be aware of.]-->
- reopening of #2616

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
