### PR TITLE
Add Zero Install in Utilities

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -135,6 +135,14 @@
         "link": "https://github.com/debauchee/barrier",
         "winget": "DebaucheeOpenSourceGroup.Barrier"
     },
+    "zeroinstall": {
+        "category": "Utilities",
+        "choco": "0install",
+        "content": "Zero Install",
+        "description": "A decentralized cross-platform software installation system available that allows software developers to publish programs directly from their own web-sites, while supporting features familiar from centralised distribution repositories such as shared libraries, automatic updates and digital signatures.",
+        "link": "https://github.com/0install/0install",
+        "winget": "ZeroInstall.ZeroInstall"
+    },
     "bat": {
         "category": "Utilities",
         "choco": "bat",


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://christitustech.github.io/winutil/contribute/ -->

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
I found this great tool called Zero Install that allows software developers to publish programs directly from their own web-sites, while supporting features familiar from centralised distribution repositories such as shared libraries, automatic updates and digital signatures. It is intended to complement, rather than replace, the operating system's package management.

## Testing
Besides some packages not being able to run with Zero Install GUI it works like expected.

## Impact
The only impact is that this program gets added.

## Issue related to PR
No issues related to any PR

## Additional Information
Not all programs in the Zero Install GUI client is runable due to link issues.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
