### PR TITLE
refac(invoke-wpfuninstall.ps1): remove null assignments and simplify taskbaritem invocation

### DIFF
--- a/functions/public/Invoke-WPFUnInstall.ps1
+++ b/functions/public/Invoke-WPFUnInstall.ps1
@@ -32,11 +32,10 @@ function Invoke-WPFUnInstall {
 
     Invoke-WPFRunspace -ArgumentList @(("PackagesToInstall", $PackagesToInstall),("ChocoPreference", $ChocoPreference)) -DebugPreference $DebugPreference -ScriptBlock {
         param($PackagesToInstall, $ChocoPreference, $DebugPreference)
-        if ($PackagesToInstall.count -eq 1) {
-            $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -state "Indeterminate" -value 0.01 -overlay "logo" })
-        } else {
-            $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -state "Normal" -value 0.01 -overlay "logo" })
-        }
+
+        $taskbarItemState = if ($PackagesToInstall.Count -eq 1) { "Indeterminate" } else { "Normal" }
+        $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -state $taskbarItemState -value 0.01 -overlay "logo" })
+
         $packagesWinget, $packagesChoco = {
             $packagesWinget = [System.Collections.ArrayList]::new()
             $packagesChoco = [System.Collections.ArrayList]::new()
@@ -47,7 +46,7 @@ function Invoke-WPFUnInstall {
                     $packagesWinget.add($package.winget)
                     Write-Host "Queueing $($package.winget) for Winget uninstall"
                 } else {
-                    $null = $packagesChoco.add($package.choco)
+                    $packagesChoco.add($package.choco)
                     Write-Host "Queueing $($package.choco) for Chocolatey uninstall"
                 }
             }
@@ -56,7 +55,7 @@ function Invoke-WPFUnInstall {
                     $packagesChoco.add($package.choco)
                     Write-Host "Queueing $($package.choco) for Chocolatey uninstall"
                 } else {
-                    $null = $packagesWinget.add($($package.winget))
+                    $packagesWinget.add($($package.winget))
                     Write-Host "Queueing $($package.winget) for Winget uninstall"
                 }
             }


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://christitustech.github.io/winutil/contribute/ -->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [x] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
<!--[Provide a detailed explanation of the changes you have made. Include the reasons behind these changes and any relevant context. Link any related issues.]-->
Refactor: functions/public/Invoke-WPFUnInstall.ps1
- Simplify code and make it shorter
- Remove unnecessary null assignments

## Testing
<!--[Detail the testing you have performed to ensure that these changes function as intended. Include information about any added tests.]-->
Not needed

## Impact
<!--[Discuss the impact of your changes on the project. This might include effects on performance, new dependencies, or changes in behaviour.]-->
Make code shorter and easier to read

## Issue related to PR
<!--[What issue/discussion is related to this PR (if any)]-->
- Resolves #

## Additional Information
<!--[Any additional information that reviewers should be aware of.]-->

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
