### PR TITLE
[MicroWin] Exclude Snip & Sketch from AppX removal

### DIFF
--- a/functions/private/Invoke-WinUtilMicroWin-Helper.ps1
+++ b/functions/private/Invoke-WinUtilMicroWin-Helper.ps1
@@ -165,7 +165,8 @@ function Remove-ProvisionedPackages() {
                 $_.PackageName -NotLike "*Paint*" -and
                 $_.PackageName -NotLike "*Gaming*" -and
                 $_.PackageName -NotLike "*Extension*" -and
-                $_.PackageName -NotLike "*SecHealthUI*"
+                $_.PackageName -NotLike "*SecHealthUI*" -and
+                $_.PackageName -NotLike "*ScreenSketch*"
         }
 
         $counter = 0


### PR DESCRIPTION
## Type of Change
- [X] Bug fix

## Description
This PR excludes Snipping Tool (Snip & Sketch on Windows 10) from AppX package listings to fix issues when pressing `Win + Shift + S` or to launch that app on command. Yes, even though there's ShareX for this (which is something I use as my main screenshot tool), some end users want a more "first-party" approach to making screenshots

## Testing
Testing concluded with no issues

## Impact
Restored missing functionality.

## Issue related to PR
- Resolves #2736

## Additional Information
No documentation changes are required

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no errors/warnings/merge conflicts.
