### PR TITLE
Displays build version of input ISO

### DIFF
--- a/functions/microwin/Invoke-Microwin.ps1
+++ b/functions/microwin/Invoke-Microwin.ps1
@@ -76,6 +76,7 @@ public class PowerManagement {
     }
 
     $imgVersion = (Get-WindowsImage -ImagePath $mountDir\sources\install.wim -Index $index).Version
+    Write-Host "The Windows Image Build Version is: $imgVersion"
 
     # Detect image version to avoid performing MicroWin processing on Windows 8 and earlier
     if ((Microwin-TestCompatibleImage $imgVersion $([System.Version]::new(10,0,10240,0))) -eq $false) {


### PR DESCRIPTION
Type of Change
 Minor update (Console output addition)
Description
This PR adds a Write-Host statement to display the Windows Image version in the console. The change outputs the retrieved image version ($imgVersion) to provide visibility into the version details directly within the script execution output.

Example output:
The Windows Image Build Version is: [version number]

This modification is particularly useful for users who need to confirm the version of the Windows Image being processed.

Testing
Testing involved running the script to ensure that the Write-Host statement correctly displays the image version without causing any errors or affecting existing functionality.

Impact
This change has no impact on performance, dependencies, or behavior beyond adding a simple console output. It provides helpful feedback for users reviewing the image details in the script.

Issue related to PR
N/A

Additional Information
N/A

Checklist
 My code adheres to the coding and style guidelines of the project.
 I have performed a self-review of my own code.
 I have commented my code, particularly in hard-to-understand areas.
 I have made corresponding changes to the documentation.
 My changes generate no errors/warnings/merge conflicts.