### PR TITLE
Fix: Window Statechange on doubleclick works everywhere

### DIFF
--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -255,10 +255,9 @@ $sync["Form"].Add_MouseLeftButtonDown({
 })
 
 $sync["Form"].Add_MouseDoubleClick({
-    if ($sync["Form"].WindowState -eq [Windows.WindowState]::Normal) {
-        $sync["Form"].WindowState = [Windows.WindowState]::Maximized;
-    } else {
-        $sync["Form"].WindowState = [Windows.WindowState]::Normal;
+    if ($_.OriginalSource -is [System.Windows.Controls.Grid] -or
+        $_.OriginalSource -is [System.Windows.Controls.StackPanel]) {
+        $sync["Form"].WindowState = $sync["Form"].WindowState -eq [Windows.WindowState]::Normal ? [Windows.WindowState]::Maximized : [Windows.WindowState]::Normal
     }
 })
 


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://christitustech.github.io/winutil/contribute/ -->

## Type of Change

- [x] Bug fix

## Description
<!--[Provide a detailed explanation of the changes you have made. Include the reasons behind these changes and any relevant context. Link any related issues.]-->
This Binds the DoubleClick action only to StackPanel and Grid. 
Before, even when you double-clicked on a button or a text field, the window would toggle between fullscreen and windowed. 

## Testing
<!--[Detail the testing you have performed to ensure that these changes function as intended. Include information about any added tests.]-->
Tested locally on Win11 23H2

## Impact
<!--[Discuss the impact of your changes on the project. This might include effects on performance, new dependencies, or changes in behaviour.]-->
The Window wont behave irrationally anymore when double clicking on stuff

## Issue related to PR
<!--[What issue/discussion is related to this PR (if any)]-->
- Resolves #

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
