### PR TITLE
Move Installer for OpenSSH to a runspace

### DIFF
--- a/functions/public/Invoke-WPFButton.ps1
+++ b/functions/public/Invoke-WPFButton.ps1
@@ -59,6 +59,6 @@ function Invoke-WPFButton {
         "MicrowinScratchDirBT" {Invoke-ScratchDialog}
         "WPFWinUtilInstallPSProfile" {Invoke-WinUtilInstallPSProfile}
         "WPFWinUtilUninstallPSProfile" {Invoke-WinUtilUninstallPSProfile}
-        "WPFWinUtilSSHServer" {Invoke-WinUtilSSHServer}
+        "WPFWinUtilSSHServer" {Invoke-WPFSSHServer}
     }
 }

--- a/functions/public/Invoke-WPFSSHServer.ps1
+++ b/functions/public/Invoke-WPFSSHServer.ps1
@@ -1,0 +1,17 @@
+function Invoke-WPFSSHServer {
+    <#
+
+    .SYNOPSIS
+        Invokes the OpenSSH Server install in a runspace
+
+  #>
+
+    Invoke-WPFRunspace -DebugPreference $DebugPreference -ScriptBlock {
+
+        Invoke-WinUtilSSHServer
+
+        Write-Host "======================================="
+        Write-Host "--     OpenSSH Server installed!    ---"
+        Write-Host "======================================="
+    }
+}


### PR DESCRIPTION
## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Moved the OpenSSH installer to a runspace so the UI doesn't lock up

## Testing
Compiled and tested with pwsh and powershell.exe

## Impact
UI no longer locks up when installing OpenSSH

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
