### PR TITLE
Correct the Header Font Size

### DIFF
--- a/config/themes.json
+++ b/config/themes.json
@@ -7,7 +7,7 @@
         "CustomDialogHeight":         "200",
         "FontSize":         "12",
         "FontFamily":       "Arial",
-        "HeaderFontSize":  "18",
+        "HeaderFontSize":  "16",
         "HeaderFontFamily": "Consolas, Monaco",
         "CheckBoxBulletDecoratorSize": "14",
         "CheckBoxMargin": "15,0,0,2",

--- a/config/themes.json
+++ b/config/themes.json
@@ -7,7 +7,7 @@
         "CustomDialogHeight":         "200",
         "FontSize":         "12",
         "FontFamily":       "Arial",
-        "HeadingFontSize":  "16",
+        "HeaderFontSize":  "18",
         "HeaderFontFamily": "Consolas, Monaco",
         "CheckBoxBulletDecoratorSize": "14",
         "CheckBoxMargin": "15,0,0,2",

--- a/functions/private/Initialize-InstallCategoryAppList.ps1
+++ b/functions/private/Initialize-InstallCategoryAppList.ps1
@@ -42,7 +42,7 @@ function Initialize-InstallCategoryAppList {
         $loadingLabel.Content = "Loading, please wait..."
         $loadingLabel.HorizontalAlignment = "Center"
         $loadingLabel.VerticalAlignment = "Center"
-        $loadingLabel.SetResourceReference([Windows.Controls.Control]::FontSizeProperty, "FontSizeHeading")
+        $loadingLabel.SetResourceReference([Windows.Controls.Control]::FontSizeProperty, "HeaderFontSize")
         $loadingLabel.FontWeight = [Windows.FontWeights]::Bold
         $loadingLabel.Foreground = [Windows.Media.Brushes]::Gray
         $sync.LoadingLabel = $loadingLabel

--- a/functions/private/Initialize-InstallHeader.ps1
+++ b/functions/private/Initialize-InstallHeader.ps1
@@ -29,7 +29,8 @@ function Initialize-InstallHeader {
     $buttonConfigs = @(
         @{Name="WPFInstall"; Content="Install/Upgrade Selected"},
         @{Name="WPFInstallUpgrade"; Content="Upgrade All"},
-        @{Name="WPFUninstall"; Content="Uninstall Selected"}
+        @{Name="WPFUninstall"; Content="Uninstall Selected"},
+        @{Name="WPFselectedAppsButton"; Content="Selected Apps: 0"}
     )
 
     foreach ($config in $buttonConfigs) {
@@ -38,18 +39,9 @@ function Initialize-InstallHeader {
         $sync[$config.Name] = $button
     }
 
-    $selectedAppsButton = New-Object Windows.Controls.Button
-    $selectedAppsButton.Name = "WPFselectedAppsButton"
-    $selectedAppsButton.Content = "Selected Apps: 0"
-    $selectedAppsButton.SetResourceReference([Windows.Controls.Control]::FontSizeProperty, "FontSizeHeading")
-    $selectedAppsButton.SetResourceReference([Windows.Controls.Control]::MarginProperty, "TabContentMargin")
-    $selectedAppsButton.SetResourceReference([Windows.Controls.Control]::ForegroundProperty, "MainForegroundColor")
-    $selectedAppsButton.HorizontalAlignment = "Center"
-    $selectedAppsButton.VerticalAlignment = "Center"
-
     $selectedAppsPopup = New-Object Windows.Controls.Primitives.Popup
     $selectedAppsPopup.IsOpen = $false
-    $selectedAppsPopup.PlacementTarget = $selectedAppsButton
+    $selectedAppsPopup.PlacementTarget = $sync.WPFselectedAppsButton
     $selectedAppsPopup.Placement = [System.Windows.Controls.Primitives.PlacementMode]::Bottom
     $selectedAppsPopup.AllowsTransparency = $true
 
@@ -66,23 +58,20 @@ function Initialize-InstallHeader {
     $selectedAppsBorder.Child = $sync.selectedAppsstackPanel
 
     # Toggle selectedAppsPopup open/close with button
-    $selectedAppsButton.Add_Click({
+    $sync.WPFselectedAppsButton.Add_Click({
         $sync.selectedAppsPopup.IsOpen = -not $sync.selectedAppsPopup.IsOpen
     })
     # Close selectedAppsPopup when mouse leaves both button and selectedAppsPopup
-    $selectedAppsButton.Add_MouseLeave({
+    $sync.WPFselectedAppsButton.Add_MouseLeave({
         if (-not $sync.selectedAppsPopup.IsMouseOver) {
             $sync.selectedAppsPopup.IsOpen = $false
         }
     })
     $selectedAppsPopup.Add_MouseLeave({
-        if (-not $selectedAppsButton.IsMouseOver) {
+        if (-not $sync.WPFselectedAppsButton.IsMouseOver) {
             $sync.selectedAppsPopup.IsOpen = $false
         }
     })
-
-    $null = $wrapPanelTop.Children.Add($selectedAppsButton)
-    $sync.$($selectedAppsButton.Name) = $selectedAppsButton
 
     [Windows.Controls.DockPanel]::SetDock($wrapPanelTop, [Windows.Controls.Dock]::Top)
     $null = $TargetElement.Children.Add($wrapPanelTop)

--- a/functions/public/Invoke-WPFUIElements.ps1
+++ b/functions/public/Invoke-WPFUIElements.ps1
@@ -144,7 +144,7 @@ function Invoke-WPFUIElements {
 
             $label = New-Object Windows.Controls.Label
             $label.Content = $category -replace ".*__", ""
-            $label.SetResourceReference([Windows.Controls.Control]::FontSizeProperty, "FontSizeHeading")
+            $label.SetResourceReference([Windows.Controls.Control]::FontSizeProperty, "HeaderFontSize")
             $label.SetResourceReference([Windows.Controls.Control]::FontFamilyProperty, "HeaderFontFamily")
             $itemsControl.Items.Add($label) | Out-Null
             $sync[$category] = $label

--- a/xaml/inputXML.xaml
+++ b/xaml/inputXML.xaml
@@ -202,7 +202,7 @@
             <Setter Property="Foreground" Value="{DynamicResource LabelboxForegroundColor}"/>
             <Setter Property="Background" Value="{DynamicResource MainBackgroundColor}"/>
             <Setter Property="FontFamily" Value="{DynamicResource HeaderFontFamily}"/>
-            <Setter Property="FontSize" Value="{DynamicResource FontSizeHeading}"/>
+            <Setter Property="FontSize" Value="{DynamicResource HeaderFontSize}"/>
             <Setter Property="HorizontalAlignment" Value="Stretch"/>
             <Setter Property="VerticalAlignment" Value="Center"/>
             <Setter Property="HorizontalContentAlignment" Value="Left"/>


### PR DESCRIPTION
## Type of Change

- [x] Bug fix
- [x] Refactoring
- [x] UI/UX improvement

## Description
<!--[Provide a detailed explanation of the changes you have made. Include the reasons behind these changes and any relevant context. Link any related issues.]-->

The naming for the Header fonts size seems to have been corrupted so that the size property couldn't be referenced anymore and the Headers (for example for the app cateories) were way too small.

This PR also simplifies and unifies the creation of the "Selected Apps" button on the Apps page to use the same logic and styling as the rest of the buttons.

## Impact
<!--[Discuss the impact of your changes on the project. This might include effects on performance, new dependencies, or changes in behaviour.]-->
The Categories and Elements using the Header Font Size are now way easier to read, especially on High DPI screens