### PR TITLE
[MicroWin] Fixed divide by zero error for fallback

### DIFF
--- a/functions/microwin/Microwin-RemovePackages.ps1
+++ b/functions/microwin/Microwin-RemovePackages.ps1
@@ -88,7 +88,7 @@ function Microwin-RemovePackages {
         } else {
             foreach ($package in $pkgList) {
                 $status = "Removing package $package"
-                Write-Progress -Activity "Removing features" -Status $status -PercentComplete ($counter++/$featlist.Count*100)
+                Write-Progress -Activity "Removing Packages" -Status $status -PercentComplete ($counter++/$pkglist.Count*100)
                 Write-Debug "Removing package $package"
                 dism /english /image="$scratchDir" /remove-package /packagename=$package /remove /quiet /norestart | Out-Null
                 if ($? -eq $false) {


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://christitustech.github.io/winutil/contribute/ -->

## Type of Change
- [X] Bug fix

## Description
Fixes a silly divide-by-zero error when attempting to remove packages with the fallback method.

## Testing
Now it makes reference to the correct list. Additionally, testing from the issue creator has concluded successfully, making this PR a success.

## Impact
Less buggy behavior

## Issue related to PR
- Resolves #3170

## Additional Information
No documentation changes required

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no errors/warnings/merge conflicts.
