### PR TITLE
Refactor preferChocolatey system to handle other package managers easier

### DIFF
--- a/functions/private/Get-WinUtilSelectedPackages.ps1
+++ b/functions/private/Get-WinUtilSelectedPackages.ps1
@@ -1,0 +1,59 @@
+function Get-WinUtilSelectedPackages
+{
+     <#
+    .SYNOPSIS
+        Sorts given packages based on installer preference and availability.
+
+    .OUTPUTS
+        Hashtable. Key = Package Manager, Value = ArrayList of packages to install
+    #>
+    param (
+        [Parameter(Mandatory=$true)]
+        $PackageList,
+        [Parameter(Mandatory=$true)]
+        [PackageManagers]$Preference
+    )
+
+    if ($PackageList.count -eq 1) {
+        $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -state "Indeterminate" -value 0.01 -overlay "logo" })
+    } else {
+        $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -state "Normal" -value 0.01 -overlay "logo" })
+    }
+
+    $packages = [System.Collections.Hashtable]::new()
+    $packagesWinget = [System.Collections.ArrayList]::new()
+    $packagesChoco = [System.Collections.ArrayList]::new()
+    $packages[[PackageManagers]::Winget] = $packagesWinget
+    $packages[[PackageManagers]::Choco] = $packagesChoco
+
+    Write-Debug "Checking packages using Preference '$($Preference)'"
+
+    foreach ($package in $PackageList) {
+        switch ($Preference) {
+            "Choco" {
+                if ($package.choco -eq "na") {
+                    Write-Debug "$($package.content) has no Choco value."
+                    $packagesWinget.add($package.winget)
+                    Write-Host "Queueing $($package.winget) for Winget"
+                } else {
+                    $null = $packagesChoco.add($package.choco)
+                    Write-Host "Queueing $($package.choco) for Chocolatey"
+                }
+                break
+            }
+            "Winget" {
+                if ($package.winget -eq "na") {
+                    Write-Debug "$($package.content) has no Winget value."
+                    $packagesChoco.add($package.choco)
+                    Write-Host "Queueing $($package.choco) for Chocolatey"
+                } else {
+                    $null = $packagesWinget.add($($package.winget))
+                    Write-Host "Queueing $($package.winget) for Winget"
+                }
+                break
+            }
+        }
+    }
+
+    return $packages
+}

--- a/functions/private/Set-PackageManagerPreference.ps1
+++ b/functions/private/Set-PackageManagerPreference.ps1
@@ -1,0 +1,47 @@
+function Set-PackageManagerPreference {
+    <#
+    .SYNOPSIS
+        Sets the currently selected package manager to global "ManagerPreference" in sync.
+        Also persists preference across Winutil restarts via preference.ini.
+
+        Reads from preference.ini if no argument sent.
+
+    .PARAMETER preferedPackageManager
+        The PackageManager that was selected.
+    #>
+    param(
+        [Parameter(Position=0, Mandatory=$false)]
+        [PackageManagers]$preferedPackageManager
+    )
+
+    $preferencePath = "$env:LOCALAPPDATA\winutil\preferences.ini"
+    $oldChocoPath = "$env:LOCALAPPDATA\winutil\preferChocolatey.ini"
+
+    #Try loading from file if no argument given.
+    if ($null -eq $preferedPackageManager) {
+        # Backwards compat for preferChocolatey.ini
+        if (Test-Path -Path $oldChocoPath)
+        {
+            $preferedPackageManager = [PackageManagers]::Choco
+            Remove-Item -Path $oldChocoPath
+        }
+        else
+        {
+            $potential = Get-Content -Path $preferencePath -TotalCount 1
+            if ($potential)
+                {$preferedPackageManager = [PackageManagers]$potential}
+        }
+    }
+
+    #If no preference argument, .ini file bad read, and $sync empty then default to winget.
+    if ($null -eq $preferedPackageManager -and $null -eq $sync["ManagerPreference"])
+        { $preferedPackageManager = [PackageManagers]::Winget }
+
+
+    $sync["ManagerPreference"] = [PackageManagers]::$preferedPackageManager
+    Write-Debug "Manager Preference changed to '$($sync["ManagerPreference"])'"
+
+
+    # Write preference to file to persist across restarts.
+    Out-File -FilePath $preferencePath -InputObject $sync["ManagerPreference"]
+}

