### PR TITLE
Disable Recall

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -2584,6 +2584,36 @@
     ],
     "link": "https://christitustech.github.io/winutil/dev/tweaks/z--Advanced-Tweaks---CAUTION/RemoveCopilot"
   },
+  "WPFTweaksRecallOff": {
+    "Content": "Disable Recall",
+    "Description": "Turn Recall off",
+    "category": "Essential Tweaks",
+    "panel": "1",
+    "Order": "a011_",
+    "registry": [
+      {
+
+        "Path": "HKLM:\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsAI",
+        "Name": "DisableAIDataAnalysis",
+        "Type": "DWord",
+        "Value": "1",
+        "OriginalValue": "0"
+      }
+    ],
+    "InvokeScript": [
+      "
+      Write-Host \"Disable Recall\"
+      DISM /Online /Disable-Feature /FeatureName:Recall
+      "
+    ],
+    "UndoScript": [
+      "
+      Write-Host \"Enable Recall\"
+      DISM /Online /Enable-Feature /FeatureName:Recall
+      "
+    ],
+    "link": "https://christitustech.github.io/winutil/dev/tweaks/Essential-Tweaks/DisableRecall"
+  },
   "WPFTweaksDisableLMS1": {
     "Content": "Disable Intel MM (vPro LMS)",
     "Description": "Intel LMS service is always listening on all ports and could be a huge security risk. There is no need to run LMS on home machines and even in the Enterprise there are better solutions.",

--- a/docs/dev/tweaks/Essential-Tweaks/DisableRecall.md
+++ b/docs/dev/tweaks/Essential-Tweaks/DisableRecall.md
@@ -1,0 +1,91 @@
+# Disable Microsoft Recall
+
+Last Updated: 2024-10-24
+
+
+!!! info
+     The Development Documentation is auto generated for every compilation of WinUtil, meaning a part of it will always stay up-to-date. **Developers do have the ability to add custom content, which won't be updated automatically.**
+## Description
+
+Disables MS Recall built into Windows since 24H2.
+
+<!-- BEGIN CUSTOM CONTENT -->
+
+<!-- END CUSTOM CONTENT -->
+
+<details>
+<summary>Preview Code</summary>
+
+```json
+"WPFTweaksRecallOff": {
+    "Content": "Disable Recall",
+    "Description": "Turn Recall off",
+    "category": "Essential Tweaks",
+    "panel": "1",
+    "Order": "a011_",
+    "registry": [
+      {
+
+        "Path": "HKLM:\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsAI",
+        "Name": "DisableAIDataAnalysis",
+        "Type": "DWord",
+        "Value": "1",
+        "OriginalValue": "0"
+      }
+    ],
+    "InvokeScript": [
+      "
+      Write-Host \"Disable Recall\"
+      DISM /Online /Disable-Feature /FeatureName:Recall     
+      "
+    ],
+    "UndoScript": [
+      "
+      Write-Host \"Enable Recall\"
+      DISM /Online /Enable-Feature /FeatureName:Recall
+      "
+    ],
+	"link": "https://christitustech.github.io/winutil/dev/tweaks/Essential-Tweaks/DisableRecall"
+  },
+```
+
+</details>
+
+## Invoke Script
+
+```powershell
+
+      Write-Host "Disable Recall"
+      DISM /Online /Disable-Feature /FeatureName:Recall    
+
+
+```
+## Undo Script
+
+```powershell
+
+      Write-Host "Enable Recall"
+      DISM /Online /Enable-Feature /FeatureName:Recall
+
+
+```
+## Registry Changes
+Applications and System Components store and retrieve configuration data to modify windows settings, so we can use the registry to change many settings in one place.
+
+
+You can find information about the registry on [Wikipedia](https://www.wikiwand.com/en/Windows_Registry) and [Microsoft's Website](https://learn.microsoft.com/en-us/windows/win32/sysinfo/registry).
+
+### Registry Key: DisableAIDataAnalysis
+
+**Type:** DWord
+
+**Original Value:** 0
+
+**New Value:** 1
+
+<!-- BEGIN SECOND CUSTOM CONTENT -->
+
+<!-- END SECOND CUSTOM CONTENT -->
+
+
+[View the JSON file](https://github.com/ChrisTitusTech/winutil/tree/main/config/tweaks.json)


### PR DESCRIPTION
Adds a new option to disable Recall using DISM and Reg Key

<!--Before you make this PR have you followed the docs here? - https://christitustech.github.io/winutil/contribute/ -->

## Type of Change
- [X] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Added reg key to disable AI Data Analysis which turns off the snapshot feature of Recall in Registry and used DISM to disable the Recall feature as shown in Chris's video "Microsoft Recall Update".

## Testing
Compiled and tested on Win11 24H2. Both Disable and Undo works verified using the command DISM /Online /Get-FeatureInfo /FeatureName:Recall

## Impact
Just disables Recall.

## Issue related to PR
Does not apply to older versions of Win11 or Win10

## Additional Information
Added a new doc file to Essential-Tweaks DisableRecall.md

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no errors/warnings/merge conflicts.
