### PR TITLE
[FEAT] Remove Start Menu Recommendations / Fix GetToggle Logic

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -3370,6 +3370,7 @@
         "Name": "InitialKeyboardIndicators",
         "Value": "2",
         "OriginalValue": "0",
+        "DefaultState": "false",
         "Type": "DWord"
       },
       {
@@ -3377,6 +3378,7 @@
         "Name": "InitialKeyboardIndicators",
         "Value": "2",
         "OriginalValue": "0",
+        "DefaultState": "false",
         "Type": "DWord"
       }
     ],
@@ -3580,6 +3582,7 @@
         "Name": "Hidden",
         "Value": "1",
         "OriginalValue": "0",
+        "DefaultState": "false",
         "Type": "DWord"
       }
     ],
@@ -3608,6 +3611,7 @@
         "Name": "HideFileExt",
         "Value": "0",
         "OriginalValue": "1",
+        "DefaultState": "false",
         "Type": "DWord"
       }
     ],

--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -3308,6 +3308,7 @@
         "Name": "AppsUseLightTheme",
         "Value": "0",
         "OriginalValue": "1",
+        "DefaultState": "false",
         "Type": "DWord"
       },
       {
@@ -3315,6 +3316,7 @@
         "Name": "SystemUsesLightTheme",
         "Value": "0",
         "OriginalValue": "1",
+        "DefaultState": "false",
         "Type": "DWord"
       }
     ],

--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -3397,12 +3397,44 @@
     ],
     "link": "https://christitustech.github.io/winutil/dev/tweaks/Customize-Preferences/VerboseLogon"
   },
