### PR TITLE
Import Bugfix: Change Preset Type and contains check

### DIFF
--- a/functions/public/Invoke-WPFImpex.ps1
+++ b/functions/public/Invoke-WPFImpex.ps1
@@ -56,8 +56,7 @@ function Invoke-WPFImpex {
                 }
             }
         }
-
-        $flattenedJson = [string]$flattenedJson
+        
         Invoke-WPFPresets -preset $flattenedJson -imported $true
     }
 }

--- a/functions/public/Invoke-WPFPresets.ps1
+++ b/functions/public/Invoke-WPFPresets.ps1
@@ -17,7 +17,7 @@ function Invoke-WPFPresets {
 
     param (
         [Parameter(position=0)]
-        [string]$preset = "",
+        [Array]$preset = "",
 
         [Parameter(position=1)]
         [bool]$imported = $false,
@@ -51,7 +51,7 @@ function Invoke-WPFPresets {
         }
 
         # Check if the checkbox name exists in the flattened JSON hashtable
-        if ($CheckBoxesToCheck.Contains($checkboxName)) {
+        if ($CheckBoxesToCheck -contains $checkboxName) {
             # If it exists, set IsChecked to true
             $sync.$checkboxName.IsChecked = $true
             Write-Debug "$checkboxName is checked"


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://christitustech.github.io/winutil/contribute/ -->

## Type of Change

- [x] Bug fix

## Description
<!--[Provide a detailed explanation of the changes you have made. Include the reasons behind these changes and any relevant context. Link any related issues.]-->
When the Powershell Tweaks Import didn't work reliably because until now, all of the imported tweaks were stored as a long string and searched for a substring. This resulted in both powershell tweaks being selected because the Internal tweak names are quite similar. 
Now, all the tweaks are loaded as an array, and checked for an exact match to fix the issue

## Testing
<!--[Detail the testing you have performed to ensure that these changes function as intended. Include information about any added tests.]-->
Created an Export of Applications / Tweaks and Features, cleared all checkmarks, imported them and checked if they are the same


## Issue related to PR
<!--[What issue/discussion is related to this PR (if any)]-->
- Resolves #2772
