### PR TITLE
[MicroWin] Exclude Search Engine Package

### DIFF
--- a/functions/private/Invoke-WinUtilMicroWin-Helper.ps1
+++ b/functions/private/Invoke-WinUtilMicroWin-Helper.ps1
@@ -47,6 +47,7 @@ function Remove-Features() {
             $_.FeatureName -NotLike "*NetFx*" -AND
             $_.FeatureName -NotLike "*Media*" -AND
             $_.FeatureName -NotLike "*NFS*" -AND
+            $_.FeatureName -NotLike "*SearchEngine*" -AND
             $_.State -ne "Disabled"
         }
 


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://christitustech.github.io/winutil/contribute/ -->

## Type of Change
- [X] Bug fix

## Description
This PR excludes the Search Engine package from feature listings. This fixes issues people were experiencing where the Indexing Options control panel applet was not present.

Even though Windows Search is crap, it's no longer that crippled on MicroWin.

## Testing
Testing was performed on a Windows 11 23H2 image and concluded with no issues. ISO file sizes are the same.

## Impact
Less broken functionality out of the box

## Issue related to PR
- Resolves #2602

## Additional Information
No documentation changes were required. No UI changes were required either, so it should not cause any merge conflicts with the "mega-PR" (#2693)

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no errors/warnings/merge conflicts.
