### PR TITLE
[MicroWin] Fix Recall "Dependency" Misinformation

### DIFF
--- a/functions/private/Invoke-WinUtilMicroWin-Helper.ps1
+++ b/functions/private/Invoke-WinUtilMicroWin-Helper.ps1
@@ -110,7 +110,6 @@ function Remove-Features() {
             $_.FeatureName -NotLike "*NFS*" -AND
             $_.FeatureName -NotLike "*SearchEngine*" -AND
             $_.FeatureName -NotLike "*RemoteDesktop*" -AND
-            $_.FeatureName -NotLike "*Recall*" -AND
             $_.State -ne "Disabled"
         }
 
@@ -274,6 +273,31 @@ function Remove-ProvisionedPackages() {
         # This can happen if getting AppX packages fails
         Write-Host "Unable to get information about the AppX packages. MicroWin processing will continue, but AppX packages will not be processed"
         Write-Host "Error information: $($_.Exception.Message)" -ForegroundColor Yellow
+    }
+}
+
+function Get-LocalizedUsers
+{
+    <#
+        .SYNOPSIS
+            Gets a localized user group representation for ICACLS commands (Port from DISMTools PE Helper)
+        .PARAMETER admins
+            Determines whether to get a localized user group representation for the Administrators user group
+        .OUTPUTS
+            A string containing the localized user group
+        .EXAMPLE
+            Get-LocalizedUsers -admins $true
+    #>
+    param (
+        [Parameter(Mandatory = $true, Position = 0)] [bool]$admins
+    )
+    if ($admins)
+    {
+        return (Get-LocalGroup | Where-Object { $_.SID.Value -like "S-1-5-32-544" }).Name
+    }
+    else
+    {
+        return (Get-LocalGroup | Where-Object { $_.SID.Value -like "S-1-5-32-545" }).Name
     }
 }
 


### PR DESCRIPTION
## Type of Change
- [X] Bug fix

## Description
This PR removes the Recall exclusion and adds the **true** fix for #2697. Thanks to @witherornot and @thecatontheceiling for spotting this problem, and thanks to Microsoft for not testing Jack.

## Testing
Testing has concluded with no issues

## Impact
Clarify that it's a Windows bug. This should not have any impact on end-users.

## Issue related to PR
- Resolves something external from GitHub - any misinformation caused by Recall being a "dependency"

## Additional Information
Please test this for any issues.

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no errors/warnings/merge conflicts.
