### PR TITLE
Add exception catch for Unauthorized Access

### DIFF
--- a/functions/private/Set-WinUtilRegistry.ps1
+++ b/functions/private/Set-WinUtilRegistry.ps1
@@ -47,6 +47,8 @@ function Set-WinUtilRegistry {
         Write-Warning "Unable to set $Path\$Name to $Value due to a Security Exception"
     } catch [System.Management.Automation.ItemNotFoundException] {
         Write-Warning $psitem.Exception.ErrorRecord
+    } catch [System.UnauthorizedAccessException]{
+       Write-Warning $psitem.Exception.Message
     } catch {
         Write-Warning "Unable to set $Name due to unhandled exception"
         Write-Warning $psitem.Exception.StackTrace


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://christitustech.github.io/winutil/contribute/ -->

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [x] UI/UX improvement

## Description
I noticed WPFToggleTaskbarWidgets was giving a very generic issue 

Enabling Taskbar Widgets
Set-ItemProperty:
Line |
3764 |          Set-ItemProperty -Path $Path -Name TaskbarDa -Value $value
     |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Attempted to perform an unauthorized operation.

Now it will give 
Set HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced\TaskbarDa to 0
WARNING: Attempted to perform an unauthorized operation.

## Testing
![image](https://github.com/user-attachments/assets/7138fa13-53ce-47bc-b40b-52b6c4f6837a)

![image](https://github.com/user-attachments/assets/d87ff606-80d1-4333-ad88-a15a2696dfb8)

I have not done a tone of troubleshooting on my end on why I am unable to update that value in the registry (even manually)

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
