### PR TITLE
[Tweaks] Disable output for DISM for the Recall tweak

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -2596,13 +2596,15 @@
     "InvokeScript": [
       "
       Write-Host \"Disable Recall\"
-      DISM /Online /Disable-Feature /FeatureName:Recall
+      DISM /Online /Disable-Feature /FeatureName:Recall /Quiet /NoRestart
+      Write-Host \"Please restart your computer in order for the changes to be fully applied.\"
       "
     ],
     "UndoScript": [
       "
       Write-Host \"Enable Recall\"
-      DISM /Online /Enable-Feature /FeatureName:Recall
+      DISM /Online /Enable-Feature /FeatureName:Recall /Quiet /NoRestart
+      Write-Host \"Please restart your computer in order for the changes to be fully applied.\"
       "
     ],
     "link": "https://christitustech.github.io/winutil/dev/tweaks/Essential-Tweaks/DisableRecall"

--- a/functions/private/Set-WinUtilRegistry.ps1
+++ b/functions/private/Set-WinUtilRegistry.ps1
@@ -47,7 +47,7 @@ function Set-WinUtilRegistry {
         Write-Warning "Unable to set $Path\$Name to $Value due to a Security Exception"
     } catch [System.Management.Automation.ItemNotFoundException] {
         Write-Warning $psitem.Exception.ErrorRecord
-    } catch [System.UnauthorizedAccessException]{
+    } catch [System.UnauthorizedAccessException] {
        Write-Warning $psitem.Exception.Message
     } catch {
         Write-Warning "Unable to set $Name due to unhandled exception"


### PR DESCRIPTION
## Type of Change
- [X] Bug fix

## Description
This is a small fix for the Recall tweak so that DISM no longer locks up the entire process due to input that is silently being asked.

Now, the user will be told to restart their computer.

## Testing
It's a simple fix that disables the output and ignores a restart.

## Impact
Bugs fixed - this is my first PR for the tweaks and not for MicroWin.

## Issue related to PR
- Resolves #3120

## Additional Information
No documentation changes are required.

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no errors/warnings/merge conflicts.
