### PR TITLE
Upgrade Code Signing Algorithm from SHA1 to SHA256

### DIFF
--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -60,7 +60,7 @@ jobs:
         run: |
           $cert = Get-ChildItem -Path Cert:\CurrentUser\My -CodeSigningCert | Select-Object -First 1
           if ($null -eq $cert) { throw "Code signing certificate not found" }
-          Set-AuthenticodeSignature -FilePath ./winutil.ps1 -Certificate $cert -TimeStampServer "http://timestamp.digicert.com"
+          Set-AuthenticodeSignature -FilePath ./winutil.ps1 -HashAlgorithm SHA256 -Certificate $cert -TimeStampServer "http://timestamp.digicert.com"
 
       - name: Verify code signature
         shell: pwsh


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://christitustech.github.io/winutil/contribute/ -->

## Type of Change
- [x] Security patch



## Description
<!--[Provide a detailed explanation of the changes you have made. Include the reasons behind these changes and any relevant context. Link any related issues.]-->

As pointed out by @ThioJoe in the linked issue, winutil currently still uses SHA1 for code signing during compilation.
This is due to Microsoft using SHA1 as the default algorithm until PowerShell 7.3, as noted in [Set-AuthenticodeSignature](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.security/set-authenticodesignature?view=powershell-7.5#-hashalgorithm). 

While finding a SHA1 hash collision is still challanging, it is becoming increasingly feasible, and this trend is likely to continue. Given that there are no performance reasons to retain SHA1, transitioning to a more secure algorithm, such as SHA256, will significantly reduce the risk of hash collisions and enhance overall security. 

## Issue related to PR
<!--[What issue/discussion is related to this PR (if any)]-->
- Resolves #3359

## Additional Information

# !  PLEASE TEST CAREFULLY AS YOU ARE THE ONLY ONE WHO HAS THE CERTIFICATE TO TEST IF THIS WORKS AS EXPECTED