### PR TITLE
[WinGet] Fix install loop

### DIFF
--- a/functions/private/Test-WinUtilPackageManager.ps1
+++ b/functions/private/Test-WinUtilPackageManager.ps1
@@ -56,7 +56,7 @@ function Test-WinUtilPackageManager {
             # Check if Winget's Version is too old.
             $wingetCurrentVersion = [System.Version]::Parse($wingetVersion.Trim('v'))
             # Grabs the latest release of Winget from the Github API for version check process.
-            $response = winget search -e Microsoft.AppInstaller
+            $response = winget search -e Microsoft.AppInstaller --accept-source-agreements
             $wingetLatestVersion = ($response | Select-String -Pattern '\d+\.\d+\.\d+\.\d+').Matches.Value
             Write-Host "Latest Search Version: $wingetLatestVersion" -ForegroundColor White
             Write-Host "Current Installed Version: $wingetCurrentVersion" -ForegroundColor White


### PR DESCRIPTION
## Type of Change
- [X] Bug fix

## Description
Only a parameter in `winget search` was required.

## Testing
It now works correctly everywhere:

![imagen](https://github.com/user-attachments/assets/af04f191-09df-4186-834a-081a0a70d08e)

## Impact
Less buggy behavior.

## Issue related to PR
<!--[What issue/discussion is related to this PR (if any)]-->
- Resolves #3234

## Additional Information

@ChrisTitusTech, **IT IS IMPORTANT THAT YOU READ THIS!!!**

This PR only focuses on fixing the version query issue. More things need to be done for the WinGet install:

- After the AppX package is installed, the script needs to be restarted
- `Repair-WinGetPackageManager` may not be present in a user's PowerShell session due to missing modules, since it doesn't come as a standard cmdlet

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no errors/warnings/merge conflicts.
