### PR TITLE
Fix Search bar functionality across multiple tabs

### DIFF
--- a/functions/private/Find-TweaksByNameOrDescription.ps1
+++ b/functions/private/Find-TweaksByNameOrDescription.ps1
@@ -1,0 +1,104 @@
+function Find-TweaksByNameOrDescription {
+    <#
+        .SYNOPSIS
+            Searches through the Tweaks on the Tweaks Tab and hides all entries that do not match the search string
+
+        .PARAMETER SearchString
+            The string to be searched for
+    #>
+    param(
+        [Parameter(Mandatory=$false)]
+        [string]$SearchString = ""
+    )
+
+    # Reset the visibility if the search string is empty or the search is cleared
+    if ([string]::IsNullOrWhiteSpace($SearchString)) {
+        # Show all categories
+        $tweakspanel = $sync.Form.FindName("tweakspanel")
+        $tweakspanel.Children | ForEach-Object {
+            $_.Visibility = [Windows.Visibility]::Visible
+
+            # Foreach category section, show all items
+            if ($_ -is [Windows.Controls.Border]) {
+                $_.Visibility = [Windows.Visibility]::Visible
+
+                # Find ItemsControl
+                $dockPanel = $_.Child
+                if ($dockPanel -is [Windows.Controls.DockPanel]) {
+                    $itemsControl = $dockPanel.Children | Where-Object { $_ -is [Windows.Controls.ItemsControl] }
+                    if ($itemsControl) {
+                        # Show items in the category
+                        foreach ($item in $itemsControl.Items) {
+                            if ($item -is [Windows.Controls.Label]) {
+                                $item.Visibility = [Windows.Visibility]::Visible
+                            } elseif ($item -is [Windows.Controls.DockPanel] -or
+                                      $item -is [Windows.Controls.StackPanel]) {
+                                $item.Visibility = [Windows.Visibility]::Visible
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return
+    }
+
+    # Search for matching tweaks when search string is not null
+    $tweakspanel = $sync.Form.FindName("tweakspanel")
+    $matchFound = $false
+
+    $tweakspanel.Children | ForEach-Object {
+        $categoryBorder = $_
+        $categoryVisible = $false
+
+        if ($_ -is [Windows.Controls.Border]) {
+            # Find the ItemsControl
+            $dockPanel = $_.Child
+            if ($dockPanel -is [Windows.Controls.DockPanel]) {
+                $itemsControl = $dockPanel.Children | Where-Object { $_ -is [Windows.Controls.ItemsControl] }
+                if ($itemsControl) {
+                    $categoryLabel = $null
+
+                    # Process all items in the ItemsControl
+                    for ($i = 0; $i -lt $itemsControl.Items.Count; $i++) {
+                        $item = $itemsControl.Items[$i]
+
+                        if ($item -is [Windows.Controls.Label]) {
+                            $categoryLabel = $item
+                            $item.Visibility = [Windows.Visibility]::Collapsed
+                        } elseif ($item -is [Windows.Controls.DockPanel]) {
+                            $checkbox = $item.Children | Where-Object { $_ -is [Windows.Controls.CheckBox] } | Select-Object -First 1
+                            $label = $item.Children | Where-Object { $_ -is [Windows.Controls.Label] } | Select-Object -First 1
+
+                            if ($label -and ($label.Content -like "*$SearchString*" -or $label.ToolTip -like "*$SearchString*")) {
+                                $item.Visibility = [Windows.Visibility]::Visible
+                                if ($categoryLabel) { $categoryLabel.Visibility = [Windows.Visibility]::Visible }
+                                $categoryVisible = $true
+                            } else {
+                                $item.Visibility = [Windows.Visibility]::Collapsed
+                            }
+                        } elseif ($item -is [Windows.Controls.StackPanel]) {
+                            # StackPanel which contain checkboxes or other elements
+                            $checkbox = $item.Children | Where-Object { $_ -is [Windows.Controls.CheckBox] } | Select-Object -First 1
+
+                            if ($checkbox -and ($checkbox.Content -like "*$SearchString*" -or $checkbox.ToolTip -like "*$SearchString*")) {
+                                $item.Visibility = [Windows.Visibility]::Visible
+                                if ($categoryLabel) { $categoryLabel.Visibility = [Windows.Visibility]::Visible }
+                                $categoryVisible = $true
+                            } else {
+                                $item.Visibility = [Windows.Visibility]::Collapsed
+                            }
+                        }
+                    }
+                }
+            }
+
+            # Set the visibility based on if any item matched
+            $categoryBorder.Visibility = if ($categoryVisible) { [Windows.Visibility]::Visible } else { [Windows.Visibility]::Collapsed }
+
+            if ($categoryVisible) {
+                $matchFound = $true
+            }
+        }
+    }
+}

--- a/functions/public/Invoke-WPFTab.ps1
+++ b/functions/public/Invoke-WPFTab.ps1
@@ -29,4 +29,30 @@ function Invoke-WPFTab {
         }
     }
     $sync.currentTab = $sync.$tabNav.Items[$tabNumber].Header
+
+    # Always reset the filter for the current tab
+    if ($sync.currentTab -eq "Install") {
+        # Reset Install tab filter
+        Find-AppsByNameOrDescription -SearchString ""
+    } elseif ($sync.currentTab -eq "Tweaks") {
+        # Reset Tweaks tab filter
+        Find-TweaksByNameOrDescription -SearchString ""
+    }
+
+    # Show search bar in Install and Tweaks tabs
+    if ($tabNumber -eq 0 -or $tabNumber -eq 1) {
+        $sync.SearchBar.Visibility = "Visible"
+        $searchIcon = ($sync.Form.FindName("SearchBar").Parent.Children | Where-Object { $_ -is [System.Windows.Controls.TextBlock] -and $_.Text -eq [char]0xE721 })[0]
+        if ($searchIcon) {
+            $searchIcon.Visibility = "Visible"
+        }
+    } else {
+        $sync.SearchBar.Visibility = "Collapsed"
+        $searchIcon = ($sync.Form.FindName("SearchBar").Parent.Children | Where-Object { $_ -is [System.Windows.Controls.TextBlock] -and $_.Text -eq [char]0xE721 })[0]
+        if ($searchIcon) {
+            $searchIcon.Visibility = "Collapsed"
+        }
+        # Hide the clear button if it's visible
+        $sync.SearchBarClearButton.Visibility = "Collapsed"
+    }
 }

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -248,6 +248,10 @@ $sync["Form"].Add_Closing({
 $sync.SearchBarClearButton.Add_Click({
     $sync.SearchBar.Text = ""
     $sync.SearchBarClearButton.Visibility = "Collapsed"
+
+    # Focus the search bar after clearing the text
+    $sync.SearchBar.Focus()
+    $sync.SearchBar.SelectAll()
 })
 
 # add some shortcuts for people that don't like clicking
@@ -470,6 +474,9 @@ $sync["SearchBar"].Add_TextChanged({
     switch ($sync.currentTab) {
         "Install" {
             Find-AppsByNameOrDescription -SearchString $sync.SearchBar.Text
+        }
+        "Tweaks" {
+            Find-TweaksByNameOrDescription -SearchString $sync.SearchBar.Text
         }
     }
 })


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://christitustech.github.io/winutil/contribute/ -->

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [x] UI/UX improvement

## Description
<!--[Provide a detailed explanation of the changes you have made. Include the reasons behind these changes and any relevant context. Link any related issues.]-->
- Fixed an issue where the search bar did not work correctly in tabs other than "Install" (#3270)
- Added proper search functionality in the "Tweaks" tab
- Removed/Hid the search bar from other tabs where it was unnecessary
- Enhanced search bar functionality to automatically regain focus after clearing the search entry
- Modified tab behavior to reset the filtered state when switching tabs, ensuring that search filters no longer persist across tab changes

## Testing
<!--[Detail the testing you have performed to ensure that these changes function as intended. Include information about any added tests.]-->
Compiled and tested. Functions as expected.

## Issue related to PR
<!--[What issue/discussion is related to this PR (if any)]-->
- Resolves #3270

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
