### PR TITLE
Fix WinUtil admin elevation for stable and pre-release builds

### DIFF
--- a/scripts/start.ps1
+++ b/scripts/start.ps1
@@ -79,7 +79,12 @@ if ($processCmd -ne $powershellCmd) {
 }
 
 # Set the title of the running PowerShell instance
-$BaseWindowTitle = $MyInvocation.MyCommand.Path ?? $MyInvocation.MyCommand.Definition
+$BaseWindowTitle = if ($MyInvocation.MyCommand.Path) {
+    $MyInvocation.MyCommand.Path
+} else {
+    $MyInvocation.MyCommand.Definition
+}
+
 $Host.UI.RawUI.WindowTitle = if ($isElevated) {
     $BaseWindowTitle + " (Admin)"
 } else {
@@ -100,7 +105,8 @@ try {
     break
 }
 
-# Start WinUtil transcript logging-mm-ss"
+# Start WinUtil transcript logging
+$dateTime = Get-Date -Format "yyyy-MM-dd_HH-mm-ss"
 $logdir = "$env:localappdata\winutil\logs"
 [System.IO.Directory]::CreateDirectory("$logdir") | Out-Null
 Start-Transcript -Path "$logdir\winutil_$dateTime.log" -Append -NoClobber | Out-Null

--- a/scripts/start.ps1
+++ b/scripts/start.ps1
@@ -78,16 +78,14 @@ if ($processCmd -ne $powershellCmd) {
     $launchArguments = "$powershellCmd $launchArguments"
 }
 
-# Store the script's directory in $CurrentDirectory
-# Note: This is not used with -WorkingDirectory but
-# is used in the PowerShell instance's window title.
+# Store the script's directory; used in the fallback window title
 $CurrentDirectory = if ($MyInvocation.MyCommand.Path) {
     "$($MyInvocation.MyCommand.Path)"
 } elseif ($PSScriptRoot) {
     "$($PSScriptRoot)"
 } elseif ($PWD) { "$PWD" }
 
-# Create the base titles used for naming the instance
+# Create the fallback and base window titles used in the window title
 $FallbackWindowTitle = "$CurrentDirectory\winutil.ps1"
 $BaseWindowTitle = if ($MyInvocation.MyCommand.Path) {
     $MyInvocation.MyCommand.Path
@@ -95,7 +93,7 @@ $BaseWindowTitle = if ($MyInvocation.MyCommand.Path) {
     $MyInvocation.MyCommand.Definition
 }
 
-# Prepend (User) or (Admin) prefix to the window title
+# Add elevation status prefix to the beginning of the window title
 try {
     $Host.UI.RawUI.WindowTitle = if (!$isElevated) {
         "(User) " + $BaseWindowTitle
@@ -104,9 +102,9 @@ try {
     }
 } catch {
     $Host.UI.RawUI.WindowTitle = if (!$isElevated) {
-        "(User) $FallbackWindowTitle"
+        "(User) " + $FallbackWindowTitle
     } else {
-        "(Admin) $FallbackWindowTitle"
+        "(Admin) " + $FallbackWindowTitle
     }
 }
 

--- a/scripts/start.ps1
+++ b/scripts/start.ps1
@@ -78,19 +78,17 @@ if ($processCmd -ne $powershellCmd) {
     $launchArguments = "$powershellCmd $launchArguments"
 }
 
-# Store the script's directory in $ScriptDirectory
+# Store the script's directory in $CurrentDirectory
 # Note: This is not used with -WorkingDirectory but
 # is used in the PowerShell instance's window title.
-if ($MyInvocation.MyCommand.Path) {
-    $ScriptDirectory = "$(Split-Path $MyInvocation.MyCommand.Path)"
+$CurrentDirectory = if ($MyInvocation.MyCommand.Path) {
+    "$($MyInvocation.MyCommand.Path)"
 } elseif ($PSScriptRoot) {
-    $ScriptDirectory = "$($PSScriptRoot)"
-} else {
-    $ScriptDirectory = "$($PWD)"
-}
+    "$($PSScriptRoot)"
+} elseif ($PWD) { "$PWD" }
 
 # Create the base titles used for naming the instance
-$FallbackWindowTitle = "$ScriptDirectory\winutil.ps1"
+$FallbackWindowTitle = "$CurrentDirectory\winutil.ps1"
 $BaseWindowTitle = if ($MyInvocation.MyCommand.Path) {
     $MyInvocation.MyCommand.Path
 } else {
@@ -99,16 +97,16 @@ $BaseWindowTitle = if ($MyInvocation.MyCommand.Path) {
 
 # Prepend (User) or (Admin) prefix to the window title
 try {
-    $Host.UI.RawUI.WindowTitle = if ($isElevated) {
-        "(Admin) " + $BaseWindowTitle
-    } else {
+    $Host.UI.RawUI.WindowTitle = if (!$isElevated) {
         "(User) " + $BaseWindowTitle
+    } else {
+        "(Admin) " + $BaseWindowTitle
     }
 } catch {
-    $Host.UI.RawUI.WindowTitle = if ($isElevated) {
-        "(Admin) $FallbackWindowTitle"
-    } else {
+    $Host.UI.RawUI.WindowTitle = if (!$isElevated) {
         "(User) $FallbackWindowTitle"
+    } else {
+        "(Admin) $FallbackWindowTitle"
     }
 }
 

--- a/scripts/start.ps1
+++ b/scripts/start.ps1
@@ -97,18 +97,18 @@ $BaseWindowTitle = if ($MyInvocation.MyCommand.Path) {
     $MyInvocation.MyCommand.Definition
 }
 
-# Append (User) or (Admin) prefix to the window title
+# Prepend (User) or (Admin) prefix to the window title
 try {
     $Host.UI.RawUI.WindowTitle = if ($isElevated) {
-        $BaseWindowTitle + " (Admin)"
+        "(Admin) " + $BaseWindowTitle
     } else {
-        $BaseWindowTitle + " (User)"
+        "(User) " + $BaseWindowTitle
     }
 } catch {
     $Host.UI.RawUI.WindowTitle = if ($isElevated) {
-        "$FallbackWindowTitle (Admin)"
+        "(Admin) $FallbackWindowTitle"
     } else {
-        "$FallbackWindowTitle (User)"
+        "(User) $FallbackWindowTitle"
     }
 }
 

--- a/windev.ps1
+++ b/windev.ps1
@@ -24,6 +24,18 @@ param (
     [switch]$Run
 )
 
+# Create a new arguments array; this will be used to store WinUtil's passed arguments.
+$WinUtilArgumentsList = @()
+
+# Loop over the arguments passed to WinUtil and append them to the arguments array.
+$PSBoundParameters.GetEnumerator() | ForEach-Object {
+    $WinUtilArgumentsList += if ($_.Value -is [switch] -and $_.Value) {
+        "-$($_.Key)"
+    } elseif ($_.Value) {
+        "-$($_.Key) `"$($_.Value)`""
+    }
+}
+
 # Speed up download-related tasks by suppressing the output of Write-Progress.
 $ProgressPreference = "SilentlyContinue"
 
@@ -108,11 +120,6 @@ function Get-WinUtilUpdates {
 
 # Function to start the latest release of WinUtil that was previously downloaded and saved to '$env:TEMP\winutil.ps1'.
 function Start-LatestWinUtil {
-    param (
-        [Parameter(Mandatory = $false)]
-        [array]$WinUtilArgumentsList
-    )
-
     # Setup the commands used to launch WinUtil using Windows Terminal or Windows PowerShell/PowerShell Core.
     $PowerShellCommand = if (Get-Command pwsh.exe -ErrorAction SilentlyContinue) { "pwsh.exe" } else { "powershell.exe" }
     $ProcessCommand = if (Get-Command wt.exe -ErrorAction SilentlyContinue) { "wt.exe" } else { $PowerShellCommand }
@@ -159,8 +166,8 @@ try {
 
 # Attempt to start the latest release of WinUtil saved to the local disk; also supports WinUtil's arguments.
 try {
-    if ($args) {
-        Start-LatestWinUtil $args
+    if ($WinUtilArgumentsList) {
+        Start-LatestWinUtil $WinUtilArgumentsList
     } else {
         Start-LatestWinUtil
     }

--- a/windev.ps1
+++ b/windev.ps1
@@ -1,55 +1,169 @@
 <#
 .SYNOPSIS
-    This Script is used as a target for the https://christitus.com/windev alias.
-    It queries the latest winget release (no matter if Pre-Release, Draft or Full Release) and invokes It
+    This script is used as a target for the https://christitus.com/windev alias.
+    It queries the latest WinUtil release (no matter if it's a Pre-Release, Draft, or Full Release) and runs it.
 .DESCRIPTION
-    This Script provides a simple way to always start the bleeding edge release even if it's not yet a full release.
-    This function should be run with administrative privileges.
-    Because this way of recursively invoking scripts via Invoke-Expression it might very well happen that AV Programs flag this because it's a common way of mulitstage exploits to run
+    This script provides a simple way to start the bleeding edge release even if it's not yet a full release.
+    This function can be run both with administrator and non-administrator permissions.
+    If it is not running as administrator, it will attempt to relaunch itself with administrator permissions.
+    The script no longer uses Invoke-Expression for its execution and now relies on Start-Process.
 .EXAMPLE
-    irm https://christitus.com/windev | iex
+    Run in PowerShell > irm https://christitus.com/windev | iex
     OR
-    Run in Admin Powershell >  ./windev.ps1
+    Run in PowerShell > .\windev.ps1
+    OR
+    Run in PowerShell > iex "& { $(irm https://christitus.com/windev) } <arguments>"
+    OR
+    Run in PowerShell > .\windev.ps1 <arguments>
 #>
 
-# Function to fetch the latest release tag from the GitHub API
-function Get-LatestRelease {
+# Define the arguments for the WinUtil script; enables argument auto-completion.
+param (
+    [switch]$Debug,
+    [string]$Config,
+    [switch]$Run
+)
+
+# Speed up download-related tasks by suppressing the output of Write-Progress.
+$ProgressPreference = "SilentlyContinue"
+
+# Determine whether or not the active process is currently running as administrator.
+$ProcessIsElevated = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+
+# Function to get the latest stable or pre-release tag from the repository's releases page.
+function Get-WinUtilReleaseTag {
+    # Retrieve the list of released versions from the repository's releases page.
     try {
-        $releases = Invoke-RestMethod -Uri 'https://api.github.com/repos/ChrisTitusTech/winutil/releases'
-        $latestRelease = $releases | Where-Object {$_.prerelease -eq $true} | Select-Object -First 1
-        return $latestRelease.tag_name
+        $ReleasesList = Invoke-RestMethod 'https://api.github.com/repos/ChrisTitusTech/winutil/releases'
     } catch {
-        Write-Host "Error fetching release data: $_" -ForegroundColor Red
-        return $latestRelease.tag_name
+        Write-Host "Error downloading WinUtil's releases list: $_" -ForegroundColor Red
+        break
     }
-}
 
-# Function to redirect to the latest pre-release version
-function RedirectToLatestPreRelease {
-    $latestRelease = Get-LatestRelease
-    if ($latestRelease) {
-        $url = "https://github.com/ChrisTitusTech/winutil/releases/download/$latestRelease/winutil.ps1"
+    # Filter through the released versions and select the first matching stable or pre-release version.
+    $StableRelease = $ReleasesList | Where-Object { -not $_.prerelease } | Select-Object -First 1
+    $PreRelease = $ReleasesList | Where-Object { $_.prerelease } | Select-Object -First 1
+
+    # Set the release tag based on the available releases; if no release tag is found use the 'latest' tag.
+    $ReleaseTag = if ($PreRelease) {
+        $PreRelease.tag_name
+    } elseif ($StableRelease) {
+        $StableRelease.tag_name
     } else {
-        Write-Host 'Unable to determine latest pre-release version.' -ForegroundColor Red
-        Write-Host "Using latest Full Release"
-        $url = "https://github.com/ChrisTitusTech/winutil/releases/latest/download/winutil.ps1"
+        "latest"
     }
 
-    $script = Invoke-RestMethod $url
-    # Elevate Shell if necessary
-    if (!([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
-        Write-Output "Winutil needs to be run as Administrator. Attempting to relaunch."
+    # Return the release tag to facilitate the usage of the version number within other parts of the script.
+    return $ReleaseTag
+}
 
-        $powershellcmd = if (Get-Command pwsh -ErrorAction SilentlyContinue) { "pwsh" } else { "powershell" }
-        $processCmd = if (Get-Command wt.exe -ErrorAction SilentlyContinue) { "wt.exe" } else { $powershellcmd }
+# Get the latest stable or pre-release tag; falling back to the 'latest' release tag if no releases are found.
+$WinUtilReleaseTag = Get-WinUtilReleaseTag
 
-        Start-Process $processCmd -ArgumentList "$powershellcmd -ExecutionPolicy Bypass -NoProfile -Command $(Invoke-Expression $script)" -Verb RunAs
+# Function to generate the URL used to download the latest release of WinUtil from the releases page.
+function Get-WinUtilReleaseURL {
+    $WinUtilDownloadURL = if ($WinUtilReleaseTag -eq "latest") {
+        "https://github.com/ChrisTitusTech/winutil/releases/$($WinUtilReleaseTag)/download/winutil.ps1"
+    } else {
+        "https://github.com/ChrisTitusTech/winutil/releases/download/$($WinUtilReleaseTag)/winutil.ps1"
     }
-    else{
-        Invoke-Expression $script
+
+    return $WinUtilDownloadURL
+}
+
+# Get the URL used to download the latest release of WinUtil from the releases page.
+$WinUtilReleaseURL = Get-WinUtilReleaseURL
+
+# Create the file path that the latest WinUtil release will be downloaded to on the local disk.
+$WinUtilScriptPath = Join-Path "$env:TEMP" "winutil.ps1"
+
+# Function to download the latest release of WinUtil from the releases page to the local disk.
+function Get-LatestWinUtil {
+    if (!(Test-Path $WinUtilScriptPath)) {
+        Write-Host "WinUtil is not found. Downloading WinUtil '$($WinUtilReleaseTag)'..." -ForegroundColor DarkYellow
+        Invoke-RestMethod $WinUtilReleaseURL -OutFile $WinUtilScriptPath
     }
 }
 
-# Call the redirect function
+# Function to check for any version changes to WinUtil, re-downloading the script if it has been upgraded/downgraded.
+function Get-WinUtilUpdates {
+    # Make a web request to the latest WinUtil release URL and store the script's raw code for processing.
+    $RawWinUtilScript = (Invoke-WebRequest $WinUtilReleaseURL -UseBasicParsing).RawContent
 
-RedirectToLatestPreRelease
+    # Create the regular expression pattern used to extract the script's version number from the script's raw content.
+    $VersionExtractionRegEx = "(\bVersion\s*:\s)([\d.]+)"
+
+    # Match the entire 'Version:' header and extract the script's version number directly using RegEx capture groups.
+    $RemoteWinUtilVersion = (([regex]($VersionExtractionRegEx)).Match($RawWinUtilScript).Groups[2].Value)
+    $LocalWinUtilVersion = (([regex]($VersionExtractionRegEx)).Match((Get-Content $WinUtilScriptPath)).Groups[2].Value)
+
+    # Check if WinUtil needs an update and either download a fresh copy or notify the user its already up-to-date.
+    if ([version]$RemoteWinUtilVersion -ne [version]$LocalWinUtilVersion) {
+        Write-Host "WinUtil is out-of-date. Downloading WinUtil '$($RemoteWinUtilVersion)'..." -ForegroundColor DarkYellow
+        Invoke-RestMethod $WinUtilReleaseURL -OutFile $WinUtilScriptPath
+    } else {
+        Write-Host "WinUtil is already up-to-date. Skipped update checking." -ForegroundColor Yellow
+    }
+}
+
+# Function to start the latest release of WinUtil that was previously downloaded and saved to '$env:TEMP\winutil.ps1'.
+function Start-LatestWinUtil {
+    param (
+        [Parameter(Mandatory = $false)]
+        [array]$WinUtilArgumentsList
+    )
+
+    # Setup the commands used to launch WinUtil using Windows Terminal or Windows PowerShell/PowerShell Core.
+    $PowerShellCommand = if (Get-Command pwsh.exe -ErrorAction SilentlyContinue) { "pwsh.exe" } else { "powershell.exe" }
+    $ProcessCommand = if (Get-Command wt.exe -ErrorAction SilentlyContinue) { "wt.exe" } else { $PowerShellCommand }
+
+    # Setup the script's launch arguments based on the presence of Windows Terminal or Windows PowerShell/PowerShell Core:
+    # 1. Windows Terminal needs the name of the process to start ($PowerShellCommand) in addition to the launch arguments.
+    # 2. Windows PowerShell and PowerShell Core can receive and use the launch arguments as is without extra modification.
+    $WinUtilLaunchArguments = "-ExecutionPolicy Bypass -NoProfile -File `"$WinUtilScriptPath`""
+    if ($ProcessCommand -ne $PowerShellCommand) {
+        $WinUtilLaunchArguments = "$PowerShellCommand $WinUtilLaunchArguments"
+    }
+
+    # If WinUtil's launch arguments are provided, append them to the end of the list of current launch arguments.
+    if ($WinUtilArgumentsList) {
+        $WinUtilLaunchArguments += " " + $($WinUtilArgumentsList -join " ")
+    }
+
+    # If the WinUtil script is not running as administrator, relaunch the script with administrator permissions.
+    if (!$ProcessIsElevated) {
+        Write-Host "WinUtil is not running as administrator. Relaunching..." -ForegroundColor DarkCyan
+        Write-Host "Running the selected WinUtil release: Version '$($WinUtilReleaseTag)'." -ForegroundColor Green
+        Start-Process $ProcessCommand -ArgumentList $WinUtilLaunchArguments -Verb RunAs
+    } else {
+        Write-Host "Running the selected WinUtil release: Version '$($WinUtilReleaseTag)'." -ForegroundColor Green
+        Start-Process $ProcessCommand -ArgumentList $WinUtilLaunchArguments
+    }
+}
+
+# If WinUtil has not already been downloaded, attempt to download it and save it to '$env:TEMP\winutil.ps1'.
+try {
+    Get-LatestWinUtil
+} catch {
+    Write-Host "Error downloading WinUtil '$($WinUtilReleaseTag)': $_" -ForegroundColor Red
+    break
+}
+
+# Attempt to check for WinUtil updates, if a version is released or removed this will re-download WinUtil.
+try {
+    Get-WinUtilUpdates
+} catch {
+    Write-Host "Error updating WinUtil '$($WinUtilReleaseTag)': $_" -ForegroundColor Red
+    break
+}
+
+# Attempt to start the latest release of WinUtil saved to the local disk; also supports WinUtil's arguments.
+try {
+    if ($args) {
+        Start-LatestWinUtil $args
+    } else {
+        Start-LatestWinUtil
+    }
+} catch {
+    Write-Host "Error launching WinUtil '$($WinUtilReleaseTag)': $_" -ForegroundColor Red
+}


### PR DESCRIPTION
## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [x] UI/UX improvement

## Description

Fixes the broken admin elevation logic for both stable and pre-release versions of the WinUtil script.

## Testing

I have tested the fixed admin elevation logic by running it in the following test scenarios:

### Local Tests

- Baseline: Running WinUtil without administrator permissions and without arguments.
  - Test 1: Running WinUtil locally without arguments: [✅] Successful
  - Test 2: Running WinUtil locally without arguments (as admin): [✅] Successful
  - Test 3: Running WinUtil locally with arguments: [✅] Successful
  - Test 4: Running WinUtil locally with arguments (as admin): [✅] Successful

### Remote Tests

- Baseline: Running WinUtil without administrator permissions and without arguments.
  - Test 1: Running WinUtil remotely without arguments: [✅] Successful
  - Test 2: Running WinUtil remotely without arguments (as admin): [✅] Successful
  - Test 3: Running WinUtil remotely with arguments: [✅] Successful
  - Test 4: Running WinUtil remotely with arguments (as admin): [✅] Successful

## Impact

- Covered by `## Description`, `## Testing / ### Local Tests`, and `## Testing / ### Remote Tests`.

## Issue related to PR

- Resolves #2812

## Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.