### PR TITLE
Use here-strings for JSON in Compile.ps1

### DIFF
--- a/Compile.ps1
+++ b/Compile.ps1
@@ -85,6 +85,7 @@ Get-ChildItem "config" | Where-Object {$psitem.extension -eq ".json"} | ForEach-
         }
     }
 
+    # Line 90 requires no whitespace inside the here-strings, to keep formatting of the JSON in the final script.
     $json = @"
 $($jsonAsObject | ConvertTo-Json -Depth 3)
 "@

--- a/Compile.ps1
+++ b/Compile.ps1
@@ -73,8 +73,10 @@ Get-ChildItem "functions" -Recurse -File | ForEach-Object {
     }
 Update-Progress "Adding: Config *.json" 40
 Get-ChildItem "config" | Where-Object {$psitem.extension -eq ".json"} | ForEach-Object {
-    $json = (Get-Content $psitem.FullName).replace("'","''")
-    $jsonAsObject = $json | convertfrom-json
+    $json = @"
+        $((Get-Content $psitem.FullName -Raw).replace("'","''"))
+"@
+    $jsonAsObject = $json | ConvertFrom-Json
 
     # Add 'WPFInstall' as a prefix to every entry-name in 'applications.json' file
     if ($psitem.Name -eq "applications.json") {
@@ -85,12 +87,12 @@ Get-ChildItem "config" | Where-Object {$psitem.extension -eq ".json"} | ForEach-
         }
     }
 
-    # The replace at the end is required, as without it the output of 'converto-json' will be somewhat weird for Multiline Strings
-    # Most Notably is the scripts in some json files, making it harder for users who want to review these scripts, which're found in the compiled script
-    $json = ($jsonAsObject | convertto-json -Depth 3).replace('\r\n',"`r`n")
+    $json = @"
+        $($jsonAsObject | ConvertTo-Json -Depth 3)
+"@
 
-    $sync.configs.$($psitem.BaseName) = $json | convertfrom-json
-    $script_content.Add($(Write-output "`$sync.configs.$($psitem.BaseName) = '$json' `| convertfrom-json" ))
+    $sync.configs.$($psitem.BaseName) = $json | ConvertFrom-Json
+    $script_content.Add($(Write-Output "`$sync.configs.$($psitem.BaseName) = '$json' `| ConvertFrom-Json" ))
 }
 
 # Read the entire XAML file as a single string, preserving line breaks

--- a/Compile.ps1
+++ b/Compile.ps1
@@ -73,9 +73,7 @@ Get-ChildItem "functions" -Recurse -File | ForEach-Object {
     }
 Update-Progress "Adding: Config *.json" 40
 Get-ChildItem "config" | Where-Object {$psitem.extension -eq ".json"} | ForEach-Object {
-    $json = @"
-        $((Get-Content $psitem.FullName -Raw).replace("'","''"))
-"@
+    $json = (Get-Content $psitem.FullName -Raw)
     $jsonAsObject = $json | ConvertFrom-Json
 
     # Add 'WPFInstall' as a prefix to every entry-name in 'applications.json' file
@@ -88,11 +86,11 @@ Get-ChildItem "config" | Where-Object {$psitem.extension -eq ".json"} | ForEach-
     }
 
     $json = @"
-        $($jsonAsObject | ConvertTo-Json -Depth 3)
+$($jsonAsObject | ConvertTo-Json -Depth 3)
 "@
 
     $sync.configs.$($psitem.BaseName) = $json | ConvertFrom-Json
-    $script_content.Add($(Write-Output "`$sync.configs.$($psitem.BaseName) = '$json' `| ConvertFrom-Json" ))
+    $script_content.Add($(Write-Output "`$sync.configs.$($psitem.BaseName) = @'`n$json`n'@ `| ConvertFrom-Json" ))
 }
 
 # Read the entire XAML file as a single string, preserving line breaks


### PR DESCRIPTION
**NOTE: I recommend going through my commits to see the changes I made over time, to better understand why I coded things the way I did.**

Change Compile.ps1 to use here-strings with JSON.

## Type of Change
- [x] Refactoring

## Description
This modifies the Compile.ps1 script's handling of JSON to use here-strings and `-Raw`, similar to what we do with Xaml. This allows us to forego the replace when we `ConvertTo-Json -Depth 3`.

There are a couple formatting to CamelCasing changes for consistency, as well. 

## Testing
Tested the Compile in pwsh and powershell (pulled in changes from @og-mrk for Pre-processing for testing in PS5.)

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no errors/warnings/merge conflicts.
