### PR TITLE
Simple changes to 'Invoke-WPFTab' Public Function

### DIFF
--- a/functions/public/Invoke-WPFTab.ps1
+++ b/functions/public/Invoke-WPFTab.ps1
@@ -19,7 +19,7 @@ function Invoke-WPFTab {
     $tabNumber = [int]($ClickedTab -replace "WPFTab","" -replace "BT","") - 1
 
     $filter = Get-WinUtilVariables -Type ToggleButton | Where-Object {$psitem -like "WPFTab?BT"}
-    $sync.GetEnumerator() | Where-Object {$psitem.Key -in $filter} | ForEach-Object {
+    ($sync.GetEnumerator()).where{$psitem.Key -in $filter} | ForEach-Object {
         if ($ClickedTab -ne $PSItem.name) {
             $sync[$PSItem.Name].IsChecked = $false
             # $tabNumber = [int]($PSItem.Name -replace "WPFTab","" -replace "BT","") - 1

--- a/functions/public/Invoke-WPFTab.ps1
+++ b/functions/public/Invoke-WPFTab.ps1
@@ -22,8 +22,6 @@ function Invoke-WPFTab {
     ($sync.GetEnumerator()).where{$psitem.Key -in $filter} | ForEach-Object {
         if ($ClickedTab -ne $PSItem.name) {
             $sync[$PSItem.Name].IsChecked = $false
-            # $tabNumber = [int]($PSItem.Name -replace "WPFTab","" -replace "BT","") - 1
-            # $sync.$tabNav.Items[$tabNumber].IsSelected = $false
         } else {
             $sync["$ClickedTab"].IsChecked = $true
             $tabNumber = [int]($ClickedTab-replace "WPFTab","" -replace "BT","") - 1

--- a/functions/public/Invoke-WPFTab.ps1
+++ b/functions/public/Invoke-WPFTab.ps1
@@ -10,7 +10,10 @@ function Invoke-WPFTab {
 
     #>
 
-    Param ($ClickedTab)
+    Param (
+        [Parameter(Mandatory,position=0)]
+        [string]$ClickedTab
+    )
 
     $tabNav = Get-WinUtilVariables | Where-Object {$psitem -like "WPFTabNav"}
     $tabNumber = [int]($ClickedTab -replace "WPFTab","" -replace "BT","") - 1


### PR DESCRIPTION
## Type of Change
- [x] Simple improvements

## Description
Simple changes to `Invoke-WPFTab` Public Function, please look into the commit history/actual changes to learn more about these changes.

Commit Summery:
- f98d3be Improve 'Invoke-WPFTab' Parameter by specifying its type (as expected by the function) and make it Mandatory
- c0e8a14 Simple performance increases in 'Invoke-WPFTab' function - Use where method instead of piping the result into Where-Object
- 85d8db1 Remove commented-out code in 'Invoke-WPFTab' function

## Testing
Switching between tabs works using the GUI as well as using the Shortcuts (`Alt` + `I | T | C | U | M`)

## Impact
Not much of an impact, other then shaving a few milliseconds (at least in theory, didn't benchmark these changes to see if there's a noticeable difference).

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
