### PR TITLE
Fix Settings Variable Typo

### DIFF
--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -499,13 +499,13 @@ $sync["LightThemeMenuItem"].Add_Click({
 # Define event handler for button click
 $sync["SettingsButton"].Add_Click({
     Write-Debug "SettingsButton clicked"
-    if ($sync.Settings.IsOpen) {
-        $sync.Settings.IsOpen = $false
+    if ($sync.SettingsPopup.IsOpen) {
+        $sync.SettingsPopup.IsOpen = $false
     }
     else{
-        $sync.Settings.IsOpen = $true
+        $sync.SettingsPopup.IsOpen = $true
     }
-    $sync.Settings.IsOpen = $false
+    $sync.ThemePopup.IsOpen = $false
     $_.Handled = $false
 })
 


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://christitustech.github.io/winutil/contribute/ -->

## Type of Change
- [x] Bug fix

Fixes a Typo in two variables. So that the settings button does work again


## Issue related to PR
<!--[What issue/discussion is related to this PR (if any)]-->
- Resolves #2778
## Additional Information
<!--[Any additional information that reviewers should be aware of.]-->

