### PR TITLE
Fix typo in Remove-Packages

### DIFF
--- a/functions/private/Invoke-WinUtilMicroWin-Helper.ps1
+++ b/functions/private/Invoke-WinUtilMicroWin-Helper.ps1
@@ -121,7 +121,7 @@ function Remove-Packages {
 
         $pkglist = $pkglist | Where-Object {
                 $_ -NotLike "*ApplicationModel*" -AND
-                $_ -NotLike "*indows-Client-LanguagePack*" -AND
+                $_ -NotLike "*Windows-Client-LanguagePack*" -AND
                 $_ -NotLike "*LanguageFeatures-Basic*" -AND
                 $_ -NotLike "*Package_for_ServicingStack*" -AND
                 $_ -NotLike "*.NET*" -AND


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://christitustech.github.io/winutil/contribute/ -->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [x] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Fix typo in Remove-Packages function: `"*indows-Client-LanguagePack*"` instead of `"*Windows-Client-LanguagePack*"`
