### PR TITLE
Add Right-Click Action on App Install Page

### DIFF
--- a/functions/private/Initalize-InstallAppEntry.ps1
+++ b/functions/private/Initalize-InstallAppEntry.ps1
@@ -18,7 +18,7 @@ function Initialize-InstallAppEntry {
         $border.Style = $sync.Form.Resources.AppEntryBorderStyle
         $border.Tag = $appKey
         $border.ToolTip = $Apps.$appKey.description
-        $border.Add_MouseUp({
+        $border.Add_MouseLeftButtonUp({
             $childCheckbox = ($this.Child | Where-Object {$_.Template.TargetType -eq [System.Windows.Controls.Checkbox]})[0]
             $childCheckBox.isChecked = -not $childCheckbox.IsChecked
         })
@@ -31,6 +31,13 @@ function Initialize-InstallAppEntry {
             if (($sync.$($this.Tag).IsChecked) -eq $false) {
                 $this.SetResourceReference([Windows.Controls.Control]::BackgroundProperty, "AppInstallUnselectedColor")
             }
+        })
+        $border.Add_MouseRightButtonUp({
+            # Store the selected app in a global variable so it can be used in the popup
+            $sync.appPopupSelectedApp = $this.Tag
+            # Set the popup position to the current mouse position
+            $sync.appPopup.PlacementTarget = $this
+            $sync.appPopup.IsOpen = $true
         })
 
         $checkBox = New-Object Windows.Controls.CheckBox

--- a/functions/public/Initialize-WPFUI.ps1
+++ b/functions/public/Initialize-WPFUI.ps1
@@ -7,7 +7,7 @@ function Initialize-WPFUI {
 
     switch ($TargetGridName) {
         "appscategory"{
-            # TODO 
+            # TODO
             # Switch UI generation of the sidebar to this function
             # $sync.ItemsControl = Initialize-InstallAppArea -TargetElement $TargetGridName
             # ...
@@ -44,6 +44,69 @@ function Initialize-WPFUI {
                     $sync.selectedAppsPopup.IsOpen = $false
                 }
             })
+
+            # Creates the popup that is displayed when the user right-clicks on an app entry
+            # This popup contains buttons for installing, uninstalling, and viewing app information
+
+            $appPopup = New-Object Windows.Controls.Primitives.Popup
+            $appPopup.StaysOpen = $false
+            $appPopup.Placement = [System.Windows.Controls.Primitives.PlacementMode]::Bottom
+            $appPopup.AllowsTransparency = $true
+            # Store the popup globally so the position can be set later
+            $sync.appPopup = $appPopup
+
+            $appPopupStackPanel = New-Object Windows.Controls.StackPanel
+            $appPopupStackPanel.Orientation = "Horizontal"
+            $appPopupStackPanel.Add_MouseLeave({
+                $sync.appPopup.IsOpen = $false
+            })
+            $appPopup.Child = $appPopupStackPanel
+
+            $appButtons = @(
+            [PSCustomObject]@{ Name = "Install";    Icon = [char]0xE118 },
+            [PSCustomObject]@{ Name = "Uninstall";  Icon = [char]0xE74D },
+            [PSCustomObject]@{ Name = "Info";       Icon = [char]0xE946 }
+            )
+            foreach ($button in $appButtons) {
+                $newButton = New-Object Windows.Controls.Button
+                $newButton.Style = $sync.Form.Resources.AppEntryButtonStyle
+                $newButton.Content = $button.Icon
+                $appPopupStackPanel.Children.Add($newButton) | Out-Null
+
+                # Dynamically load the selected app object so the buttons can be reused and do not need to be created for each app
+                switch ($button.Name) {
+                    "Install" {
+                        $newButton.Add_MouseEnter({
+                            $appObject = $sync.configs.applicationsHashtable.$($sync.appPopupSelectedApp)
+                            $this.ToolTip = "Install or Upgrade $($appObject.content)"
+                        })
+                        $newButton.Add_Click({
+                            $appObject = $sync.configs.applicationsHashtable.$($sync.appPopupSelectedApp)
+                            Invoke-WPFInstall -PackagesToInstall $appObject
+                        })
+                    }
+                    "Uninstall" {
+                        $newButton.Add_MouseEnter({
+                            $appObject = $sync.configs.applicationsHashtable.$($sync.appPopupSelectedApp)
+                            $this.ToolTip = "Uninstall $($appObject.content)"
+                        })
+                        $newButton.Add_Click({
+                            $appObject = $sync.configs.applicationsHashtable.$($sync.appPopupSelectedApp)
+                            Invoke-WPFUnInstall -PackagesToUninstall $appObject
+                        })
+                    }
+                    "Info" {
+                        $newButton.Add_MouseEnter({
+                            $appObject = $sync.configs.applicationsHashtable.$($sync.appPopupSelectedApp)
+                            $this.ToolTip = "Open the application's website in your default browser`n$($appObject.link)"
+                        })
+                        $newButton.Add_Click({
+                            $appObject = $sync.configs.applicationsHashtable.$($sync.appPopupSelectedApp)
+                            Start-Process $appObject.link
+                        })
+                    }
+                }
+            }
         }
         "appspanel" {
             $sync.ItemsControl = Initialize-InstallAppArea -TargetElement $TargetGridName

--- a/xaml/inputXML.xaml
+++ b/xaml/inputXML.xaml
@@ -117,7 +117,53 @@
         <Setter Property="Margin" Value="{DynamicResource AppEntryMargin}"/>
         <Setter Property="Background" Value="Transparent"/>
     </Style>
+    <Style x:Key="AppEntryButtonStyle" TargetType="Button">
+        <Setter Property="Width" Value="{DynamicResource IconButtonSize}"/>
+        <Setter Property="Height" Value="{DynamicResource IconButtonSize}"/>
+        <Setter Property="Margin" Value="{DynamicResource AppEntryMargin}"/>
+        <Setter Property="Foreground" Value="{DynamicResource ButtonForegroundColor}"/>
+        <Setter Property="Background" Value="{DynamicResource ButtonBackgroundColor}"/>
+        <Setter Property="HorizontalAlignment" Value="Center"/>
+        <Setter Property="VerticalAlignment" Value="Center"/>
+        <Setter Property="ContentTemplate">
+            <Setter.Value>
+                <DataTemplate>
+                    <TextBlock  Text="{Binding}"
+                                FontFamily="Segoe MDL2 Assets"
+                                FontSize="{DynamicResource IconFontSize}"
+                                Background="Transparent"/>
+                </DataTemplate>
+            </Setter.Value>
+        </Setter>
+        <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Grid>
+                            <Border x:Name="BackgroundBorder"
+                                    Background="{TemplateBinding Background}"
+                                    BorderBrush="{TemplateBinding BorderBrush}"
+                                    BorderThickness="{DynamicResource ButtonBorderThickness}"
+                                    CornerRadius="{DynamicResource ButtonCornerRadius}">
+                                <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                            </Border>
+                        </Grid>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsPressed" Value="True">
+                                <Setter TargetName="BackgroundBorder" Property="Background" Value="{DynamicResource ButtonBackgroundPressedColor}"/>
+                            </Trigger>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="BackgroundBorder" Property="Background" Value="{DynamicResource ButtonBackgroundMouseoverColor}"/>
+                            </Trigger>
+                            <Trigger Property="IsEnabled" Value="False">
+                                <Setter TargetName="BackgroundBorder" Property="Background" Value="{DynamicResource ButtonBackgroundSelectedColor}"/>
+                                <Setter Property="Foreground" Value="DimGray"/>
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
 
+    </Style>
     <Style TargetType="Button" x:Key="HoverButtonStyle">
         <Setter Property="Foreground" Value="{DynamicResource MainForegroundColor}" />
         <Setter Property="FontWeight" Value="Normal" />

--- a/xaml/inputXML.xaml
+++ b/xaml/inputXML.xaml
@@ -152,6 +152,7 @@
                                 <Setter TargetName="BackgroundBorder" Property="Background" Value="{DynamicResource ButtonBackgroundPressedColor}"/>
                             </Trigger>
                             <Trigger Property="IsMouseOver" Value="True">
+                                <Setter Property="Cursor" Value="Hand"/>
                                 <Setter TargetName="BackgroundBorder" Property="Background" Value="{DynamicResource ButtonBackgroundMouseoverColor}"/>
                             </Trigger>
                             <Trigger Property="IsEnabled" Value="False">


### PR DESCRIPTION
… and info options

<!--Before you make this PR have you followed the docs here? - https://christitustech.github.io/winutil/contribute/ -->

## Type of Change
- [x] New feature
- [x] UI/UX improvement

## Description
<!--[Provide a detailed explanation of the changes you have made. Include the reasons behind these changes and any relevant context. Link any related issues.]-->

This pull request adds a right-click context menu on the app install page, allowing users to quickly access essential actions for each app.

Right-Click Menu: Users can right-click on an app to reveal a context menu.
Action Buttons:
- Install: Initiate app installation.
- Uninstall: Remove the app directly.
- Info: Open the app's web page for more details.


![image](https://github.com/user-attachments/assets/4f76f5d9-249c-4f41-a38b-3fe6643df25e)

## Additional Information
The context menu, which includes Install, Uninstall, and Info buttons, is created once and dynamically updated with the relevant app information and button positioning. This approach reduces the number of WPF elements from over 1000 to just 5, significantly improving loading times compared to the initial redesign