+  "WPFToggleStartMenuRecommendations": {
+    "Content": "Recommendations in Start Menu",
+    "Description": "If disabled then you will not see recommendations in the Start Menu. | Relogin Required.",
+    "category": "Customize Preferences",
+    "panel": "2",
+    "Order": "a104_",
+    "Type": "Toggle",
+    "registry": [
+      {
+        "Path": "HKLM:\\SOFTWARE\\Microsoft\\PolicyManager\\current\\device\\Start",
+        "Name": "HideRecommendedSection",
+        "Value": "0",
+        "OriginalValue": "1",
+        "Type": "DWord"
+      },
+      {
+        "Path": "HKLM:\\SOFTWARE\\Microsoft\\PolicyManager\\current\\device\\Education",
+        "Name": "IsEducationEnvironment",
+        "Value": "0",
+        "OriginalValue": "1",
+        "Type": "DWord"
+      },
+      {
+        "Path": "HKLM:\\SOFTWARE\\Policies\\Microsoft\\Windows\\Explorer",
+        "Name": "HideRecommendedSection",
+        "Value": "0",
+        "OriginalValue": "1",
+        "Type": "DWord"
+      }
+    ],
+    "link": "https://christitustech.github.io/winutil/dev/tweaks/Customize-Preferences/WPFToggleStartMenuRecommendations"
+  },
   "WPFToggleSnapWindow": {
     "Content": "Snap Window",
     "Description": "If enabled you can align windows by dragging them. | Relogin Required",
     "category": "Customize Preferences",
     "panel": "2",
-    "Order": "a104_",
+    "Order": "a105_",
     "Type": "Toggle",
     "registry": [
       {
@@ -3420,7 +3452,7 @@
     "Description": "If enabled then Snap preview is disabled when maximize button is hovered.",
     "category": "Customize Preferences",
     "panel": "2",
-    "Order": "a105_",
+    "Order": "a106_",
     "Type": "Toggle",
     "registry": [
       {
@@ -3448,7 +3480,7 @@
     "Description": "If enabled then you will get suggestions to snap other applications in the left over spaces.",
     "category": "Customize Preferences",
     "panel": "2",
-    "Order": "a106_",
+    "Order": "a107_",
     "Type": "Toggle",
     "registry": [
       {
@@ -3476,7 +3508,7 @@
     "Description": "If Enabled then Cursor movement is affected by the speed of your physical mouse movements.",
     "category": "Customize Preferences",
     "panel": "2",
-    "Order": "a107_",
+    "Order": "a108_",
     "Type": "Toggle",
     "registry": [
       {
@@ -3508,7 +3540,7 @@
     "Description": "If Enabled then Sticky Keys is activated - Sticky keys is an accessibility feature of some graphical user interfaces which assists users who have physical disabilities or help users reduce repetitive strain injury.",
     "category": "Customize Preferences",
     "panel": "2",
-    "Order": "a108_",
+    "Order": "a109_",
     "Type": "Toggle",
     "registry": [
       {

--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -3399,7 +3399,7 @@
   },
   "WPFToggleStartMenuRecommendations": {
     "Content": "Recommendations in Start Menu",
-    "Description": "If disabled then you will not see recommendations in the Start Menu. | Relogin Required.",
+    "Description": "If disabled then you will not see recommendations in the Start Menu. | Enables 'iseducationenvironment' | Relogin Required.",
     "category": "Customize Preferences",
     "panel": "2",
     "Order": "a104_",

--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -3349,6 +3349,7 @@
         "Name": "BingSearchEnabled",
         "Value": "1",
         "OriginalValue": "0",
+        "DefaultState": "true",
         "Type": "DWord"
       }
     ],
@@ -3392,6 +3393,7 @@
         "Name": "VerboseStatus",
         "Value": "1",
         "OriginalValue": "0",
+        "DefaultState": "false",
         "Type": "DWord"
       }
     ],
@@ -3410,6 +3412,7 @@
         "Name": "HideRecommendedSection",
         "Value": "0",
         "OriginalValue": "1",
+        "DefaultState": "true",
         "Type": "DWord"
       },
       {
@@ -3417,6 +3420,7 @@
         "Name": "IsEducationEnvironment",
         "Value": "0",
         "OriginalValue": "1",
+        "DefaultState": "true",
         "Type": "DWord"
       },
       {
@@ -3424,6 +3428,7 @@
         "Name": "HideRecommendedSection",
         "Value": "0",
         "OriginalValue": "1",
+        "DefaultState": "true",
         "Type": "DWord"
       }
     ],
@@ -3442,6 +3447,7 @@
         "Name": "WindowArrangementActive",
         "Value": "1",
         "OriginalValue": "0",
+        "DefaultState": "true",
         "Type": "String"
       }
     ],
@@ -3460,6 +3466,7 @@
         "Name": "EnableSnapAssistFlyout",
         "Value": "1",
         "OriginalValue": "0",
+        "DefaultState": "true",
         "Type": "DWord"
       }
     ],
@@ -3488,6 +3495,7 @@
         "Name": "SnapAssist",
         "Value": "1",
         "OriginalValue": "0",
+        "DefaultState": "true",
         "Type": "DWord"
       }
     ],
@@ -3516,6 +3524,7 @@
         "Name": "MouseSpeed",
         "Value": "1",
         "OriginalValue": "0",
+        "DefaultState": "true",
         "Type": "DWord"
       },
       {
@@ -3523,6 +3532,7 @@
         "Name": "MouseThreshold1",
         "Value": "6",
         "OriginalValue": "0",
+        "DefaultState": "true",
         "Type": "DWord"
       },
       {
@@ -3530,6 +3540,7 @@
         "Name": "MouseThreshold2",
         "Value": "10",
         "OriginalValue": "0",
+        "DefaultState": "true",
         "Type": "DWord"
       }
     ],
@@ -3548,6 +3559,7 @@
         "Name": "Flags",
         "Value": "510",
         "OriginalValue": "58",
+        "DefaultState": "true",
         "Type": "DWord"
       }
     ],
@@ -3622,6 +3634,7 @@
         "Name": "SearchboxTaskbarMode",
         "Value": "1",
         "OriginalValue": "0",
+        "DefaultState": "true",
         "Type": "DWord"
       }
     ],
@@ -3640,6 +3653,7 @@
         "Name": "ShowTaskViewButton",
         "Value": "1",
         "OriginalValue": "0",
+        "DefaultState": "true",
         "Type": "DWord"
       }
     ],
@@ -3658,6 +3672,7 @@
         "Name": "TaskbarDa",
         "Value": "1",
         "OriginalValue": "0",
+        "DefaultState": "true",
         "Type": "DWord"
       }
     ],
