### PR TITLE
[Tweaks] Disable "News and Interest" widget

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -128,6 +128,23 @@
     ],
     "link": "https://christitustech.github.io/winutil/dev/tweaks/Essential-Tweaks/Home"
   },
+  "WPFTweaksDisableNews": {
+    "Content": "Disable News and Interest in Taskbar",
+    "Description": "Disables the 'News and Interest' taskbar widget.",
+    "category": "Essential Tweaks",
+    "panel": "1",
+    "Order": "a005_",
+    "registry": [
+      {
+        "Path": "HKLM:\\SOFTWARE\\Policies\\Microsoft\\Windows\\Windows Feeds",
+        "Name": "EnableFeeds",
+        "Value": "0",
+        "OriginalValue": "1",
+        "Type": "DWord"
+      }
+    ],
+    "link": "https://christitustech.github.io/winutil/dev/tweaks/Essential-Tweaks/DisableNews"
+  },
   "WPFTweaksLoc": {
     "Content": "Disable Location Tracking",
     "Description": "Disables Location Tracking...DUH!",


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://christitustech.github.io/winutil/contribute/ -->

## Type of Change
- [X] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Get rid of the "News and Tweaks" widget in the bottom right of the taskbar more permanently and with less clicks than just hiding it.

Mentioned in #555.


## Testing
With Windows 10 22H2:
- Run tweak.
- Undo tweak.

## Impact
Additional tweak to "Essential Tweaks" list.


## Issue related to PR
- Resolves #555

## Additional Information
<!--[Any additional information that reviewers should be aware of.]-->

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no errors/warnings/merge conflicts.
