### PR TITLE
Fix WinUtil's self-elevation when running winutil.ps1 without administrator

### DIFF
--- a/scripts/start.ps1
+++ b/scripts/start.ps1
@@ -62,9 +62,7 @@ $downloadURL = "https://github.com/ChrisTitusTech/winutil/releases/latest/downlo
 # Download the WinUtil script to '$env:TEMP'
 try {
     Write-Host "Downloading latest stable WinUtil version..." -ForegroundColor Green
-    $ProgressPreference = "SilentlyContinue"
     Invoke-RestMethod $downloadURL -OutFile "$env:TEMP\winutil.ps1"
-    $ProgressPreference = "Continue"
 } catch {
     Write-Host "Error downloading WinUtil: $_" -ForegroundColor Red
     break
@@ -86,7 +84,7 @@ try {
         Write-Host "WinUtil is not running as administrator. Relaunching..." -ForegroundColor DarkCyan
         Start-Process $processCmd -ArgumentList $launchArguments -Verb RunAs
     } else {
-        Write-Host "Running the latest stable version of WinUtil." -ForegroundColor Green
+        Write-Host "Running the latest stable version of WinUtil." -ForegroundColor DarkCyan
         Start-Process $processCmd -ArgumentList $launchArguments
     }
     break

--- a/scripts/start.ps1
+++ b/scripts/start.ps1
@@ -6,6 +6,7 @@
     Version        : #{replaceme}
 #>
 
+# Define the arguments for the WinUtil script
 param (
     [switch]$Debug,
     [string]$Config,
@@ -17,12 +18,13 @@ if ($Debug) {
     $DebugPreference = "Continue"
 }
 
+# Handle the -Config parameter
 if ($Config) {
     $PARAM_CONFIG = $Config
 }
 
-$PARAM_RUN = $false
 # Handle the -Run switch
+$PARAM_RUN = $false
 if ($Run) {
     Write-Host "Running config file tasks..."
     $PARAM_RUN = $true
@@ -39,38 +41,66 @@ $sync.version = "#{replaceme}"
 $sync.configs = @{}
 $sync.ProcessRunning = $false
 
-if (!([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
-    Write-Output "Winutil needs to be run as Administrator. Attempting to relaunch."
-    $argList = @()
+# Store elevation status of the process
+$isElevated = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
 
-    $PSBoundParameters.GetEnumerator() | ForEach-Object {
-        $argList += if ($_.Value -is [switch] -and $_.Value) {
-            "-$($_.Key)"
-        } elseif ($_.Value) {
-            "-$($_.Key) `"$($_.Value)`""
-        }
+# Initialize the arguments list array
+$argsList = @()
+
+# Add the passed parameters to $argsList
+$PSBoundParameters.GetEnumerator() | ForEach-Object {
+    $argsList += if ($_.Value -is [switch] -and $_.Value) {
+        "-$($_.Key)"
+    } elseif ($_.Value) {
+        "-$($_.Key) `"$($_.Value)`""
     }
+}
 
-    $script = if ($MyInvocation.MyCommand.Path) {
-        "& { & '$($MyInvocation.MyCommand.Path)' $argList }"
-    } else {
-        "iex '& { $(irm https://github.com/ChrisTitusTech/winutil/releases/latest/download/winutil.ps1) } $argList'"
-    }
+# Set the download URL for the latest release
+$downloadURL = "https://github.com/ChrisTitusTech/winutil/releases/latest/download/winutil.ps1"
 
-    $powershellcmd = if (Get-Command pwsh -ErrorAction SilentlyContinue) { "pwsh" } else { "powershell" }
-    $processCmd = if (Get-Command wt.exe -ErrorAction SilentlyContinue) { "wt.exe" } else { $powershellcmd }
-
-    Start-Process $processCmd -ArgumentList "$powershellcmd -ExecutionPolicy Bypass -NoProfile -Command $script" -Verb RunAs
-
+# Download the WinUtil script to '$env:TEMP'
+try {
+    Write-Host "Downloading latest stable WinUtil version..." -ForegroundColor Green
+    $ProgressPreference = "SilentlyContinue"
+    Invoke-RestMethod $downloadURL -OutFile "$env:TEMP\winutil.ps1"
+    $ProgressPreference = "Continue"
+} catch {
+    Write-Host "Error downloading WinUtil: $_" -ForegroundColor Red
     break
 }
 
-$dateTime = Get-Date -Format "yyyy-MM-dd_HH-mm-ss"
+# Setup the commands used to launch the script
+$powershellCmd = if (Get-Command pwsh -ErrorAction SilentlyContinue) { "pwsh.exe" } else { "powershell.exe" }
+$processCmd = if (Get-Command wt.exe -ErrorAction SilentlyContinue) { "wt.exe" } else { $powershellCmd }
 
+# Setup the script's launch arguments
+$launchArguments = "-ExecutionPolicy Bypass -NoProfile -File `"$env:TEMP\winutil.ps1`" $argsList"
+if ($processCmd -ne $powershellCmd) {
+    $launchArguments = "$powershellCmd $launchArguments"
+}
+
+# Relaunch the script as administrator if necessary
+try {
+    if (!$isElevated) {
+        Write-Host "WinUtil is not running as administrator. Relaunching..." -ForegroundColor DarkCyan
+        Start-Process $processCmd -ArgumentList $launchArguments -Verb RunAs
+    } else {
+        Write-Host "Running the latest stable version of WinUtil." -ForegroundColor Green
+        Start-Process $processCmd -ArgumentList $launchArguments
+    }
+    break
+} catch {
+    Write-Host "Error launching WinUtil: $_" -ForegroundColor Red
+    break
+}
+
+# Start WinUtil transcript logging
+$dateTime = Get-Date -Format "yyyy-MM-dd_HH-mm-ss"
 $logdir = "$env:localappdata\winutil\logs"
 [System.IO.Directory]::CreateDirectory("$logdir") | Out-Null
 Start-Transcript -Path "$logdir\winutil_$dateTime.log" -Append -NoClobber | Out-Null
 
 # Set PowerShell window title
-$Host.UI.RawUI.WindowTitle = $myInvocation.MyCommand.Definition + "(Admin)"
-clear-host
+$Host.UI.RawUI.WindowTitle = $MyInvocation.MyCommand.Definition + "(Admin)"
+Clear-Host


### PR DESCRIPTION
## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [x] UI/UX improvement

## Description

### Problem

WinUtil Stable currently doesn't launch correctly when run as a non-elevated user.
The following error occurs when running `irm https://christitus.com/win | iex` without elevation:
![WinUtil Stable Launch Issue](https://github.com/user-attachments/assets/c79e28a0-8846-4f2d-9f11-2352e9e98f83)

### Changes

#### Summary

- Updated `scripts\start.ps1` to use `Invoke-RestMethod <url> -OutFile <file_path>` instead of `Invoke-RestMethod <url>`.
- Updated `scripts\start.ps1` to fix the `Start-Process` command; it will now handle the launch arguments correctly for:
  - `Windows Terminal`
  - `Windows PowerShell`
  - `PowerShell Core`

## Testing

I conducted thorough testing using both local execution and remote execution.
For remote execution, I used npm's `http-server` package to serve the script's directory with the following command:
`http-server -p 4300 -c-1 C:\Users\#####\NoSync\Projects\Cryostrixx\forks\winutil`.

### Results

#### Local Execution

**Command**: `.\winutil.ps1`
**Result**: WinUtil launches successfully with no errors.
![WinUtil Local Command Test - Without Arguments](https://github.com/user-attachments/assets/ceb47f5e-3a8d-4b75-bd53-8bb9a05fd617)

**Command**: `.\winutil.ps1 -Config "C:\Users\#####\Documents\Configs\winutil.json"`
**Result**: WinUtil launches successfully and imports my config with no errors.
![WinUtil Local Command Test - With Arguments](https://github.com/user-attachments/assets/843edf26-d98f-4b1e-9e76-4e813744b69f)

#### Remote Execution

**Command**: `iex "& { $(irm http://127.0.0.1:4300/winutil.ps1) }"`:
**Result**: WinUtil launches successfully with no errors.
![WinUtil Remote Command Test - Without Arguments](https://github.com/user-attachments/assets/2f3b931a-1389-49da-9c75-4d83dcda28af)

**Command**: `iex "& { $(irm http://127.0.0.1:4300/winutil.ps1) } -Config 'C:\Users\#####\Documents\Configs\winutil.json'"`
**Result**: WinUtil launches successfully and imports my config with no errors.
![WinUtil Remote Command Test - With Arguments](https://github.com/user-attachments/assets/badd2a53-9d5c-4a1b-a63c-a592510128d0)

## Impact

- Corrected the launch arguments handling to facilitate smoother launching of WinUtil using the appropriate process:
  - `Windows PowerShell/PowerShell Core running in Windows Terminal`.
  - `Windows PowerShell/PowerShell Core running as a standalone app`.
- Corrected the launch arguments handling to allow passing the arguments `-Run`, `-Config`, and `-Debug` correctly.

## Issues related to PR

- Fixes #2812

## Additional Information

None.

## Checklist

- [x] My code adheres to the project's coding and style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
