### PR TITLE
fix: missing `-AND` and inconsistent formatting

### DIFF
--- a/functions/private/Invoke-WinUtilMicroWin-Helper.ps1
+++ b/functions/private/Invoke-WinUtilMicroWin-Helper.ps1
@@ -240,19 +240,19 @@ function Remove-ProvisionedPackages() {
     {
         $appxProvisionedPackages = Get-AppxProvisionedPackage -Path "$($scratchDir)" | Where-Object {
                 $_.PackageName -NotLike "*AppInstaller*" -AND
-                $_.PackageName -NotLike "*Store*" -and
-                $_.PackageName -NotLike "*Notepad*" -and
-                $_.PackageName -NotLike "*Printing*" -and
-                $_.PackageName -NotLike "*YourPhone*" -and
-                $_.PackageName -NotLike "*Xbox*" -and
-                $_.PackageName -NotLike "*WindowsTerminal*" -and
-                $_.PackageName -NotLike "*Calculator*" -and
-                $_.PackageName -NotLike "*Photos*" -and
-                $_.PackageName -NotLike "*VCLibs*" -and
-                $_.PackageName -NotLike "*Paint*" -and
-                $_.PackageName -NotLike "*Gaming*" -and
-                $_.PackageName -NotLike "*Extension*" -and
-                $_.PackageName -NotLike "*SecHealthUI*" -and
+                $_.PackageName -NotLike "*Store*" -AND
+                $_.PackageName -NotLike "*Notepad*" -AND
+                $_.PackageName -NotLike "*Printing*" -AND
+                $_.PackageName -NotLike "*YourPhone*" -AND
+                $_.PackageName -NotLike "*Xbox*" -AND
+                $_.PackageName -NotLike "*WindowsTerminal*" -AND
+                $_.PackageName -NotLike "*Calculator*" -AND
+                $_.PackageName -NotLike "*Photos*" -AND
+                $_.PackageName -NotLike "*VCLibs*" -AND
+                $_.PackageName -NotLike "*Paint*" -AND
+                $_.PackageName -NotLike "*Gaming*" -AND
+                $_.PackageName -NotLike "*Extension*" -AND
+                $_.PackageName -NotLike "*SecHealthUI*" -AND
                 $_.PackageName -NotLike "*ScreenSketch*"
         }
 

--- a/functions/private/Invoke-WinUtilMicroWin-Helper.ps1
+++ b/functions/private/Invoke-WinUtilMicroWin-Helper.ps1
@@ -140,7 +140,7 @@ function Remove-Packages {
                 $_ -NotLike "*.NET*" -AND
                 $_ -NotLike "*Store*" -AND
                 $_ -NotLike "*VCLibs*" -AND
-                $_ -NotLike "*AAD.BrokerPlugin",
+                $_ -NotLike "*AAD.BrokerPlugin" -AND
                 $_ -NotLike "*LockApp*" -AND
                 $_ -NotLike "*Notepad*" -AND
                 $_ -NotLike "*immersivecontrolpanel*" -AND


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://christitustech.github.io/winutil/contribute/ -->

## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [X] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
<!--[Provide a detailed explanation of the changes you have made. Include the reasons behind these changes and any relevant context. Link any related issues.]-->

This pull request fix a missing `-AND` and make make the formatting of all `-AND` consistent

## Testing
<!--[Detail the testing you have performed to ensure that these changes function as intended. Include information about any added tests.]-->

None needed

## Impact
<!--[Discuss the impact of your changes on the project. This might include effects on performance, new dependencies, or changes in behaviour.]-->

Minor

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [X] I have performed a self-review of my own code.
- [X] My changes generate no errors/warnings/merge conflicts.