### PR TITLE
[MicroWin] Remove WinUtil shortcut on first logon

### DIFF
--- a/functions/private/Invoke-WinUtilMicroWin-Helper.ps1
+++ b/functions/private/Invoke-WinUtilMicroWin-Helper.ps1
@@ -807,41 +807,6 @@ function New-FirstRun {
     Remove-Item -Path "$env:USERPROFILE\Desktop\*.lnk"
     Remove-Item -Path "$env:HOMEDRIVE\Users\Default\Desktop\*.lnk"
 
-    # ************************************************
-    # Create WinUtil shortcut on the desktop
-    #
-    $desktopPath = "$($env:USERPROFILE)\Desktop"
-    # Specify the target PowerShell command
-    $command = "powershell.exe -NoProfile -ExecutionPolicy Bypass -Command 'irm https://christitus.com/win | iex'"
-    # Specify the path for the shortcut
-    $shortcutPath = Join-Path $desktopPath 'winutil.lnk'
-    # Create a shell object
-    $shell = New-Object -ComObject WScript.Shell
-
-    # Create a shortcut object
-    $shortcut = $shell.CreateShortcut($shortcutPath)
-
-    if (Test-Path -Path "$env:HOMEDRIVE\Windows\cttlogo.png") {
-        $shortcut.IconLocation = "$env:HOMEDRIVE\Windows\cttlogo.png"
-    }
-
-    # Set properties of the shortcut
-    $shortcut.TargetPath = "powershell.exe"
-    $shortcut.Arguments = "-NoProfile -ExecutionPolicy Bypass -Command `"$command`""
-    # Save the shortcut
-    $shortcut.Save()
-
-    # Make the shortcut have 'Run as administrator' property on
-    $bytes = [System.IO.File]::ReadAllBytes($shortcutPath)
-    # Set byte value at position 0x15 in hex, or 21 in decimal, from the value 0x00 to 0x20 in hex
-    $bytes[0x15] = $bytes[0x15] -bor 0x20
-    [System.IO.File]::WriteAllBytes($shortcutPath, $bytes)
-
-    Write-Host "Shortcut created at: $shortcutPath"
-    #
-    # Done create WinUtil shortcut on the desktop
-    # ************************************************
-
     try
     {
         if ((Get-WindowsOptionalFeature -Online | Where-Object { $_.FeatureName -like "Recall" }).Count -gt 0)


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://christitustech.github.io/winutil/contribute/ -->

## Type of Change
- [X] Hotfix
- [X] Security patch

## Description
This PR removes the WinUtil shortcut for MicroWin images due to the same reasons that affected the shortcut that could be created on demand - false positives.

## Testing
This PR only removes the shortcut. No testing is required

## Impact
Less support overhead for false positives

## Issue related to PR
- Resolves all issues related to the shortcut

## Additional Information
No documentation changes required.

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no errors/warnings/merge conflicts.
