### PR TITLE
Add PotPlayer to applications.json

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -1647,6 +1647,14 @@
         "link": "https://www.postman.com/",
         "winget": "Postman.Postman"
     },
+    "potplayer": {
+        "category": "Multimedia Tools",
+        "choco": "potplayer",
+        "content": "PotPlayer",
+        "description": "Potplayer is a powerful All-in-one multimedia software player playing most of the media formats. It provides the maximum performance with the minimum resource using DVXA,CUDA and QuickSync.",
+        "link": "https://potplayer.daum.net/",
+        "winget": "Daum.PotPlayer"
+    },
     "powerautomate": {
         "category": "Microsoft Tools",
         "choco": "powerautomatedesktop",


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://christitustech.github.io/winutil/contribute/ -->

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Added PotPlayer as an optional application in the installable software list.
This change includes the appropriate download logic and categorization to align with other media player entries.

## Testing
Tested installation script on a Windows 11.
Confirmed that PotPlayer downloads and installs correctly without errors.
Verified that the application appears in the software list and installs when selected.

## Impact
This change extends the software offering in winutil without introducing breaking changes.
No external dependencies beyond PotPlayer’s official installer were added.

## Additional Information
PotPlayer is a widely used media player with high performance and low resource usage, making it a good fit for power users customizing their system with winutil.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
