### PR TITLE
add Gpg4win to utilities

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -799,6 +799,14 @@
         "link": "https://www.google.com/drive/",
         "winget": "Google.GoogleDrive"
     },
+    "gpg4win": {
+        "category": "Utilities",
+        "choco": "gpg4win",
+        "content": "Gpg4win",
+        "description": "Gpg4win is a Windows version of GnuPG, a free encryption software for secure communication and data storage.",
+        "link": "https://www.gpg4win.org/",
+        "winget": "GnuPG.Gpg4win"
+    },
     "gpuz": {
         "category": "Utilities",
         "choco": "gpu-z",


### PR DESCRIPTION
## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description

Added Gpg4win to the list of installable utility programs. Gpg4win is a widely used open-source Windows version of GnuPG, an encryption suite to sign/verify and encrypt/decrypt files and emails. 

## Testing

Tested with the current pre-release installer; Gpg4win installs and functions as expected.

## Impact

Gpg4win gets added to the available list of installable utility programs.

## Issue related to PR

None.

## Additional Information

Gpg4win install works, winutil works as exptected.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
