### PR TITLE
Add timestamp server to code signature

### DIFF
--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -60,7 +60,7 @@ jobs:
         run: |
           $cert = Get-ChildItem -Path Cert:\CurrentUser\My -CodeSigningCert | Select-Object -First 1
           if ($null -eq $cert) { throw "Code signing certificate not found" }
-          Set-AuthenticodeSignature -FilePath ./winutil.ps1 -Certificate $cert
+          Set-AuthenticodeSignature -FilePath ./winutil.ps1 -Certificate $cert -TimeStampServer "http://timestamp.digicert.com"
 
       - name: Verify code signature
         shell: pwsh


### PR DESCRIPTION


## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement
- [x] CI improvement

## Description
Add a timestamp signature to the final artifact in order to still have a vaild signature even when the code signing certificate is already expired.

## Testing
I have done an offline test with a local selfsigned codesign certificate in order to verify that this actually works with powershell scripts.

## Impact
The final released powershell script carries a valid code signature even after the certificate with which it was signed is already expired.

## Issue related to PR
<!--[What issue/discussion is related to this PR (if any)]-->
- Resolves -

## Additional Information
<!--[Any additional information that reviewers should be aware of.]-->

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
