### PR TITLE
Fix: Resolve ms-edge policy errors by removing invalid policies

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -1602,13 +1602,6 @@
       },
       {
         "Path": "HKLM:\\SOFTWARE\\Policies\\Microsoft\\Edge",
-        "Name": "EdgeEnhanceImagesEnabled",
-        "Type": "DWord",
-        "Value": "0",
-        "OriginalValue": "1"
-      },
-      {
-        "Path": "HKLM:\\SOFTWARE\\Policies\\Microsoft\\Edge",
         "Name": "PersonalizationReportingEnabled",
         "Type": "DWord",
         "Value": "0",
@@ -1652,13 +1645,6 @@
       {
         "Path": "HKLM:\\SOFTWARE\\Policies\\Microsoft\\Edge",
         "Name": "EdgeCollectionsEnabled",
-        "Type": "DWord",
-        "Value": "0",
-        "OriginalValue": "1"
-      },
-      {
-        "Path": "HKLM:\\SOFTWARE\\Policies\\Microsoft\\Edge",
-        "Name": "EdgeFollowEnabled",
         "Type": "DWord",
         "Value": "0",
         "OriginalValue": "1"


### PR DESCRIPTION
## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Removed ms-edge polices which were causing "unknown policy" errors.

## Testing
- Successfully compiled using Compile.ps1 without issues.
- Ran winutil.ps1 and was able to select and execute the tweak "Debloat Edge".
- Verified the settings in ms-edge (edge://policy/).
- Tested on ms-edge 129 on Windows 11 IoT Enterprise LTSC 24H2 (x64).

## Impact
- Removed EdgeEnhanceImagesEnabled policy.
- Removed EdgeFollowEnabled policy.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
