### PR TITLE
feat: disable explorer automatic folder discovery

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -3791,6 +3791,8 @@
 
       Remove-Item -Path $bagsMRU -Recurse -Force
       Write-Host \"Removed $bagsMRU\"
+
+      Write-Host Please sign out and back in, or restart your computer to apply the changes!
       "
     ],
   },

--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -3740,5 +3740,34 @@
     "Type": "Button",
     "ButtonWidth": "300",
     "link": "https://christitustech.github.io/winutil/dev/tweaks/Performance-Plans/RemoveUltPerf"
-  }
+  },
+  "WPFTweaksDisableExplorerAutoDiscovery": {
+    "Content": "Disable Explorer automatic folder discovery",
+    "Description": "Windows Explorer automatically tries to guess the type of the folder based on its contents, slowing down the browsing experience.",
+    "category": "Essential Tweaks",
+    "panel": "1",
+    "Order": "a017_",
+    "InvokeScript": [
+      "
+      $bags = \"HKCU:\\Software\\Classes\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\Bags\"
+      $bagsMRU = \"HKCU:\\Software\\Classes\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\BagsMRU\"
+
+      Remove-Item -Path $bags -Recurse -Force
+      Write-Host \"Removed $bags\"
+
+      Remove-Item -Path $bagsMRU -Recurse -Force
+      Write-Host \"Removed $bagsMRU\"
+
+      $allFolders = \"HKCU:\\Software\\Classes\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\Bags\\AllFolders\\Shell\"
+
+      if (!(Test-Path $allFolders)) {
+        New-Item -Path $allFolders -Force
+        Write-Host \"Created $allFolders\"
+      }
+
+      New-ItemProperty -Path $allFolders -Name \"FolderType\" -Value \"NotSpecified\" -PropertyType String -Force
+      Write-Host \"Set FolderType to NotSpecified\"
+      "
+    ],
+  },
 }

--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -3777,5 +3777,21 @@
       Write-Host Please sign out and back in, or restart your computer to apply the changes!
       "
     ],
+    "UndoScript": [
+      "
+      # Previously detected folders
+      $bags = \"HKCU:\\Software\\Classes\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\Bags\"
+
+      # Folder types lookup table
+      $bagsMRU = \"HKCU:\\Software\\Classes\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\BagsMRU\"
+
+      # Flush explorer view database
+      Remove-Item -Path $bags -Recurse -Force
+      Write-Host \"Removed $bags\"
+
+      Remove-Item -Path $bagsMRU -Recurse -Force
+      Write-Host \"Removed $bagsMRU\"
+      "
+    ],
   },
 }

--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -3749,15 +3749,20 @@
     "Order": "a017_",
     "InvokeScript": [
       "
+      # Previously detected folders
       $bags = \"HKCU:\\Software\\Classes\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\Bags\"
+
+      # Folder types lookup table
       $bagsMRU = \"HKCU:\\Software\\Classes\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\BagsMRU\"
 
+      # Flush explorer view database
       Remove-Item -Path $bags -Recurse -Force
       Write-Host \"Removed $bags\"
 
       Remove-Item -Path $bagsMRU -Recurse -Force
       Write-Host \"Removed $bagsMRU\"
 
+      # Every folder
       $allFolders = \"HKCU:\\Software\\Classes\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\Bags\\AllFolders\\Shell\"
 
       if (!(Test-Path $allFolders)) {
@@ -3765,8 +3770,11 @@
         Write-Host \"Created $allFolders\"
       }
 
+      # Generic view
       New-ItemProperty -Path $allFolders -Name \"FolderType\" -Value \"NotSpecified\" -PropertyType String -Force
       Write-Host \"Set FolderType to NotSpecified\"
+
+      Write-Host Please sign out and back in, or restart your computer to apply the changes!
       "
     ],
   },

--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -3753,14 +3753,14 @@
       $bags = \"HKCU:\\Software\\Classes\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\Bags\"
 
       # Folder types lookup table
-      $bagsMRU = \"HKCU:\\Software\\Classes\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\BagsMRU\"
+      $bagMRU = \"HKCU:\\Software\\Classes\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\BagMRU\"
 
       # Flush explorer view database
       Remove-Item -Path $bags -Recurse -Force
       Write-Host \"Removed $bags\"
 
-      Remove-Item -Path $bagsMRU -Recurse -Force
-      Write-Host \"Removed $bagsMRU\"
+      Remove-Item -Path $bagMRU -Recurse -Force
+      Write-Host \"Removed $bagMRU\"
 
       # Every folder
       $allFolders = \"HKCU:\\Software\\Classes\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\Bags\\AllFolders\\Shell\"
@@ -3783,14 +3783,14 @@
       $bags = \"HKCU:\\Software\\Classes\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\Bags\"
 
       # Folder types lookup table
-      $bagsMRU = \"HKCU:\\Software\\Classes\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\BagsMRU\"
+      $bagMRU = \"HKCU:\\Software\\Classes\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\BagMRU\"
 
       # Flush explorer view database
       Remove-Item -Path $bags -Recurse -Force
       Write-Host \"Removed $bags\"
 
-      Remove-Item -Path $bagsMRU -Recurse -Force
-      Write-Host \"Removed $bagsMRU\"
+      Remove-Item -Path $bagMRU -Recurse -Force
+      Write-Host \"Removed $bagMRU\"
 
       Write-Host Please sign out and back in, or restart your computer to apply the changes!
       "


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://christitustech.github.io/winutil/contribute/ -->

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Windows Explorer automatically tries to guess the type of the folder based on its contents, slowing down the browsing experience, especially on folders with large amounts of media (photos, videos). This simple tweak sets all the folders' type to `NotSpecified`, stopping explorer from (for example) loading media thumbnails.

[Video reference (by Enderman)](https://www.youtube.com/watch?v=ctMyvJsBSzI&t=1073)

## Testing
The `%USERPROFILE%\Pictures` folder (for example) no longer shows large icons with previews.
![image](https://github.com/user-attachments/assets/6836673a-2182-4ffc-ac6b-566516a7b765)

## Impact
Media thumbnails are no longer loaded and displayed.

## Issue related to PR
Closes #3236

## Additional Information
None

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.