### PR TITLE
Remove OpenOffice from the App list

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -1503,14 +1503,6 @@
         "link": "https://github.com/namazso/OpenHashTab/",
         "winget": "namazso.OpenHashTab"
     },
-    "openoffice": {
-        "category": "Document",
-        "choco": "openoffice",
-        "content": "Apache OpenOffice",
-        "description": "Apache OpenOffice is an open-source office software suite for word processing, spreadsheets, presentations, and more.",
-        "link": "https://www.openoffice.org/",
-        "winget": "Apache.OpenOffice"
-    },
     "openrgb": {
         "category": "Utilities",
         "choco": "openrgb",


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://christitustech.github.io/winutil/contribute/ -->

## Type of Change
- [x] App Update

## Description
<!--[Provide a detailed explanation of the changes you have made. Include the reasons behind these changes and any relevant context. Link any related issues.]-->
This pull request removes OpenOffice from the application list. LibreOffice is a more modern and actively maintained alternative that is likely to meet the needs of the majority of users.

## Rationale
In the interest of maintaining a curated list of recommended software, I believe it is essential to streamline the application list. OpenOffice, while historically significant, has not kept pace with the advancements and features offered by LibreOffice. Therefore, it is more appropriate to recommend LibreOffice as the primary office suite for users.

Additionally, I would like to emphasize that the winutil project should focus on providing a curated selection of recommended software rather than functioning as a comprehensive graphical software installer, akin to UnigetUI. Given the nature of a PowerShell script, it is not ideally suited for this purpose.

## Issue related to PR
<!--[What issue/discussion is related to this PR (if any)]-->
- Resolves #3329
