### PR TITLE
Simples fixes to 'Compile.ps1' Script

### DIFF
--- a/Compile.ps1
+++ b/Compile.ps1
@@ -125,10 +125,12 @@ Write-Progress -Activity "Compiling" -Completed
 
 Update-Progress -Activity "Validating" -StatusMessage "Checking winutil.ps1 Syntax" -Percent 0
 try {
-    $null = Get-Command -Syntax .\winutil.ps1
+    Get-Command -Syntax .\winutil.ps1 | Out-Null
 } catch {
     Write-Warning "Syntax Validation for 'winutil.ps1' has failed"
     Write-Host "$($Error[0])" -ForegroundColor Red
+    Pop-Location # Restore previous location before exiting...
+    exit 1
 }
 Write-Progress -Activity "Validating" -Completed
 

--- a/Compile.ps1
+++ b/Compile.ps1
@@ -91,7 +91,7 @@ $($jsonAsObject | ConvertTo-Json -Depth 3)
 "@
 
     $sync.configs.$($psitem.BaseName) = $json | ConvertFrom-Json
-    $script_content.Add($(Write-Output "`$sync.configs.$($psitem.BaseName) = @'`n$json`n'@ `| ConvertFrom-Json" ))
+    $script_content.Add($(Write-Output "`$sync.configs.$($psitem.BaseName) = @'`r`n$json`r`n'@ `| ConvertFrom-Json" ))
 }
 
 # Read the entire XAML file as a single string, preserving line breaks


### PR DESCRIPTION
## Type of Change
- [x] Bug fix

## Description
Commit Summery:
- 974c46c Save WinUtil's json strings with DOS-Style Newline Character (CRLF) instead of Unix-Style Newline Character (LF)
  Originated from PR https://github.com/ChrisTitusTech/winutil/pull/2816 by @ruxunderscore
- 5641623 Exit Early when facing Syntax Errors, Solves a problem when passing '-Run' Argument with 'Compile.ps1' Script - Use 'Out-Null' to follow common project conventions

## Testing
Tested these changes when:
1. Compiling without providing any extra arguments (`Compile.ps1`)
2. Compiling with providing `-Run` Argument (`Compile.ps1 -Run`)
3. Compiling with providing `-Run -Arguments "-Debug"` (`Compile.ps1 -Run -Arguments "-Debug"`)
4. Done the previous cases when _**no syntax errors**_ are present and when there's _**syntax errors**_ in WinUtil's code base.

All previous manual tests have passed successfully.

## Impact
Won't have a major impact on end-user nor on contributors.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
