### PR TITLE
Add dns0.eu

### DIFF
--- a/config/dns.json
+++ b/config/dns.json
@@ -46,5 +46,23 @@
         "Secondary": "94.140.15.16",
         "Primary6": "2a10:50c0::bad1:ff",
         "Secondary6": "2a10:50c0::bad2:ff"
+    },
+    "dns0.eu_Open":{
+        "Primary": "193.110.81.254",
+        "Secondary": "185.253.5.254",
+        "Primary6": "2a0f:fc80::ffff",
+        "Secondary6": "2a0f:fc81::ffff"
+    },
+    "dns0.eu_ZERO":{
+        "Primary": "193.110.81.9",
+        "Secondary": "185.253.5.9",
+        "Primary6": "2a0f:fc80::9",
+        "Secondary6": "2a0f:fc81::9"
+    },
+    "dns0.eu_KIDS":{
+        "Primary": "193.110.81.1",
+        "Secondary": "185.253.5.1",
+        "Primary6": "2a0f:fc80::1",
+        "Secondary6": "2a0f:fc81::1"
     }
 }

--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -3441,7 +3441,7 @@
     "panel": "1",
     "Order": "a040_",
     "Type": "Combobox",
-    "ComboItems": "Default DHCP Google Cloudflare Cloudflare_Malware Cloudflare_Malware_Adult Open_DNS Quad9 AdGuard_Ads_Trackers AdGuard_Ads_Trackers_Malware_Adult",
+    "ComboItems": "Default DHCP Google Cloudflare Cloudflare_Malware Cloudflare_Malware_Adult Open_DNS Quad9 AdGuard_Ads_Trackers AdGuard_Ads_Trackers_Malware_Adult dns0.eu_Open dns0.eu_ZERO dns0.eu_KIDS",
     "link": "https://christitustech.github.io/winutil/dev/tweaks/z--Advanced-Tweaks---CAUTION/changedns"
   },
   "WPFAddUltPerf": {


### PR DESCRIPTION
## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Added dns0.eu, a European public DNS service.
https://www.dns0.eu/

## Testing
- Successfully compiled using Compile.ps1 without issues.
- Ran winutil.ps1 and was able to select and change the DNS settings.
- Verified the settings in Windows.
- Tested on Windows 11 IoT Enterprise LTSC 24H2.

## Impact
- Additional DNS Options: This change adds more flexibility for users by providing an additional public DNS service.
- Regional Benefits: Specifically beneficial for users in European regions, offering a geographically closer DNS service.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
