### PR TITLE
Elevation fixes for start.ps1

### DIFF
--- a/scripts/start.ps1
+++ b/scripts/start.ps1
@@ -39,28 +39,16 @@ $sync.version = "#{replaceme}"
 $sync.configs = @{}
 $sync.ProcessRunning = $false
 
+$latestScript = "https://github.com/ChrisTitusTech/winutil/releases/latest/download/winutil.ps1"
+
 if (!([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
     Write-Output "Winutil needs to be run as Administrator. Attempting to relaunch."
-    $argList = @()
-
-    $PSBoundParameters.GetEnumerator() | ForEach-Object {
-        $argList += if ($_.Value -is [switch] -and $_.Value) {
-            "-$($_.Key)"
-        } elseif ($_.Value) {
-            "-$($_.Key) `"$($_.Value)`""
-        }
-    }
-
-    $script = if ($MyInvocation.MyCommand.Path) {
-        "& { & '$($MyInvocation.MyCommand.Path)' $argList }"
-    } else {
-        "iex '& { $(Invoke-RestMethod https://github.com/ChrisTitusTech/winutil/releases/latest/download/winutil.ps1) } $argList'"
-    }
+    $script = if ($MyInvocation.MyCommand.Path) { "& '" + $MyInvocation.MyCommand.Path + "'" } else { "Invoke-RestMethod '$latestScript' | Invoke-Expression"}
 
     $powershellcmd = if (Get-Command pwsh -ErrorAction SilentlyContinue) { "pwsh" } else { "powershell" }
     $processCmd = if (Get-Command wt.exe -ErrorAction SilentlyContinue) { "wt.exe" } else { $powershellcmd }
 
-    Start-Process $processCmd -ArgumentList "$powershellcmd -ExecutionPolicy Bypass -NoExit -NoProfile -Command $script" -Verb RunAs
+    Start-Process $processCmd -ArgumentList "$powershellcmd -ExecutionPolicy Bypass -NoProfile -Command $script" -Verb RunAs
 
     break
 }

--- a/scripts/start.ps1
+++ b/scripts/start.ps1
@@ -54,7 +54,7 @@ if (!([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]:
     $script = if ($MyInvocation.MyCommand.Path) {
         "& { & '$($MyInvocation.MyCommand.Path)' $argList }"
     } else {
-        "iex '& { $(irm https://github.com/ChrisTitusTech/winutil/releases/latest/download/winutil.ps1) } $argList'"
+        "iex '& { $(Invoke-RestMethod https://github.com/ChrisTitusTech/winutil/releases/latest/download/winutil.ps1) } $argList'"
     }
 
     $powershellcmd = if (Get-Command pwsh -ErrorAction SilentlyContinue) { "pwsh" } else { "powershell" }

--- a/scripts/start.ps1
+++ b/scripts/start.ps1
@@ -39,20 +39,26 @@ $sync.version = "#{replaceme}"
 $sync.configs = @{}
 $sync.ProcessRunning = $false
 
+# Store latest script URL in variable.
 $latestScript = "https://github.com/ChrisTitusTech/winutil/releases/latest/download/winutil.ps1"
 
+# Check if script is running as Administrator
 if (!([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
     Write-Output "Winutil needs to be run as Administrator. Attempting to relaunch."
+
+    # Partial rollback from #2648, changed irm and iex to Invoke-RestMethod and Invoke-Expression.
     $script = if ($MyInvocation.MyCommand.Path) { "& '" + $MyInvocation.MyCommand.Path + "'" } else { "Invoke-RestMethod '$latestScript' | Invoke-Expression"}
 
     $powershellcmd = if (Get-Command pwsh -ErrorAction SilentlyContinue) { "pwsh" } else { "powershell" }
     $processCmd = if (Get-Command wt.exe -ErrorAction SilentlyContinue) { "wt.exe" } else { $powershellcmd }
 
+    # Start new process with elevated privileges
     Start-Process $processCmd -ArgumentList "$powershellcmd -ExecutionPolicy Bypass -NoProfile -Command $script" -Verb RunAs
 
     break
 }
 
+# Logging
 $dateTime = Get-Date -Format "yyyy-MM-dd_HH-mm-ss"
 
 $logdir = "$env:localappdata\winutil\logs"

--- a/scripts/start.ps1
+++ b/scripts/start.ps1
@@ -60,7 +60,7 @@ if (!([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]:
     $powershellcmd = if (Get-Command pwsh -ErrorAction SilentlyContinue) { "pwsh" } else { "powershell" }
     $processCmd = if (Get-Command wt.exe -ErrorAction SilentlyContinue) { "wt.exe" } else { $powershellcmd }
 
-    Start-Process $processCmd -ArgumentList "$powershellcmd -ExecutionPolicy Bypass -NoProfile -Command $script" -Verb RunAs
+    Start-Process $processCmd -ArgumentList "$powershellcmd -ExecutionPolicy Bypass -NoExit -NoProfile -Command $script" -Verb RunAs
 
     break
 }


### PR DESCRIPTION
There were elevation issues after #2648, so I reverted one of the changes associate to building the $script variable. Made a couple other changes to have more consistency and maintain Powershell scripting standards.

## Type of Change
- [x] Bug fix
- [x] Hotfix

## Description
- Partial rollback of changes from #2648
- Create Variable for script location.
- irm -> Invoke-RestMethod, for Powershell standard coding practices.
- iex -> Invoke-Expression, for Powershell standard coding practices.

## Testing
Compiled, hosted on local server, and pulled as if I was pulling winutil from Chris's host.
![image](https://github.com/user-attachments/assets/2116eb02-b175-418a-b8dc-044f265fc9d8)

## Impact
It might not be as robust as what @MyDrift-user tried to do. And -Config parameters don't get passed through. 

## Issue related to PR
Related to PR #2908, while keeping the script in RAM.
Partial Fix of #2812

## Additional Information
Strangely, the changes before this partial rollback, worked if the winutil.ps1 was local, but broke as soon as you hosted it through the internet and tried loading it into RAM. Quirk of powershell possible or security measure?
windev.ps1 also has the same issue, but I haven't looked at it yet. 

_Ignore my older commits, I was testing other things before I rolled back._

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no errors/warnings/merge conflicts.
