### PR TITLE
Add logic to remove Registry Keys via Tweaks

### DIFF
--- a/functions/private/Set-WinUtilRegistry.ps1
+++ b/functions/private/Set-WinUtilRegistry.ps1
@@ -36,7 +36,12 @@ function Set-WinUtilRegistry {
         }
 
         Write-Host "Set $Path\$Name to $Value"
-        Set-ItemProperty -Path $Path -Name $Name -Type $Type -Value $Value -Force -ErrorAction Stop | Out-Null
+        if ($Value -ne "<RemoveEntry>"){
+            Set-ItemProperty -Path $Path -Name $Name -Type $Type -Value $Value -Force -ErrorAction Stop | Out-Null
+        }
+        else{
+            Remove-ItemProperty -Path $Path -Name $Name -Force -ErrorAction Stop | Out-Null
+        }
     } catch [System.Security.SecurityException] {
         Write-Warning "Unable to set $Path\$Name to $Value due to a Security Exception"
     } catch [System.Management.Automation.ItemNotFoundException] {


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://christitustech.github.io/winutil/contribute/ -->

## Type of Change
- [x] New feature

## Description
<!--[Provide a detailed explanation of the changes you have made. Include the reasons behind these changes and any relevant context. Link any related issues.]-->

Adds the option to specify "<RemoveEntry>" as a Registry Value in the tweaks.json registry definition. 
When this is provided, the value will be fully removed instead of simply being set to a specific value.

## Testing
Tested this on a demo Tweak and it seemed to work. 

## Impact
<!--[Discuss the impact of your changes on the project. This might include effects on performance, new dependencies, or changes in behaviour.]-->
This should not affect anything except when the Registry value is explicitly set to <RemoveEntry>

## Issue related to PR
<!--[What issue/discussion is related to this PR (if any)]-->
- Resolves #2821

## Additional Information
<!--[Any additional information that reviewers should be aware of.]-->
@MyDrift-user I have no clue where to put this in the documentation. Maybe you can give me a hint on where to mention this "feature"

