### PR TITLE
Explicitly look for a Boolean Result

### DIFF
--- a/functions/public/Invoke-WPFUIElements.ps1
+++ b/functions/public/Invoke-WPFUIElements.ps1
@@ -292,7 +292,7 @@ function Invoke-WPFUIElements {
                         $checkBox.FontSize = $theme.FontSize
                         $checkBox.ToolTip = $entryInfo.Description
                         $checkBox.Margin = $theme.CheckBoxMargin
-                        if ($entryInfo.Checked) {
+                        if ($entryInfo.Checked -eq $true) {
                             $checkBox.IsChecked = $entryInfo.Checked
                         }
                         $horizontalStackPanel.Children.Add($checkBox) | Out-Null


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://christitustech.github.io/winutil/contribute/ -->

## Type of Change
- [x] Bug fix


## Description
<!--[Provide a detailed explanation of the changes you have made. Include the reasons behind these changes and any relevant context. Link any related issues.]-->
There was a Bug in the new function to build the UI where, when the option "Checked" was present, the Checkbox would always be checked, even if the value was "Checked" : "False"
Now it correctly differentiates between "True" and "False"

## Issue related to PR
<!--[What issue/discussion is related to this PR (if any)]-->
- Resolves #2689

## Additional Information
<!--[Any additional information that reviewers should be aware of.]-->
The technical Problem was, that "False" got parsed as a string, so 
`if ($checked)` would always return true because in Powershell this only checks if the variable is assigned. 