--- a/functions/private/Set-PackageManagerPreference.ps1
+++ b/functions/private/Set-PackageManagerPreference.ps1
@@ -20,13 +20,11 @@ function Set-PackageManagerPreference {
     #Try loading from file if no argument given.
     if ($null -eq $preferedPackageManager) {
         # Backwards compat for preferChocolatey.ini
-        if (Test-Path -Path $oldChocoPath)
-        {
+        if (Test-Path -Path $oldChocoPath) {
             $preferedPackageManager = [PackageManagers]::Choco
             Remove-Item -Path $oldChocoPath
         }
-        else
-        {
+        else {
             $potential = Get-Content -Path $preferencePath -TotalCount 1
             if ($potential)
                 {$preferedPackageManager = [PackageManagers]$potential}

--- a/functions/public/Invoke-WPFGetInstalled.ps1
+++ b/functions/public/Invoke-WPFGetInstalled.ps1
@@ -18,15 +18,15 @@ function Invoke-WPFGetInstalled {
     if (($sync.ChocoRadioButton.IsChecked -eq $false) -and ((Test-WinUtilPackageManager -winget) -eq "not-installed") -and $checkbox -eq "winget") {
         return
     }
-    $preferChoco = $sync.ChocoRadioButton.IsChecked
+    $managerPreference = $sync["ManagerPreference"]
     $sync.ItemsControl.Dispatcher.Invoke([action] {
             $sync.ItemsControl.Items | ForEach-Object { $_.Visibility = [Windows.Visibility]::Collapsed }
             $null = $sync.itemsControl.Items.Add($sync.LoadingLabel)
         })
-    Invoke-WPFRunspace -ParameterList @(("preferChoco", $preferChoco),("checkbox", $checkbox),("ShowOnlyCheckedApps", ${function:Show-OnlyCheckedApps})) -DebugPreference $DebugPreference -ScriptBlock {
+    Invoke-WPFRunspace -ParameterList @(("managerPreference", $managerPreference),("checkbox", $checkbox),("ShowOnlyCheckedApps", ${function:Show-OnlyCheckedApps})) -DebugPreference $DebugPreference -ScriptBlock {
         param (
             [string]$checkbox,
-            [boolean]$preferChoco,
+            [PackageManagers]$managerPreference,
             [scriptblock]$ShowOnlyCheckedApps
         )
         $sync.ProcessRunning = $true
@@ -34,8 +34,10 @@ function Invoke-WPFGetInstalled {
 
         if ($checkbox -eq "winget") {
             Write-Host "Getting Installed Programs..."
-            if ($preferChoco) { $Checkboxes = Invoke-WinUtilCurrentSystem -CheckBox "choco" }
-            else { $Checkboxes = Invoke-WinUtilCurrentSystem -CheckBox $checkbox }
+            switch ($managerPreference) {
+                "Choco"{$Checkboxes = Invoke-WinUtilCurrentSystem -CheckBox "choco"; break}
+                "Winget"{$Checkboxes = Invoke-WinUtilCurrentSystem -CheckBox $checkbox; break}
+            }
         }
         elseif ($checkbox -eq "tweaks") {
             Write-Host "Getting Installed Tweaks..."

--- a/functions/public/Invoke-WPFUnInstall.ps1
+++ b/functions/public/Invoke-WPFUnInstall.ps1
@@ -29,46 +29,20 @@ function Invoke-WPFUnInstall {
     $confirm = [System.Windows.MessageBox]::Show($Messageboxbody, $MessageboxTitle, $ButtonType, $MessageIcon)
 
     if($confirm -eq "No") {return}
-    $ChocoPreference = $($sync.ChocoRadioButton.IsChecked)
 
-    Invoke-WPFRunspace -ArgumentList @(("PackagesToUninstall", $PackagesToUninstall),("ChocoPreference", $ChocoPreference)) -DebugPreference $DebugPreference -ScriptBlock {
-        param($PackagesToUninstall, $ChocoPreference, $DebugPreference)
-        if ($PackagesToUninstall.count -eq 1) {
-            $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -state "Indeterminate" -value 0.01 -overlay "logo" })
-        } else {
-            $sync.form.Dispatcher.Invoke([action]{ Set-WinUtilTaskbaritem -state "Normal" -value 0.01 -overlay "logo" })
-        }
-        $packagesWinget, $packagesChoco = {
-            $packagesWinget = [System.Collections.ArrayList]::new()
-            $packagesChoco = [System.Collections.ArrayList]::new()
+    $ManagerPreference = $sync["ManagerPreference"]
 
-        foreach ($package in $PackagesToUninstall) {
-            if ($ChocoPreference) {
-                if ($package.choco -eq "na") {
-                    $packagesWinget.add($package.winget)
-                    Write-Host "Queueing $($package.winget) for Winget uninstall"
-                } else {
-                    $null = $packagesChoco.add($package.choco)
-                    Write-Host "Queueing $($package.choco) for Chocolatey uninstall"
-                }
-            }
-            else {
-                if ($package.winget -eq "na") {
-                    $packagesChoco.add($package.choco)
-                    Write-Host "Queueing $($package.choco) for Chocolatey uninstall"
-                } else {
-                    $null = $packagesWinget.add($($package.winget))
-                    Write-Host "Queueing $($package.winget) for Winget uninstall"
-                }
-            }
-        }
-        return $packagesWinget, $packagesChoco
-        }.Invoke($PackagesToUninstall)
+    Invoke-WPFRunspace -ArgumentList @(("PackagesToUninstall", $PackagesToInstall),("ManagerPreference", $ManagerPreference)) -DebugPreference $DebugPreference -ScriptBlock {
+        param($PackagesToUninstall, $ManagerPreference, $DebugPreference)
+
+        $packagesSorted = Get-WinUtilSelectedPackages -PackageList $PackagesToInstall -Preference $ManagerPreference
+        $packagesWinget = $packagesSorted[[PackageManagers]::Winget]
+        $packagesChoco = $packagesSorted[[PackageManagers]::Choco]
 
         try {
             $sync.ProcessRunning = $true
 
-            # Install all selected programs in new window
+            # Uninstall all selected programs in new window
             if($packagesWinget.Count -gt 0) {
                 Install-WinUtilProgramWinget -Action Uninstall -Programs $packagesWinget
             }

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -1,3 +1,12 @@
+# Create enums
+Add-Type @"
+public enum PackageManagers
+{
+    Winget,
+    Choco
+}
+"@
+
 # SPDX-License-Identifier: MIT
 # Set the maximum number of threads for the RunspacePool to the number of threads on the machine
 $maxthreads = [int]$env:NUMBER_OF_PROCESSORS
@@ -140,12 +149,14 @@ Invoke-WPFUIElements -configVariable $sync.configs.feature -targetGridName "feat
 
 $xaml.SelectNodes("//*[@Name]") | ForEach-Object {$sync["$("$($psitem.Name)")"] = $sync["Form"].FindName($psitem.Name)}
 
-#Persist the Chocolatey preference across winutil restarts
-$ChocoPreferencePath = "$env:LOCALAPPDATA\winutil\preferChocolatey.ini"
-$sync.ChocoRadioButton.Add_Checked({New-Item -Path $ChocoPreferencePath -Force })
-$sync.ChocoRadioButton.Add_Unchecked({Remove-Item $ChocoPreferencePath -Force})
-if (Test-Path $ChocoPreferencePath) {
-   $sync.ChocoRadioButton.IsChecked = $true
+#Persist Package Manager preference across winutil restarts
+$sync.ChocoRadioButton.Add_Checked({Set-PackageManagerPreference Choco})
+$sync.WingetRadioButton.Add_Checked({Set-PackageManagerPreference Winget})
+Set-PackageManagerPreference
+
+switch ($sync["ManagerPreference"]) {
+    "Choco" {$sync.ChocoRadioButton.IsChecked = $true; break}
+    "Winget" {$sync.WingetRadioButton.IsChecked = $true; break}
 }
 
 $sync.keys | ForEach-Object {


### PR DESCRIPTION
## Type of Change
-  New feature
-  Bug fix
-  Documentation update
- [X] Refactoring
- Hotfix
- Security patch
-  UI/UX improvement

## Description
I heard in a recent video that CTT wanted to add Scoop sometime in the future. Since I added local installs in my own fork, I went ahead and looked into just making it easier to add different package managers.

The two major changes are:
1. Factor out duplicate code in `WPFInstall` and `WPFUninstall`  that handles organizing packages into which package manager to use. Now both functions call `Get-WinUtilSelectedPackages` for this.
2. Use Enum `PackageManagers` to reference package managers instead of raw string.

With the following changes as well:
- Added `$sync["ManagerPreference"]` to keep track of favored package manager.
- Changed instances of `preferChoco` to instead read from `$sync["ManagerPreference"]`
- Instead of persisting preference by file existence, now stores value in `preference.ini`
- Moved functionality for altering and persisting package manager preference from `main.ps1` to `Set-PackageManagerPreference.ps1` which is called once in main and also whenever a package manager radio button is pressed.


## Testing
<!--[Detail the testing you have performed to ensure that these changes function as intended. Include information about any added tests.]-->
Tested on Win10 22H2
Tested with PS Version 7.5 Core
- Install Notepad++(winget)
- Uninstall Notepad++(winget)
- Install Notepad++(choco)
- Uninstall Notepad++(choco)
- Run Get Installed (winget)
- Change preference to choco, restart. Still Choco.
- Change preference to winget, restart. Still Winget.
- Ran with no `preferences.ini`
- Ran with gibberish in 1st line of `preferences.ini`.
- Ran with `preferChocolatey.ini`
- Install Notepad++(choco)
- Uninstall Notepad++(choco)

## Impact
No visual changes visible to UI. 
"preferChocolatey.ini" is now deprecated in favor of "preference.ini", but any instance of the old .ini file will be converted into the new one.

## Issue related to PR
<!--[What issue/discussion is related to this PR (if any)]-->
- Resolves #

## Additional Information
<!--[Any additional information that reviewers should be aware of.]-->

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [X ] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [X] My changes generate no errors/warnings/merge conflicts.
