### PR TITLE
Fix Double Click problem by using UIElement Names instead of Types

### DIFF
--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -303,8 +303,8 @@ $sync["Form"].Add_MouseLeftButtonDown({
 })
 
 $sync["Form"].Add_MouseDoubleClick({
-    if ($_.OriginalSource -is [System.Windows.Controls.Grid] -or
-        $_.OriginalSource -is [System.Windows.Controls.StackPanel]) {
+    if ($_.OriginalSource.Name -eq "NavDockPanel" -OR
+        $_.OriginalSource.Name -eq "GridBesideNavDockPanel") {
             if ($sync["Form"].WindowState -eq [Windows.WindowState]::Normal) {
                 $sync["Form"].WindowState = [Windows.WindowState]::Maximized
             }

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -303,7 +303,7 @@ $sync["Form"].Add_MouseLeftButtonDown({
 })
 
 $sync["Form"].Add_MouseDoubleClick({
-    if ($_.OriginalSource.Name -eq "NavDockPanel" -OR
+    if ($_.OriginalSource.Name -eq "NavDockPanel" -or
         $_.OriginalSource.Name -eq "GridBesideNavDockPanel") {
             if ($sync["Form"].WindowState -eq [Windows.WindowState]::Normal) {
                 $sync["Form"].WindowState = [Windows.WindowState]::Maximized

--- a/xaml/inputXML.xaml
+++ b/xaml/inputXML.xaml
@@ -851,7 +851,7 @@
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*"/>
         </Grid.ColumnDefinitions>
-        <DockPanel HorizontalAlignment="Stretch" Background="{DynamicResource MainBackgroundColor}" SnapsToDevicePixels="True" Grid.Row="0" Width="Auto">
+        <DockPanel Name="NavDockPanel" HorizontalAlignment="Stretch" Background="{DynamicResource MainBackgroundColor}" SnapsToDevicePixels="True" Grid.Row="0" Width="Auto">
             <StackPanel Name="NavLogoPanel" Orientation="Horizontal" HorizontalAlignment="Left" Background="{DynamicResource MainBackgroundColor}" SnapsToDevicePixels="True" Margin="10,0,20,0">
             </StackPanel>
             <ToggleButton Margin="0,0,5,0" HorizontalAlignment="Left" Height="{DynamicResource TabButtonHeight}" Width="{DynamicResource TabButtonWidth}"
@@ -894,7 +894,7 @@
                     </TextBlock>
                 </ToggleButton.Content>
             </ToggleButton>
-            <Grid Background="{DynamicResource MainBackgroundColor}" ShowGridLines="False" Width="Auto" Height="Auto" HorizontalAlignment="Stretch">
+            <Grid Name="GridBesideNavDockPanel" Background="{DynamicResource MainBackgroundColor}" ShowGridLines="False" Width="Auto" Height="Auto" HorizontalAlignment="Stretch">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*"/> <!-- Main content area -->
                     <ColumnDefinition Width="Auto"/><!-- Space for options button -->


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://christitustech.github.io/winutil/contribute/ -->

## Type of Change
- [x] Bug fix

## Description
This approach would guarantee that double clicking to maximize the window would only work on top row of WinUtil. It's a simple approach.. but a one that works really well (as far as I can tell).

## Testing
Tested it by Double Clicking on:
- The intended areas (top row) - Works
- Other places of WinUtil, like Grids, StackPanels, Buttons of different types from toggles to normal buttons, and so on... - Did not maximize the window (as intended)
- Double Clicking on Settings/Theme popup buttons - Did not maximize the window (as intended)

## Impact
Now clicking anywhere on WinUtil, other then top row, doesn't cause it to maximize the window.

## Additional Information
This problem has been fixed by @Marterich in PR #2768, but I've faced this problem _again_ when testing out @MyDrift-user 's PR on Update Tab (PR #3230).

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
