### PR TITLE
Windows Spotlight warning

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -3380,7 +3380,7 @@
   },
   "WPFToggleStartMenuRecommendations": {
     "Content": "Recommendations in Start Menu",
-    "Description": "If disabled then you will not see recommendations in the Start Menu. | Enables 'iseducationenvironment' | Relogin Required.",
+    "Description": "If disabled then you will not see recommendations in the Start Menu. | Enables 'iseducationenvironment' | Relogin Required. | WARNING: This will also disable Windows Spotlight on your Lock Screen as a side effect.",
     "category": "Customize Preferences",
     "panel": "2",
     "Order": "a104_",


### PR DESCRIPTION
## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [x] UI/UX improvement

## Description
Added a small note to make it clear that enabling this will disable Windows Spotlight on Lock Screen.

## Issue related to PR
Relates to issue #3203 - does not resolve it outright but gives fair warning of a hidden and unexpected side effect.
