### PR TITLE
Hotfix feature.json

### DIFF
--- a/config/feature.json
+++ b/config/feature.json
@@ -321,5 +321,5 @@
     "Order": "a084_",
     "Type": "Button",
     "ButtonWidth": "300"
-  },
+  }
 }


### PR DESCRIPTION
Stray comma at the end of line 324, causing compiling issue in Powershell 5.

## Type of Change
- [x] Bug fix
- [x] Hotfix

## Description
Since JSON handling is different between Powershell 5 and Powershell 7. You only notice the error during Compiling on Powershell 5.

## Testing
Debugged and tested compile in Powershell 5 and 7.

## Issue related to PR
Fixes #2864 

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no errors/warnings/merge conflicts.
