### PR TITLE
Update start.ps1

### DIFF
--- a/scripts/start.ps1
+++ b/scripts/start.ps1
@@ -39,6 +39,7 @@ $sync.version = "#{replaceme}"
 $sync.configs = @{}
 $sync.ProcessRunning = $false
 
+
 if (!([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
     Write-Output "Winutil needs to be run as Administrator. Attempting to relaunch."
     $argList = @()
@@ -46,21 +47,23 @@ if (!([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]:
     $PSBoundParameters.GetEnumerator() | ForEach-Object {
         $argList += if ($_.Value -is [switch] -and $_.Value) {
             "-$($_.Key)"
+        } elseif ($_.Value -is [array]) {
+            "-$($_.Key) $($_.Value -join ',')"
         } elseif ($_.Value) {
-            "-$($_.Key) `"$($_.Value)`""
+            "-$($_.Key) '$($_.Value)'"
         }
     }
-
-    $script = if ($MyInvocation.MyCommand.Path) {
-        "& { & '$($MyInvocation.MyCommand.Path)' $argList }"
+    
+    $script = if ($PSCommandPath) {
+        "& { & `"$($PSCommandPath)`" $($argList -join ' ') }"
     } else {
-        "iex '& { $(irm https://github.com/ChrisTitusTech/winutil/releases/latest/download/winutil.ps1) } $argList'"
+        "&([ScriptBlock]::Create((irm https://github.com/ChrisTitusTech/winutil/releases/latest/download/winutil.ps1))) $($argList -join ' ')"
     }
-
+    
     $powershellcmd = if (Get-Command pwsh -ErrorAction SilentlyContinue) { "pwsh" } else { "powershell" }
     $processCmd = if (Get-Command wt.exe -ErrorAction SilentlyContinue) { "wt.exe" } else { $powershellcmd }
-
-    Start-Process $processCmd -ArgumentList "$powershellcmd -ExecutionPolicy Bypass -NoProfile -Command $script" -Verb RunAs
+    
+    Start-Process $processCmd -ArgumentList "$powershellcmd -ExecutionPolicy Bypass -NoProfile -Command `"$script`"" -Verb RunAs
 
     break
 }


### PR DESCRIPTION
fix logic of permissions elevation process

<!--Before you make this PR have you followed the docs here? - https://christitustech.github.io/winutil/contribute/ -->

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
I've encountered the same issue in multiple installation of Windows, in pwsh and powershell as described in issue #3099 when trying to run the winutil script:

```
> irm "https://christitus.com/win" | iex
Winutil needs to be run as Administrator. Attempting to relaunch.
Start-Process : This command cannot be run due to the error: The parameter is incorrect.
At line:68 char:5
+     Start-Process $processCmd -ArgumentList "$powershellcmd -Executio ...
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [Start-Process], InvalidOperationException
    + FullyQualifiedErrorId : InvalidOperationException,Microsoft.PowerShell.Commands.StartProcessCommand
```

## Testing
I was able to fix this issue by updating the logic for elevation of permissions. Here is a link to my test script for elevation of permissions on GitHub Gist:
[emilwojcik93](https://gist.github.com/emilwojcik93)/[admin-script.ps1](https://gist.github.com/emilwojcik93/91a272c996b03c4d51a19702641466a0)

I even tested this method by editing the winutil script with my updated logic for elevation of permissions, which is demonstrated in the demo video.

Please refer to the provided script and video for a detailed solution to the elevation of permissions issue.

https://github.com/user-attachments/assets/d317f039-510b-45b1-8da5-362fede8ace8

## Impact
Script might startup differently in different kind of terminals/shells (pwsh/powershell/wt)

## Issue related to PR
[Relaunching as Administrator is not working #3099](https://github.com/ChrisTitusTech/winutil/issues/3099)

## Additional Information
I checked this solution only for wt.exe with pwsh (powershell 7) and powershell 5. I didn't verify how it's behaving on Win10, nor with additional pass parameters for script (e.g. config file/debug param)

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
