### PR TITLE
Fix WinUtil's self-elevation when running windev.ps1 without administrator

### DIFF
--- a/windev.ps1
+++ b/windev.ps1
@@ -82,6 +82,7 @@ $WinUtilScriptPath = Join-Path "$env:TEMP" "winutil.ps1"
 # Function to download the latest release of WinUtil from the releases page to the local disk.
 function Get-LatestWinUtil {
     if (!(Test-Path $WinUtilScriptPath)) {
+        Write-Host "WinUtil is not found. Downloading WinUtil '$($WinUtilReleaseTag)'..." -ForegroundColor DarkYellow
         Invoke-RestMethod $WinUtilReleaseURL -OutFile $WinUtilScriptPath
     }
 }

--- a/windev.ps1
+++ b/windev.ps1
@@ -98,14 +98,11 @@ function Get-WinUtilUpdates {
     $RemoteWinUtilVersion = (([regex]($VersionExtractionRegEx)).Match($RawWinUtilScript).Groups[2].Value)
     $LocalWinUtilVersion = (([regex]($VersionExtractionRegEx)).Match((Get-Content $WinUtilScriptPath)).Groups[2].Value)
 
-    # If WinUtil has been modified since the last time it was launched, download a fresh copy of the script.
+    # Check if WinUtil needs an update and either download a fresh copy or notify the user its already up-to-date.
     if ([version]$RemoteWinUtilVersion -ne [version]$LocalWinUtilVersion) {
         Write-Host "WinUtil is out-of-date. Downloading WinUtil '$($RemoteWinUtilVersion)'..." -ForegroundColor DarkYellow
         Invoke-RestMethod $WinUtilReleaseURL -OutFile $WinUtilScriptPath
-    }
-
-    # If WinUtil has not been modified, skip updating the script and let the user know it is already up-to-date.
-    if ([version]$RemoteWinUtilVersion -eq [version]$LocalWinUtilVersion) {
+    } else {
         Write-Host "WinUtil is already up-to-date. Skipped update checking." -ForegroundColor Yellow
     }
 }

--- a/windev.ps1
+++ b/windev.ps1
@@ -133,12 +133,12 @@ function Start-LatestWinUtil {
     }
 
     # If the WinUtil script is not running as administrator, relaunch the script with administrator permissions.
+    Write-Host "Running the selected WinUtil release: Version '$($WinUtilReleaseTag)'." -ForegroundColor Green
+
     if (!$ProcessIsElevated) {
         Write-Host "WinUtil is not running as administrator. Relaunching..." -ForegroundColor DarkCyan
-        Write-Host "Running the selected WinUtil release: Version '$($WinUtilReleaseTag)'." -ForegroundColor Green
         Start-Process $ProcessCommand -ArgumentList $WinUtilLaunchArguments -Wait -Verb RunAs
     } else {
-        Write-Host "Running the selected WinUtil release: Version '$($WinUtilReleaseTag)'." -ForegroundColor Green
         Start-Process $ProcessCommand -ArgumentList $WinUtilLaunchArguments -Wait
     }
 }

