### PR TITLE
Fix windev.ps1 self-elevation and refactor the code

### DIFF
--- a/windev.ps1
+++ b/windev.ps1
@@ -62,12 +62,15 @@ function Get-WinUtilReleaseTag {
     return $ReleaseTag
 }
 
+# Get the latest release tag for the current WinUtil release from the repository source.
+$WinUtilReleaseTag = Get-WinUtilReleaseTag
+
 # Function to generate the download URL used to download the latest release of WinUtil.
 function Get-WinUtilReleaseURL {
     $WinUtilDownloadURL = if ($ReleaseTag -eq "latest") {
-        "https://github.com/ChrisTitusTech/winutil/releases/$($ReleaseTag)/download/winutil.ps1"
+        "https://github.com/ChrisTitusTech/winutil/releases/$($WinUtilReleaseTag)/download/winutil.ps1"
     } elseif ($PreRelease -or $StableRelease) {
-        "https://github.com/ChrisTitusTech/winutil/releases/download/$($ReleaseTag)/winutil.ps1"
+        "https://github.com/ChrisTitusTech/winutil/releases/download/$($WinUtilReleaseTag)/winutil.ps1"
     }
 
     return $WinUtilDownloadURL
@@ -140,10 +143,10 @@ function Start-LatestWinUtil {
     # Run the WinUtil script, relaunching it with administrator permissions when they are required.
     if (!$ProcessIsElevated) {
         Write-Host "WinUtil is not running as administrator. Relaunching with elevated permissions..." -ForegroundColor DarkCyan
-        Write-Host "Running the selected WinUtil release: Version '$($ReleaseTag)' from the source repository." -ForegroundColor Green
+        Write-Host "Running the selected WinUtil release: Version '$($WinUtilReleaseTag)' from the source repository." -ForegroundColor Green
         Start-Process $ProcessCommand -ArgumentList $WinUtilLaunchArguments -Wait -Verb RunAs
     } else {
-        Write-Host "Running the selected WinUtil release: Version '$($ReleaseTag)' from the source repository." -ForegroundColor Green
+        Write-Host "Running the selected WinUtil release: Version '$($WinUtilReleaseTag)' from the source repository." -ForegroundColor Green
         Start-Process $ProcessCommand -ArgumentList $WinUtilLaunchArguments -Wait
     }
 }
@@ -152,7 +155,7 @@ function Start-LatestWinUtil {
 try {
     Get-LatestWinUtil
 } catch {
-    Write-Host "An error occurred while downloading WinUtil release '$($ReleaseTag)': $_" -ForegroundColor Red
+    Write-Host "An error occurred while downloading WinUtil release '$($WinUtilReleaseTag)': $_" -ForegroundColor Red
     break
 }
 
@@ -161,7 +164,7 @@ try {
 try {
     Get-WinUtilUpdates
 } catch {
-    Write-Host "An error occurred while upgrading/downgrading WinUtil release '$($ReleaseTag)': $_" -ForegroundColor Red
+    Write-Host "An error occurred while upgrading/downgrading WinUtil release '$($WinUtilReleaseTag)': $_" -ForegroundColor Red
     break
 }
 
@@ -173,5 +176,5 @@ try {
         Start-LatestWinUtil
     }
 } catch {
-    Write-Host "An error occurred while launching WinUtil release '$($ReleaseTag)': $_" -ForegroundColor Red
+    Write-Host "An error occurred while launching WinUtil release '$($WinUtilReleaseTag)': $_" -ForegroundColor Red
 }

--- a/windev.ps1
+++ b/windev.ps1
@@ -1,55 +1,190 @@
 <#
 .SYNOPSIS
-    This Script is used as a target for the https://christitus.com/windev alias.
-    It queries the latest winget release (no matter if Pre-Release, Draft or Full Release) and invokes It
+    This script is used as a target for the https://christitus.com/windev alias.
+    It queries the latest WinUtil release (no matter if it's a Pre-Release, Draft, or Full Release) and runs it.
 .DESCRIPTION
-    This Script provides a simple way to always start the bleeding edge release even if it's not yet a full release.
-    This function should be run with administrative privileges.
-    Because this way of recursively invoking scripts via Invoke-Expression it might very well happen that AV Programs flag this because it's a common way of mulitstage exploits to run
+    This script provides a simple way to start the bleeding edge release even if it's not yet a full release.
+    This function can be run both with administrator and non-administrator permissions.
+    If it is not running as administrator, it will attempt to relaunch itself with administrator permissions.
+    The script no longer uses Invoke-Expression for its execution and now relies on Start-Process.
 .EXAMPLE
-    irm https://christitus.com/windev | iex
+    Run in PowerShell > irm https://christitus.com/windev | iex
     OR
-    Run in Admin Powershell >  ./windev.ps1
+    Run in PowerShell > .\windev.ps1
+    OR
+    Run in PowerShell > iex "& { $(irm https://christitus.com/windev) } <arguments>"
+    OR
+    Run in PowerShell > .\windev.ps1 <arguments>
+.NOTES
+    Below are some usage examples for running the script with arguments:
+    Run in PowerShell > iex "& { $(irm https://christitus.com/windev) } -Config 'C:\your\config\file\path\here'"
+    OR
+    Run in PowerShell > .\windev.ps1 -Config "C:\your\config\file\path\here"
+    OR
+    Run in PowerShell > iex "& { $(irm https://christitus.com/windev) } -Run -Config 'C:\your\config\file\path\here'"
+    OR
+    Run in PowerShell > .\windev.ps1 -Run -Config "C:\your\config\file\path\here"
 #>
 
-# Function to fetch the latest release tag from the GitHub API
-function Get-LatestRelease {
+# Speed up file download tasks by suppressing the progress output.
+$ProgressPreference = "SilentlyContinue"
+
+# Determine the current elevation status of the running process.
+$isElevated = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+
+# Query for the latest WinUtil releases from the source repository.
+try {
+    # Retrieve the list of WinUtil releases from the source repository.
+    $releases = Invoke-RestMethod 'https://api.github.com/repos/ChrisTitusTech/winutil/releases'
+
+    # Filter through WinUtil's releases and select the first stable release tag.
+    $stableRelease = $releases | Where-Object { $_.prerelease -eq $false } | Select-Object -First 1
+
+    # Filter through WinUtil's releases and select the first pre-release tag.
+    $preRelease = $releases | Where-Object { $_.prerelease -eq $true } | Select-Object -First 1
+
+    # If releases exist, set the release tag based on the first matching release.
+    if ($releases -and ($preRelease -or $stableRelease)) {
+        $releaseTag = if ($preRelease) { $preRelease.tag_name } elseif ($stableRelease) { $stableRelease.tag_name }
+    }
+
+    # If no releases exist, set the release tag to 'latest' and use it as a fallback.
+    if (!$releases -or !($preRelease -or $stableRelease)) {
+        $releaseTag = "latest"
+    }
+} catch {
+    Write-Host "An error occurred while downloading WinUtil's release metadata: $_`n" -ForegroundColor Red -NoNewline
+    break
+}
+
+# Function to generate the download URL used to download the latest release of WinUtil.
+function Get-WinUtilReleaseURL {
+    $url = if ($releaseTag -eq "latest") {
+        "https://github.com/ChrisTitusTech/winutil/releases/$($releaseTag)/download/winutil.ps1"
+    } elseif ($preRelease -or $stableRelease) {
+        "https://github.com/ChrisTitusTech/winutil/releases/download/$($releaseTag)/winutil.ps1"
+    }
+
+    return $url
+}
+
+# Function to check for and download any available updates to WinUtil from the source repository.
+function Get-WinUtilUpdates {
+    # Define the proxy parameters used to capture the values of $LatestReleaseURL and $WinUtilScriptPath.
+    param (
+        [Parameter()]
+        [string] $ProxyLatestReleaseURL,
+
+        [Parameter()]
+        [string] $ProxyWinUtilScriptPath
+    )
+
+    # Make a web request to the latest WinUtil release URL and store the raw script's content.
     try {
-        $releases = Invoke-RestMethod -Uri 'https://api.github.com/repos/ChrisTitusTech/winutil/releases'
-        $latestRelease = $releases | Where-Object {$_.prerelease -eq $true} | Select-Object -First 1
-        return $latestRelease.tag_name
+        $RawScriptContent = (Invoke-WebRequest $ProxyLatestReleaseURL -UseBasicParsing).RawContent
     } catch {
-        Write-Host "Error fetching release data: $_" -ForegroundColor Red
-        return $latestRelease.tag_name
+        Write-Host "An error occurred while getting the raw script content: $_`n" -ForegroundColor Red -NoNewline
+        break
+    }
+
+    # Extract and store the version numbers for both the remote WinUtil and local WinUtil script.
+    try {
+        $RemoteWinUtilVersion = ([regex]"\bVersion\s*:\s[\d.]+").Match($RawScriptContent).Value -replace ".*:\s", ""
+        $LocalWinUtilVersion = ([regex]"\bVersion\s*:\s[\d.]+").Match((Get-Content $ProxyWinUtilScriptPath)).Value -replace ".*:\s", ""
+    } catch {
+        Write-Host "An error occurred while extracting the version numbers: $_`n" -ForegroundColor Red -NoNewline
+        break
+    }
+
+    # Re-download WinUtil from the source repository if it has been upgraded since its last launch time.
+    if ([version]$RemoteWinUtilVersion -gt [version]$LocalWinUtilVersion) {
+        try {
+            Write-Host "WinUtil has been upgraded since the last time it was launched. Downloading '$($RemoteWinUtilVersion)'..." -ForegroundColor DarkYellow
+            Invoke-RestMethod $ProxyLatestReleaseURL -OutFile $ProxyWinUtilScriptPath
+        } catch {
+            Write-Host "An error occurred while upgrading WinUtil to '$($RemoteWinUtilVersion)': $_`n" -ForegroundColor Red -NoNewline
+            break
+        }
+    }
+
+    # Re-download WinUtil from the source repository if it has been downgraded since its last launch time.
+    if ([version]$RemoteWinUtilVersion -lt [version]$LocalWinUtilVersion) {
+        try {
+            Write-Host "WinUtil has been downgraded since the last time it was launched. Downloading '$($RemoteWinUtilVersion)'..." -ForegroundColor DarkYellow
+            Invoke-RestMethod $ProxyLatestReleaseURL -OutFile $ProxyWinUtilScriptPath
+        } catch {
+            Write-Host "An error occurred while downgrading WinUtil to '$($RemoteWinUtilVersion)': $_`n" -ForegroundColor Red -NoNewline
+            break
+        }
+    }
+
+    # Let the user know re-downloading WinUtil is skipped if the downloaded script is already up-to-date.
+    if ([version]$RemoteWinUtilVersion -eq [version]$LocalWinUtilVersion) {
+        Write-Host "WinUtil is already up-to-date with release: Version '$($RemoteWinUtilVersion)'. Skipped update check." -ForegroundColor Yellow
     }
 }
 
-# Function to redirect to the latest pre-release version
-function RedirectToLatestPreRelease {
-    $latestRelease = Get-LatestRelease
-    if ($latestRelease) {
-        $url = "https://github.com/ChrisTitusTech/winutil/releases/download/$latestRelease/winutil.ps1"
+# Function to download the latest release of WinUtil from the source repository.
+function Get-LatestWinUtil {
+    # Download and save the latest WinUtil release to $env:TEMP\winutil-dev.ps1 on the local disk.
+    $LatestReleaseURL = Get-WinUtilReleaseURL
+    $WinUtilScriptPath = Join-Path "$env:TEMP" "winutil-dev.ps1"
+
+    try {
+        if (!(Test-Path $WinUtilScriptPath)) {
+            Invoke-RestMethod $LatestReleaseURL -OutFile $WinUtilScriptPath
+        } else {
+            Get-WinUtilUpdates $LatestReleaseURL $WinUtilScriptPath
+        }
+    } catch {
+        Write-Host "An error occurred while downloading WinUtil release '$($releaseTag)': $_`n" -ForegroundColor Red -NoNewline
+        break
+    }
+}
+
+# Function to start the latest release of WinUtil from the source repository.
+function Start-LatestWinUtil {
+    param (
+        [Parameter(Mandatory = $false)]
+        [array]$argsList
+    )
+
+    # Create the file path pointing to $env:TEMP\winutil-dev.ps1 on the local disk.
+    $WinUtilScriptPath = Join-Path "$env:TEMP" "winutil-dev.ps1"
+
+    # Setup the commands used to launch WinUtil based on what is the preferred console software.
+    $powershellCmd = if (Get-Command pwsh.exe -ErrorAction SilentlyContinue) { "pwsh.exe" } else { "powershell.exe" }
+    $processCmd = if (Get-Command wt.exe -ErrorAction SilentlyContinue) { "wt.exe" } else { $powershellCmd }
+
+    # Setup the script's launch arguments based on what is used as preferred console software.
+    if ($processCmd -ne $powershellCmd) {
+        $WinUtilLaunchArguments = "$powershellCmd -ExecutionPolicy Bypass -NoProfile -File `"$WinUtilScriptPath`""
     } else {
-        Write-Host 'Unable to determine latest pre-release version.' -ForegroundColor Red
-        Write-Host "Using latest Full Release"
-        $url = "https://github.com/ChrisTitusTech/winutil/releases/latest/download/winutil.ps1"
+        $WinUtilLaunchArguments = "-ExecutionPolicy Bypass -NoProfile -File `"$WinUtilScriptPath`""
     }
 
-    $script = Invoke-RestMethod $url
-    # Elevate Shell if necessary
-    if (!([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
-        Write-Output "Winutil needs to be run as Administrator. Attempting to relaunch."
-
-        $powershellcmd = if (Get-Command pwsh -ErrorAction SilentlyContinue) { "pwsh" } else { "powershell" }
-        $processCmd = if (Get-Command wt.exe -ErrorAction SilentlyContinue) { "wt.exe" } else { $powershellcmd }
-
-        Start-Process $processCmd -ArgumentList "$powershellcmd -ExecutionPolicy Bypass -NoProfile -Command $(Invoke-Expression $script)" -Verb RunAs
+    # Append WinUtil's launch arguments from $argsList to the current arguments list if provided.
+    if ($argsList) {
+        $WinUtilLaunchArguments += " " + $($argsList -join " ")
     }
-    else{
-        Invoke-Expression $script
+
+    # Run the WinUtil script, relaunching it with administrator permissions when they are required.
+    if (!$isElevated) {
+        Write-Host "WinUtil is not running as administrator. Relaunching with elevated permissions..." -ForegroundColor DarkCyan
+        Write-Host "Running the selected WinUtil release: Version '$($releaseTag)' from the source repository." -ForegroundColor Green
+        Start-Process $processCmd -ArgumentList $WinUtilLaunchArguments -Wait -Verb RunAs
+    } else {
+        Write-Host "Running the selected WinUtil release: Version '$($releaseTag)' from the source repository." -ForegroundColor Green  
+        Start-Process $processCmd -ArgumentList $WinUtilLaunchArguments -Wait
     }
 }
 
-# Call the redirect function
+# Download the latest release of WinUtil from the source repository and launch it using Start-LatestWinUtil.
+Get-LatestWinUtil
 
-RedirectToLatestPreRelease
+# Start the latest WinUtil release from the source repository; supports WinUtil's arguments if they are provided.
+if ($args) {
+    Start-LatestWinUtil $args
+} else {
+    Start-LatestWinUtil
+}

--- a/windev.ps1
+++ b/windev.ps1
@@ -118,7 +118,7 @@ function Get-WinUtilUpdates {
 function Start-LatestWinUtil {
     param (
         [Parameter(Mandatory = $false)]
-        [array]$WinUtilArguments
+        [array]$WinUtilArgumentsList
     )
 
     # Setup the commands used to launch WinUtil based on the preferred console host.
@@ -127,24 +127,24 @@ function Start-LatestWinUtil {
 
     # Setup the script's launch arguments based on the preferred console host.
     if ($ProcessCommand -ne $PowerShellCommand) {
-        $WinUtilArgumentsList = "$PowerShellCommand -ExecutionPolicy Bypass -NoProfile -File `"$WinUtilScriptPath`""
+        $WinUtilLaunchArguments = "$PowerShellCommand -ExecutionPolicy Bypass -NoProfile -File `"$WinUtilScriptPath`""
     } else {
-        $WinUtilArgumentsList = "-ExecutionPolicy Bypass -NoProfile -File `"$WinUtilScriptPath`""
+        $WinUtilLaunchArguments = "-ExecutionPolicy Bypass -NoProfile -File `"$WinUtilScriptPath`""
     }
 
-    # Append WinUtil's launch arguments from $WinUtilArguments to the current arguments list if provided.
-    if ($WinUtilArguments) {
-        $WinUtilArgumentsList += " " + $($WinUtilArguments -join " ")
+    # Append WinUtil's launch arguments from $WinUtilArgumentsList to the current arguments list if provided.
+    if ($WinUtilArgumentsList) {
+        $WinUtilLaunchArguments += " " + $($WinUtilArgumentsList -join " ")
     }
 
     # Run the WinUtil script, relaunching it with administrator permissions when they are required.
     if (!$ProcessIsElevated) {
         Write-Host "WinUtil is not running as administrator. Relaunching with elevated permissions..." -ForegroundColor DarkCyan
         Write-Host "Running the selected WinUtil release: Version '$($ReleaseTag)' from the source repository." -ForegroundColor Green
-        Start-Process $ProcessCommand -ArgumentList $WinUtilArgumentsList -Wait -Verb RunAs
+        Start-Process $ProcessCommand -ArgumentList $WinUtilLaunchArguments -Wait -Verb RunAs
     } else {
         Write-Host "Running the selected WinUtil release: Version '$($ReleaseTag)' from the source repository." -ForegroundColor Green
-        Start-Process $ProcessCommand -ArgumentList $WinUtilArgumentsList -Wait
+        Start-Process $ProcessCommand -ArgumentList $WinUtilLaunchArguments -Wait
     }
 }
 


### PR DESCRIPTION
## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [x] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [x] UI/UX improvement

## Description

### Problem

WinUtil Dev currently doesn't launch correctly when run as a non-elevated user.
The following error occurs when running `irm https://christitus.com/windev | iex` without elevation:
![WinUtil Dev Launch Issue](https://github.com/user-attachments/assets/ffa327a2-00b0-465c-b548-6d2ca79fe5f6)

### Changes

#### Summary

- Updated `windev.ps1` to use `Invoke-RestMethod <url> -OutFile <file_path>` instead of using `Invoke-RestMethod` directly.
- Updated `windev.ps1` to use `Start-Process` instead of `Invoke-Expression` when launching the downloaded WinUtil script.
- Updated `windev.ps1` to no longer re-download WinUtil every time; now it only re-downloads when it has been updated.

## Testing

I conducted thorough testing using both local execution and remote execution.
For remote execution, I used npm's `http-server` package to serve the script's directory with the following command:
`http-server -c-1 C:\Users\#####\NoSync\Projects\Cryostrixx\forks\winutil\.staging\fix-admin-elevation`.

### Commands Used

#### Local Execution

**Command**: `.\windev.ps1`
**Result**: WinUtil launches successfully with no errors.
  ![WinUtil Local Command Test #1](https://github.com/user-attachments/assets/06f52bde-003a-40b8-b03d-8a4a2652d03f)

**Command**: `.\windev.ps1 -Config "C:\Users\#####\Documents\Configs\winutil.json"`
**Result**: WinUtil launches successfully and imports my config with no errors.
  ![WinUtil Local Command Test #2](https://github.com/user-attachments/assets/90849832-a1d9-4a1f-9fd8-9a824260a2fc)

#### Remote Execution

**Command**: `iex "& { $(irm http://127.0.0.1:4300/windev.ps1) }"`:
**Result**: WinUtil launches successfully with no errors.
  ![WinUtil Remote Command Test #1](https://github.com/user-attachments/assets/8be21308-7b63-4095-83d3-4ffeb76446bc)

**Command**: `iex "& { $(irm http://127.0.0.1:4300/windev.ps1) } -Config 'C:\Users\#####\Documents\Configs\winutil.json'"`
**Result**: WinUtil launches successfully and imports my config with no errors.
  ![WinUtil Remote Command Test #2](https://github.com/user-attachments/assets/b56c1301-9e62-4010-a9a4-e695aee2dcb1)

## Impact

- Revised the synopsis at the top of the script to clarify changes and provide basic usage examples.
- Implemented the `Get-WinUtilReleaseTag` function to return the latest matching release tag for WinUtil.
  - Supports both `stable` and `pre-release` tags, falling back to the `latest` tag when no releases are found.
- Implemented the `Get-WinUtilReleaseURL` function to return the download URL for the latest release of WinUtil.
  - Supports `stable` and `pre-release` URLs, and uses the `latest` release URL when no releases are found.
- Implemented the `Get-LatestWinUtil` function to download WinUtil to `winutil-dev.ps1` in the `$env:TEMP` directory.
- Implemented `Get-WinUtilUpdates` for intelligent updates, ensuring WinUtil is only downloaded when it receives updates.
- Implemented the `Start-LatestWinUtil` function for smoother launching of WinUtil using the appropriate process:
  - `Windows PowerShell/PowerShell Core running in Windows Terminal`.
  - `Windows PowerShell/PowerShell Core running as a standalone app`.
- Corrected the argument support to allow passing the arguments `-Run`, `-Config`, and `-Debug` correctly.

## Issues related to PR

- Fixes #2765

## Additional Information

Edited the screenshots to remove details like usernames and the `Prefer Chocolatey` toggle from the `Install` tab:
This was only done to keep the screenshots visually consistent; no features have been removed.
  
## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
