### PR TITLE
Remove inline C# Type to get the window dimensions

### DIFF
--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -191,7 +191,7 @@ Invoke-WPFRunspace -ScriptBlock {
         $sync.ConfigLoaded = $True
     }
     finally{
-        $ProgressPreference = "Continue"
+        $ProgressPreference = $oldProgressPreference
     }
 
 } | Out-Null
@@ -320,55 +320,6 @@ $sync["Form"].Add_Deactivated({
 })
 
 $sync["Form"].Add_ContentRendered({
-
-    try {
-        [void][Window]
-    } catch {
-Add-Type @"
-        using System;
-        using System.Runtime.InteropServices;
-        public class Window {
-            [DllImport("user32.dll")]
-            public static extern IntPtr SendMessage(IntPtr hWnd, uint Msg, IntPtr wParam, IntPtr lParam);
-
-            [DllImport("user32.dll")]
-            [return: MarshalAs(UnmanagedType.Bool)]
-            public static extern bool GetWindowRect(IntPtr hWnd, out RECT lpRect);
-
-            [DllImport("user32.dll")]
-            [return: MarshalAs(UnmanagedType.Bool)]
-            public static extern bool MoveWindow(IntPtr handle, int x, int y, int width, int height, bool redraw);
-
-            [DllImport("user32.dll")]
-            public static extern int GetSystemMetrics(int nIndex);
-        };
-        public struct RECT {
-            public int Left;   // x position of upper-left corner
-            public int Top;    // y position of upper-left corner
-            public int Right;  // x position of lower-right corner
-            public int Bottom; // y position of lower-right corner
-        }
-"@
-    }
-
-   foreach ($proc in (Get-Process).where{ $_.MainWindowTitle -and $_.MainWindowTitle -like "*titus*" }) {
-        # Check if the process's MainWindowHandle is valid
-        if ($proc.MainWindowHandle -ne [System.IntPtr]::Zero) {
-            Write-Debug "MainWindowHandle: $($proc.Id) $($proc.MainWindowTitle) $($proc.MainWindowHandle)"
-            $windowHandle = $proc.MainWindowHandle
-        } else {
-            Write-Warning "Process found, but no MainWindowHandle: $($proc.Id) $($proc.MainWindowTitle)"
-
-        }
-    }
-
-    $rect = New-Object RECT
-    [Window]::GetWindowRect($windowHandle, [ref]$rect)
-    $width  = $rect.Right  - $rect.Left
-    $height = $rect.Bottom - $rect.Top
-
-    Write-Debug "UpperLeft:$($rect.Left),$($rect.Top) LowerBottom:$($rect.Right),$($rect.Bottom). Width:$($width) Height:$($height)"
-
     # Load the Windows Forms assembly
     Add-Type -AssemblyName System.Windows.Forms
     $primaryScreen = [System.Windows.Forms.Screen]::PrimaryScreen
@@ -383,9 +334,12 @@ Add-Type @"
         Write-Debug "Primary Monitor Height: $screenHeight pixels"
 
         # Compare with the primary monitor size
-        if ($width -gt $screenWidth -or $height -gt $screenHeight) {
+        if ($sync.Form.ActualWidth -gt $screenWidth -or $sync.Form.ActualHeight -gt $screenHeight) {
             Write-Debug "The specified width and/or height is greater than the primary monitor size."
-            [void][Window]::MoveWindow($windowHandle, 0, 0, $screenWidth, $screenHeight, $True)
+            $sync.Form.Left = 0
+            $sync.Form.Top = 0
+            $sync.Form.Width = $screenWidth
+            $sync.Form.Height = $screenHeight
         } else {
             Write-Debug "The specified width and height are within the primary monitor size limits."
         }


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://christitustech.github.io/winutil/contribute/ -->

## Type of Change
- [x] Refactoring

## Description
<!--[Provide a detailed explanation of the changes you have made. Include the reasons behind these changes and any relevant context. Link any related issues.]-->
This pull request simplifies the process of obtaining window dimensions in our PowerShell scripts by eliminating the need for inline C# code. This change enhances readability and performance, making it more accessible for users who are more familiar with PowerShell than C#.



## Testing
<!--[Detail the testing you have performed to ensure that these changes function as intended. Include information about any added tests.]-->
UI Loads and is responsive. 
When the initial window is bigger than the screen, it resizes as expected.

## Issues related to PR
- Resolves: #3279