--- a/windev.ps1
+++ b/windev.ps1
@@ -121,10 +121,9 @@ function Start-LatestWinUtil {
     # Setup the script's launch arguments based on the presence of Windows Terminal or Windows PowerShell/PowerShell Core:
     # 1. Windows Terminal needs the name of the process to start ($PowerShellCommand) in addition to the launch arguments.
     # 2. Windows PowerShell and PowerShell Core can receive and use the launch arguments as is without extra modification.
+    $WinUtilLaunchArguments = "-ExecutionPolicy Bypass -NoProfile -File `"$WinUtilScriptPath`""
     if ($ProcessCommand -ne $PowerShellCommand) {
-        $WinUtilLaunchArguments = "$PowerShellCommand -ExecutionPolicy Bypass -NoProfile -File `"$WinUtilScriptPath`""
-    } else {
-        $WinUtilLaunchArguments = "-ExecutionPolicy Bypass -NoProfile -File `"$WinUtilScriptPath`""
+        $WinUtilLaunchArguments = "$PowerShellCommand $WinUtilLaunchArguments"
     }
 
     # If WinUtil's launch arguments are provided, append them to the end of the list of current launch arguments.

--- a/windev.ps1
+++ b/windev.ps1
@@ -17,6 +17,13 @@
     Run in PowerShell > .\windev.ps1 <arguments>
 #>
 
+# Define the arguments for the WinUtil script; enables argument auto-completion.
+param (
+    [switch]$Debug,
+    [string]$Config,
+    [switch]$Run
+)
+
 # Speed up download-related tasks by suppressing the output of Write-Progress.
 $ProgressPreference = "SilentlyContinue"
 

--- a/windev.ps1
+++ b/windev.ps1
@@ -133,12 +133,12 @@ function Start-LatestWinUtil {
     }
 
     # If the WinUtil script is not running as administrator, relaunch the script with administrator permissions.
-    Write-Host "Running the selected WinUtil release: Version '$($WinUtilReleaseTag)'." -ForegroundColor Green
-
     if (!$ProcessIsElevated) {
         Write-Host "WinUtil is not running as administrator. Relaunching..." -ForegroundColor DarkCyan
+        Write-Host "Running the selected WinUtil release: Version '$($WinUtilReleaseTag)'." -ForegroundColor Green
         Start-Process $ProcessCommand -ArgumentList $WinUtilLaunchArguments -Wait -Verb RunAs
     } else {
+        Write-Host "Running the selected WinUtil release: Version '$($WinUtilReleaseTag)'." -ForegroundColor Green
         Start-Process $ProcessCommand -ArgumentList $WinUtilLaunchArguments -Wait
     }
 }

--- a/windev.ps1
+++ b/windev.ps1
@@ -15,15 +15,6 @@
     Run in PowerShell > iex "& { $(irm https://christitus.com/windev) } <arguments>"
     OR
     Run in PowerShell > .\windev.ps1 <arguments>
-.NOTES
-    Below are some usage examples for running the script with arguments:
-    Run in PowerShell > iex "& { $(irm https://christitus.com/windev) } -Config 'C:\your\config\file\path\here'"
-    OR
-    Run in PowerShell > .\windev.ps1 -Config "C:\your\config\file\path\here"
-    OR
-    Run in PowerShell > iex "& { $(irm https://christitus.com/windev) } -Run -Config 'C:\your\config\file\path\here'"
-    OR
-    Run in PowerShell > .\windev.ps1 -Run -Config "C:\your\config\file\path\here"
 #>
 
 # Speed up download-related tasks by suppressing the output of Write-Progress.

--- a/windev.ps1
+++ b/windev.ps1
@@ -1,55 +1,184 @@
 <#
 .SYNOPSIS
-    This Script is used as a target for the https://christitus.com/windev alias.
-    It queries the latest winget release (no matter if Pre-Release, Draft or Full Release) and invokes It
+    This script is used as a target for the https://christitus.com/windev alias.
+    It queries the latest WinUtil release (no matter if it's a Pre-Release, Draft, or Full Release) and runs it.
 .DESCRIPTION
-    This Script provides a simple way to always start the bleeding edge release even if it's not yet a full release.
-    This function should be run with administrative privileges.
-    Because this way of recursively invoking scripts via Invoke-Expression it might very well happen that AV Programs flag this because it's a common way of mulitstage exploits to run
+    This script provides a simple way to start the bleeding edge release even if it's not yet a full release.
+    This function can be run both with administrator and non-administrator permissions.
+    If it is not running as administrator, it will attempt to relaunch itself with administrator permissions.
+    The script no longer uses Invoke-Expression for its execution and now relies on Start-Process.
 .EXAMPLE
-    irm https://christitus.com/windev | iex
+    Run in PowerShell > irm https://christitus.com/windev | iex
     OR
-    Run in Admin Powershell >  ./windev.ps1
+    Run in PowerShell > .\windev.ps1
+    OR
+    Run in PowerShell > iex "& { $(irm https://christitus.com/windev) } <arguments>"
+    OR
+    Run in PowerShell > .\windev.ps1 <arguments>
+.NOTES
+    Below are some usage examples for running the script with arguments:
+    Run in PowerShell > iex "& { $(irm https://christitus.com/windev) } -Config 'C:\your\config\file\path\here'"
+    OR
+    Run in PowerShell > .\windev.ps1 -Config "C:\your\config\file\path\here"
+    OR
+    Run in PowerShell > iex "& { $(irm https://christitus.com/windev) } -Run -Config 'C:\your\config\file\path\here'"
+    OR
+    Run in PowerShell > .\windev.ps1 -Run -Config "C:\your\config\file\path\here"
 #>
 
-# Function to fetch the latest release tag from the GitHub API
-function Get-LatestRelease {
+# Speed up download-related tasks by suppressing the output of Write-Progress.
+$ProgressPreference = "SilentlyContinue"
+
+# Determine whether or not the active process is currently running as administrator.
+$ProcessIsElevated = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+
+# Function to get the latest stable or pre-release tag from the repository's releases page.
+function Get-WinUtilReleaseTag {
+    # Retrieve the list of released versions from the repository's releases page.
     try {
-        $releases = Invoke-RestMethod -Uri 'https://api.github.com/repos/ChrisTitusTech/winutil/releases'
-        $latestRelease = $releases | Where-Object {$_.prerelease -eq $true} | Select-Object -First 1
-        return $latestRelease.tag_name
+        $ReleasesList = Invoke-RestMethod 'https://api.github.com/repos/ChrisTitusTech/winutil/releases'
     } catch {
-        Write-Host "Error fetching release data: $_" -ForegroundColor Red
-        return $latestRelease.tag_name
+        Write-Host "Error downloading WinUtil's releases list: $_" -ForegroundColor Red
+        break
     }
+
+    # Filter through the released versions and select the first matching stable version.
+    $StableRelease = $ReleasesList | Where-Object { $_.prerelease -eq $false } | Select-Object -First 1
+
+    # Filter through the released versions and select the first matching pre-release version.
+    $PreRelease = $ReleasesList | Where-Object { $_.prerelease -eq $true } | Select-Object -First 1
+
+    # If a stable or pre-release version is found, set the release tag to the returned version number.
+    if ($ReleasesList -and ($PreRelease -or $StableRelease)) {
+        $ReleaseTag = if ($PreRelease) {
+            $PreRelease.tag_name
+        } elseif ($StableRelease) {
+            $StableRelease.tag_name
+        }
+    }
+
+    # If no releases are found or a stable or pre-release doesn't exist default to using the 'latest' tag.
+    if (!$ReleasesList -or !($PreRelease -or $StableRelease)) {
+        $ReleaseTag = "latest"
+    }
+
+    # Return the release tag to facilitate the usage of the version number within other parts of the script.
+    return $ReleaseTag
 }
 
-# Function to redirect to the latest pre-release version
-function RedirectToLatestPreRelease {
-    $latestRelease = Get-LatestRelease
-    if ($latestRelease) {
-        $url = "https://github.com/ChrisTitusTech/winutil/releases/download/$latestRelease/winutil.ps1"
+# Get the latest stable or pre-release tag; falling back to the 'latest' release tag if no releases are found.
+$WinUtilReleaseTag = Get-WinUtilReleaseTag
+
+# Function to generate the URL used to download the latest release of WinUtil from the releases page.
+function Get-WinUtilReleaseURL {
+    $WinUtilDownloadURL = if ($WinUtilReleaseTag -eq "latest") {
+        "https://github.com/ChrisTitusTech/winutil/releases/$($WinUtilReleaseTag)/download/winutil.ps1"
     } else {
-        Write-Host 'Unable to determine latest pre-release version.' -ForegroundColor Red
-        Write-Host "Using latest Full Release"
-        $url = "https://github.com/ChrisTitusTech/winutil/releases/latest/download/winutil.ps1"
+        "https://github.com/ChrisTitusTech/winutil/releases/download/$($WinUtilReleaseTag)/winutil.ps1"
     }
 
-    $script = Invoke-RestMethod $url
-    # Elevate Shell if necessary
-    if (!([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
-        Write-Output "Winutil needs to be run as Administrator. Attempting to relaunch."
+    return $WinUtilDownloadURL
+}
 
-        $powershellcmd = if (Get-Command pwsh -ErrorAction SilentlyContinue) { "pwsh" } else { "powershell" }
-        $processCmd = if (Get-Command wt.exe -ErrorAction SilentlyContinue) { "wt.exe" } else { $powershellcmd }
+# Get the URL used to download the latest release of WinUtil from the releases page.
+$WinUtilReleaseURL = Get-WinUtilReleaseURL
 
-        Start-Process $processCmd -ArgumentList "$powershellcmd -ExecutionPolicy Bypass -NoProfile -Command $(Invoke-Expression $script)" -Verb RunAs
-    }
-    else{
-        Invoke-Expression $script
+# Create the file path that the latest WinUtil release will be downloaded to on the local disk.
+$WinUtilScriptPath = Join-Path "$env:TEMP" "winutil.ps1"
+
+# Function to download the latest release of WinUtil from the releases page to the local disk.
+function Get-LatestWinUtil {
+    if (!(Test-Path $WinUtilScriptPath)) {
+        Invoke-RestMethod $WinUtilReleaseURL -OutFile $WinUtilScriptPath
     }
 }
 
-# Call the redirect function
+# Function to check for any version changes to WinUtil, re-downloading the script if it has been upgraded/downgraded.
+function Get-WinUtilUpdates {
+    # Make a web request to the latest WinUtil release URL and store the script's raw code for processing.
+    $RawWinUtilScript = (Invoke-WebRequest $WinUtilReleaseURL -UseBasicParsing).RawContent
 
-RedirectToLatestPreRelease
+    # Match the 'Version:' header and replace it with an empty string, leaving the script's version number behind.
+    $RemoteWinUtilVersion = ([regex]"\bVersion\s*:\s[\d.]+").Match($RawWinUtilScript).Value -replace ".*:\s", ""
+    $LocalWinUtilVersion = ([regex]"\bVersion\s*:\s[\d.]+").Match((Get-Content $WinUtilScriptPath)).Value -replace ".*:\s", ""
+
+    # If WinUtil has been upgraded since the last time it has been launched, re-download the WinUtil script.
+    if ([version]$RemoteWinUtilVersion -gt [version]$LocalWinUtilVersion) {
+        Write-Host "WinUtil has been upgraded since the last time it was launched. Downloading '$($RemoteWinUtilVersion)'..." -ForegroundColor DarkYellow
+        Invoke-RestMethod $WinUtilReleaseURL -OutFile $WinUtilScriptPath
+    }
+
+    # If WinUtil has been downgraded since the last time it has been launched, re-download the WinUtil script.
+    if ([version]$RemoteWinUtilVersion -lt [version]$LocalWinUtilVersion) {
+        Write-Host "WinUtil has been downgraded since the last time it was launched. Downloading '$($RemoteWinUtilVersion)'..." -ForegroundColor DarkYellow
+        Invoke-RestMethod $WinUtilReleaseURL -OutFile $WinUtilScriptPath
+    }
+
+    # If WinUtil is already up-to-date, skip updating the script and let the user know it is already up-to-date. 
+    if ([version]$RemoteWinUtilVersion -eq [version]$LocalWinUtilVersion) {
+        Write-Host "WinUtil is already up-to-date. Skipped update checking." -ForegroundColor Yellow
+    }
+}
+
+# Function to start the latest release of WinUtil that was previously downloaded and saved to '$env:TEMP\winutil.ps1'.
+function Start-LatestWinUtil {
+    param (
+        [Parameter(Mandatory = $false)]
+        [array]$WinUtilArgumentsList
+    )
+
+    # Setup the commands used to launch WinUtil using Windows Terminal or Windows PowerShell/PowerShell Core.
+    $PowerShellCommand = if (Get-Command pwsh.exe -ErrorAction SilentlyContinue) { "pwsh.exe" } else { "powershell.exe" }
+    $ProcessCommand = if (Get-Command wt.exe -ErrorAction SilentlyContinue) { "wt.exe" } else { $PowerShellCommand }
+
+    # Setup the script's launch arguments based on the presence of Windows Terminal or Windows PowerShell/PowerShell Core:
+    # 1. Windows Terminal needs the name of the process to start ($PowerShellCommand) in addition to the launch arguments.
+    # 2. Windows PowerShell and PowerShell Core can receive and use the launch arguments as is without extra modification.
+    if ($ProcessCommand -ne $PowerShellCommand) {
+        $WinUtilLaunchArguments = "$PowerShellCommand -ExecutionPolicy Bypass -NoProfile -File `"$WinUtilScriptPath`""
+    } else {
+        $WinUtilLaunchArguments = "-ExecutionPolicy Bypass -NoProfile -File `"$WinUtilScriptPath`""
+    }
+
+    # If WinUtil's launch arguments are provided, append them to the end of the list of current launch arguments.
+    if ($WinUtilArgumentsList) {
+        $WinUtilLaunchArguments += " " + $($WinUtilArgumentsList -join " ")
+    }
+
+    # If the WinUtil script is not running as administrator, relaunch the script with administrator permissions.
+    if (!$ProcessIsElevated) {
+        Write-Host "WinUtil is not running as administrator. Relaunching..." -ForegroundColor DarkCyan
+        Write-Host "Running the selected WinUtil release: Version '$($WinUtilReleaseTag)'." -ForegroundColor Green
+        Start-Process $ProcessCommand -ArgumentList $WinUtilLaunchArguments -Wait -Verb RunAs
+    } else {
+        Write-Host "Running the selected WinUtil release: Version '$($WinUtilReleaseTag)'." -ForegroundColor Green
+        Start-Process $ProcessCommand -ArgumentList $WinUtilLaunchArguments -Wait
+    }
+}
+
+# If WinUtil has not already been downloaded, attempt to download it and save it to '$env:TEMP\winutil.ps1'.
+try {
+    Get-LatestWinUtil
+} catch {
+    Write-Host "Error downloading WinUtil '$($WinUtilReleaseTag)': $_" -ForegroundColor Red
+    break
+}
+
+# Attempt to check for WinUtil updates, if a version is released or removed this will re-download WinUtil.
+try {
+    Get-WinUtilUpdates
+} catch {
+    Write-Host "Error updating WinUtil '$($WinUtilReleaseTag)': $_" -ForegroundColor Red
+    break
+}
+
+# Attempt to start the latest release of WinUtil saved to the local disk; also supports WinUtil's arguments.
+try {
+    if ($args) {
+        Start-LatestWinUtil $args
+    } else {
+        Start-LatestWinUtil
+    }
+} catch {
+    Write-Host "Error launching WinUtil '$($WinUtilReleaseTag)': $_" -ForegroundColor Red
+}

--- a/windev.ps1
+++ b/windev.ps1
@@ -134,10 +134,10 @@ function Start-LatestWinUtil {
     if (!$ProcessIsElevated) {
         Write-Host "WinUtil is not running as administrator. Relaunching..." -ForegroundColor DarkCyan
         Write-Host "Running the selected WinUtil release: Version '$($WinUtilReleaseTag)'." -ForegroundColor Green
-        Start-Process $ProcessCommand -ArgumentList $WinUtilLaunchArguments -Wait -Verb RunAs
+        Start-Process $ProcessCommand -ArgumentList $WinUtilLaunchArguments -Verb RunAs
     } else {
         Write-Host "Running the selected WinUtil release: Version '$($WinUtilReleaseTag)'." -ForegroundColor Green
-        Start-Process $ProcessCommand -ArgumentList $WinUtilLaunchArguments -Wait
+        Start-Process $ProcessCommand -ArgumentList $WinUtilLaunchArguments
     }
 }
 


### PR DESCRIPTION
## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [x] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [x] UI/UX improvement

## Description

### Problem

WinUtil Dev currently doesn't launch correctly when run as a non-elevated user.
The following error occurs when running `irm https://christitus.com/windev | iex` without elevation:
![WinUtil Dev Launch Issue](https://github.com/user-attachments/assets/e967e887-2b5e-4dc8-881f-017e43bef02c)

### Changes

#### Summary

- Updated `windev.ps1` to use `Invoke-RestMethod <url> -OutFile <file_path>` instead of using `Invoke-RestMethod` directly.
- Updated `windev.ps1` to use `Start-Process` instead of `Invoke-Expression` when launching the downloaded WinUtil script.
- Updated `windev.ps1` to no longer re-download WinUtil every time; now it only re-downloads when releases are modified.

## Testing

I conducted thorough testing using both local execution and remote execution.
For remote execution, I used npm's `http-server` package to serve the script's directory with the following command:
`http-server -p 4300 -c-1 C:\Users\#####\NoSync\Projects\Cryostrixx\forks\winutil\.staging\fix-windev-admin-elevation`.

### Results

#### Local Execution

**Command**: `.\windev.ps1`
**Result**: WinUtil launches successfully with no errors.
![WinUtil Local Command Test - Without Arguments](https://github.com/user-attachments/assets/52acbf2e-43c4-4fcb-8432-1e3655bcf894)

**Command**: `.\windev.ps1 -Config "C:\Users\#####\Documents\Configs\winutil.json"`
**Result**: WinUtil launches successfully and imports my config with no errors.
![WinUtil Local Command Test - With Arguments](https://github.com/user-attachments/assets/0412666d-f0bb-4c0e-92cd-b72152d21225)

#### Remote Execution

**Command**: `iex "& { $(irm http://127.0.0.1:4300/windev.ps1) }"`:
**Result**: WinUtil launches successfully with no errors.
![WinUtil Remote Command Test - Without Arguments](https://github.com/user-attachments/assets/be70db9c-fcb5-4a88-941e-fa3f6ab3ca28)

**Command**: `iex "& { $(irm http://127.0.0.1:4300/windev.ps1) } -Config 'C:\Users\#####\Documents\Configs\winutil.json'"`
**Result**: WinUtil launches successfully and imports my config with no errors.
![WinUtil Remote Command Test - With Arguments](https://github.com/user-attachments/assets/deae2637-fcf6-442e-8eb7-a3fa9baefee2)

## Impact

- Revised the synopsis at the top of the script to clarify the changes made and provide basic usage examples.
- Implemented the `Get-WinUtilReleaseTag` function to return the latest matching tag for WinUtil.
  - Supports both `stable` and `pre-release` tags, falling back to the `latest` tag when no releases are found.
- Implemented the `Get-WinUtilReleaseURL` function to return the download URL for the latest release of WinUtil.
  - Supports `stable` and `pre-release` URLs, and uses the `latest` release URL when no releases are found.
- Implemented the `Get-LatestWinUtil` function to download WinUtil to `winutil.ps1` in the `$env:TEMP` directory.
- Implemented the `Get-WinUtilUpdates` function for updates, ensuring WinUtil is only re-downloaded when modified:
  - Supports upgrading WinUtil if the version of the remote script is newer than the version of the downloaded script.
  - Supports downgrading WinUtil if the version of the remote script is older than the version of the downloaded script.
- Implemented the `Start-LatestWinUtil` function for smoother launching of WinUtil using the appropriate process:
  - `Windows PowerShell/PowerShell Core running in Windows Terminal`.
  - `Windows PowerShell/PowerShell Core running as a standalone app`.
- Corrected the argument support to allow passing the arguments `-Run`, `-Config`, and `-Debug` correctly.

## Issues related to PR

- Fixes #2765

## Additional Information

None.

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
