### PR TITLE
Remove Balena Etcher due to privacy concerns

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -527,14 +527,6 @@
         "link": "https://espanso.org/",
         "winget": "Espanso.Espanso"
     },
-    "etcher": {
-        "category": "Utilities",
-        "choco": "etcher",
-        "content": "Etcher USB Creator",
-        "description": "Etcher is a powerful tool for creating bootable USB drives with ease.",
-        "link": "https://www.balena.io/etcher/",
-        "winget": "Balena.Etcher"
-    },
     "falkon": {
         "category": "Browsers",
         "choco": "falkon",


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://christitustech.github.io/winutil/contribute/ -->

## Type of Change
- [x] Security patch


## Description
<!--[Provide a detailed explanation of the changes you have made. Include the reasons behind these changes and any relevant context. Link any related issues.]-->
In the recent past, the privacy focused Linux Distro TAILS removed the recommendation to use Balena Etcher to create there USB Keys due to privacy concerns. 
An [investigation](https://gitlab.tails.boum.org/tails/tails/-/issues/16381) on their part resulted in at least the following data being shared with the balena company
* The IP of the user
* The filename of the image, which lets Balena knows that the user is installing Tails
* The brand and model of the USB stick

https://tails.net/news/rufus/index.en.html
https://cybernews.com/privacy/tails-raises-privacy-concerns-over-balenaetcher-recommends-rufus/

## Issue related to PR
<!--[What issue/discussion is related to this PR (if any)]-->
- Resolves #3260
