### PR TITLE
 Optimize Preprocessor by Implementing File Hashing for Modified Files Detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@
 
 winutil.pdb
 
+### Preprocessor Hashes ###
+.preprocessor_hashes.json
+
 ### Windows ###
 
 # Folder config file

--- a/Compile.ps1
+++ b/Compile.ps1
@@ -53,7 +53,7 @@ $preprocessingFilePath = ".\tools\Invoke-Preprocessing.ps1"
 
 $excludedFiles = @('.\.git\', '.\.gitignore', '.\.gitattributes', '.\.github\CODEOWNERS', '.\LICENSE', "$preprocessingFilePath", '*.png', '*.exe','.\.preprocessor_hashes.json')
 $msg = "Pre-req: Code Formatting"
-Invoke-Preprocessing -WorkingDir "$workingdir" -ExcludedFiles $excludedFiles -ProgressStatusMessage $msg -ThrowExceptionOnEmptyFilesList
+Invoke-Preprocessing -WorkingDir "$workingdir" -ExcludedFiles $excludedFiles -ProgressStatusMessage $msg
 
 # Create the script in memory.
 Update-Progress "Pre-req: Allocating Memory" 0

--- a/Compile.ps1
+++ b/Compile.ps1
@@ -1,7 +1,6 @@
 param (
     [switch]$Debug,
     [switch]$Run,
-    [switch]$SkipPreprocessing,
     [string]$Arguments
 )
 
@@ -45,17 +44,16 @@ $header = @"
 ################################################################################################################
 "@
 
-if (-NOT $SkipPreprocessing) {
-    Update-Progress "Pre-req: Running Preprocessor..." 0
 
-    # Dot source the 'Invoke-Preprocessing' Function from 'tools/Invoke-Preprocessing.ps1' Script
-    $preprocessingFilePath = ".\tools\Invoke-Preprocessing.ps1"
-    . $preprocessingFilePath
+Update-Progress "Pre-req: Running Preprocessor..." 0
 
-    $excludedFiles = @('.\.git\', '.\.gitignore', '.\.gitattributes', '.\.github\CODEOWNERS', '.\LICENSE', "$preprocessingFilePath", '*.png', '*.exe')
-    $msg = "Pre-req: Code Formatting"
-    Invoke-Preprocessing -WorkingDir "$workingdir" -ExcludedFiles $excludedFiles -ProgressStatusMessage $msg -ThrowExceptionOnEmptyFilesList
-}
+# Dot source the 'Invoke-Preprocessing' Function from 'tools/Invoke-Preprocessing.ps1' Script
+$preprocessingFilePath = ".\tools\Invoke-Preprocessing.ps1"
+. $preprocessingFilePath
+
+$excludedFiles = @('.\.git\', '.\.gitignore', '.\.gitattributes', '.\.github\CODEOWNERS', '.\LICENSE', "$preprocessingFilePath", '*.png', '*.exe','.\.preprocessor_hashes.json')
+$msg = "Pre-req: Code Formatting"
+Invoke-Preprocessing -WorkingDir "$workingdir" -ExcludedFiles $excludedFiles -ProgressStatusMessage $msg -ThrowExceptionOnEmptyFilesList
 
 # Create the script in memory.
 Update-Progress "Pre-req: Allocating Memory" 0

--- a/tools/Invoke-Preprocessing.ps1
+++ b/tools/Invoke-Preprocessing.ps1
@@ -3,12 +3,9 @@ function Invoke-Preprocessing {
         .SYNOPSIS
         A function that does Code Formatting using RegEx, useful when trying to force specific coding standard(s) to a project.
 
-        .PARAMETER SkipExcludedFilesValidation
-        A switch to stop file path validation on 'ExcludedFiles' list.
-
         .PARAMETER ExcludedFiles
         A list of file paths which're *relative to* 'WorkingDir' Folder, every item in the list can be pointing to File (doesn't end with '\') or Directory (ends with '\') or None-Existing File/Directory.
-        By default, it checks if everyitem exists, and throws an exception if one or more are not found (None-Existing), if you want to skip this validation, please consider providing the '-SkipExcludedFilesValidation' switch to skip this check.
+        By default, it checks if everyitem exists, and throws an exception if one or more are not found (None-Existing).
 
         .PARAMETER WorkingDir
         The folder to search inside recursively for files which're going to be Preprocessed (Code Formatted), unless they're found in 'ExcludedFiles' List.
@@ -36,7 +33,6 @@ function Invoke-Preprocessing {
         .EXAMPLE
         Invoke-Preprocessing -Skip -WorkingDir "DRIVE:\Path\To\Folder\" -ExcludedFiles @('file.txt', '.\.git\', '*.png') -ProgressStatusMessage "Doing Preprocessing"
 
-        Same as Example No. 1, but uses '-SkipExcludedFilesValidation', which'll skip the validation step for 'ExcludedFiles' list. This can be useful when 'ExcludedFiles' list is generated from another function, or from unreliable source (you can't guarantee every item in list is a valid path), but you want to silently continue through the function.
     #>
 
     param (
@@ -62,9 +58,8 @@ function Invoke-Preprocessing {
     ForEach ($excludedFile in $ExcludedFiles) {
         $InternalExcludedFiles.Add($excludedFile) | Out-Null
     }
-
-    # Validate the ExcludedItems List before continuing on,
-    # that's if there's a list in the first place, and '-SkipInternalExcludedFilesValidation' was not provided.
+    
+    # Validate the ExcludedItems List before continuing on
     if ($ExcludedFiles.Count -gt 0) {
         ForEach ($excludedFile in $ExcludedFiles) {
             $filePath = "$(($WorkingDir -replace ('\\$', '')) + '\' + ($excludedFile -replace ('\.\\', '')))"
@@ -76,8 +71,8 @@ function Invoke-Preprocessing {
             } else { $failedFilesList += "'$filePath', " }
         }
         $failedFilesList = $failedFilesList -replace (',\s*$', '')
-        if ((-not $failedFilesList -eq "") -and (-not $SkipExcludedFilesValidation) -and (-not $excludedFile -eq ".preprocessor_hashes.json")) {
-            throw "[Invoke-Preprocessing] One or more File Paths and/or File Patterns were not found, you can use '-SkipExcludedFilesValidation' switch to skip this check, the failed to validate are: $failedFilesList"
+        if ((-not $failedFilesList -eq "")) {
+            Write-Warning "[Invoke-Preprocessing] One or more File Paths and/or File Patterns were not found: $failedFilesList"
         }
     }
 


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://christitustech.github.io/winutil/contribute/ -->

## Type of Change
- [x] New feature

## Background
I noticed that I frequently disabled the preprocessor using the -SkipPreprocessing flag because processing all 200+ files on my VM consistently took several seconds. This effectively negated the purpose of having a preprocessor in the first place.

To address this issue, this PR removes the option to disable the preprocessor entirely. Instead, it introduces a feature that runs the preprocessor once for all files, stores their hashes in a temporary file, and only processes files that have been modified in subsequent runs. This enhancement aims to improve efficiency and streamline the preprocessing workflow.

## Changes Made

- Removed the -SkipPreprocessing flag option.
- Removed ThrowExceptionOnEmptyFileList flag option and replaced it with a Write-Debug message
- Implemented file hashing to track modifications.
- Added logic to store file hashes in a temporary file.
- Updated the preprocessing routine to only process modified files on consecutive runs.
- This change should significantly reduce processing time and enhance the overall functionality of the preprocessor.