@@ -3676,6 +3691,7 @@
         "Name": "TaskbarAl",
         "Value": "1",
         "OriginalValue": "0",
+        "DefaultState": "true",
         "Type": "DWord"
       }
     ],
@@ -3694,6 +3710,7 @@
         "Name": "DisplayParameters",
         "Value": "1",
         "OriginalValue": "0",
+        "DefaultState": "false",
         "Type": "DWord"
       },
       {
@@ -3701,6 +3718,7 @@
         "Name": "DisableEmoticon",
         "Value": "1",
         "OriginalValue": "0",
+        "DefaultState": "false",
         "Type": "DWord"
       }
     ],

--- a/functions/private/Get-WinUtilToggleStatus.ps1
+++ b/functions/private/Get-WinUtilToggleStatus.ps1
@@ -46,19 +46,15 @@ Function Get-WinUtilToggleStatus {
                     Write-Debug "$($regentry.Name) is false (state: $regstate, value: $($regentry.Value), original: $($regentry.OriginalValue))"
                 }
                 if (!$regstate) {
-                    write-host "missing $($regentry.Name)"
                     switch ($regentry.DefaultState) {
                         "true" {
-                            write-host "true"
                             $regstate = $regentry.Value
                             $count += 1
                         }
                         "false" {
-                            write-host "false"
                             $regstate = $regentry.OriginalValue
                         }
                         default {
-                            write-host "default"
                             Write-Error "Entry for $($regentry.Name) does not exist and no DefaultState is defined."
                             $regstate = $regentry.OriginalValue
                         }

--- a/functions/private/Get-WinUtilToggleStatus.ps1
+++ b/functions/private/Get-WinUtilToggleStatus.ps1
@@ -35,6 +35,9 @@ Function Get-WinUtilToggleStatus {
 
         foreach ($regentry in $ToggleSwitchReg) {
             try {
+                if (!(Test-Path $regentry.Path)) {
+                    New-Item -Path $regentry.Path -Force | Out-Null
+                }
                 $regstate = (Get-ItemProperty -path $regentry.Path).$($regentry.Name)
                 if ($regstate -eq $regentry.Value) {
                     $count += 1
@@ -42,8 +45,27 @@ Function Get-WinUtilToggleStatus {
                 } else {
                     Write-Debug "$($regentry.Name) is false (state: $regstate, value: $($regentry.Value), original: $($regentry.OriginalValue))"
                 }
+                if (!$regstate) {
+                    write-host "missing $($regentry.Name)"
+                    switch ($regentry.DefaultState) {
+                        "true" {
+                            write-host "true"
+                            $regstate = $regentry.Value
+                            $count += 1
+                        }
+                        "false" {
+                            write-host "false"
+                            $regstate = $regentry.OriginalValue
+                        }
+                        default {
+                            write-host "default"
+                            Write-Error "Entry for $($regentry.Name) does not exist and no DefaultState is defined."
+                            $regstate = $regentry.OriginalValue
+                        }
+                    }
+                }
             } catch {
-                Write-Error "An error occurred while accessing registry entry $($regentry.Path): $_"
+                Write-Error "An unexpected error occurred: $_"
             }
         }
 


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://christitustech.github.io/winutil/contribute/ -->

## Type of Change
- [x] New feature

## Description
<!--[Provide a detailed explanation of the changes you have made. Include the reasons behind these changes and any relevant context. Link any related issues.]-->
- Removes recommendation setting entirely from Start Menu (pinned list even gets longer and not cut)
![image](https://github.com/user-attachments/assets/84f0b5b3-3851-4978-851f-c7e173822e21)



## Testing
<!--[Detail the testing you have performed to ensure that these changes function as intended. Include information about any added tests.]-->
- Tested on:
  - Win11 23H2
  - Win11 22H2
  - Win10 21H2

## Issue related to PR
<!--[What issue/discussion is related to this PR (if any)]-->
- Resolves #2215
- Resolves #2037

## Additional Information
<!--[Any additional information that reviewers should be aware of.]-->
- I am Enbling `iseducationenvironment` for this to work
https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-education#iseducationenvironment

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
