### PR TITLE
Reactively follow windows theme

### DIFF
--- a/functions/private/Invoke-WinUtilDarkMode.ps1
+++ b/functions/private/Invoke-WinUtilDarkMode.ps1
@@ -22,6 +22,10 @@ Function Invoke-WinUtilDarkMode {
         Set-ItemProperty -Path $Path -Name AppsUseLightTheme -Value $DarkMoveValue
         Set-ItemProperty -Path $Path -Name SystemUsesLightTheme -Value $DarkMoveValue
         Invoke-WinUtilExplorerRefresh
+        # Update Winutil Theme if the Theme Button shows the Icon for Auto
+        if ($sync.ThemeButton.Content -eq [char]0xF08C) {
+            Invoke-WinutilThemeChange -theme "Auto"
+        }
     } catch [System.Security.SecurityException] {
         Write-Warning "Unable to set $Path\$Name to $Value due to a Security Exception"
     } catch [System.Management.Automation.ItemNotFoundException] {


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://christitustech.github.io/winutil/contribute/ -->

## Type of Change
- [x] New feature
- [x] UI/UX improvement

## Description
<!--[Provide a detailed explanation of the changes you have made. Include the reasons behind these changes and any relevant context. Link any related issues.]-->
Listen to windows theme change events so that if a user changes from dark to light mode in the windows settings and also has the winutil theme set to auto, it updates instantly. 

Also update the Theme automatically if the setting is auto and the user activates the tweak to set windows to dark mode