### PR TITLE
Implement search bar debounce functionality to improve UI responsiveness

### DIFF
--- a/functions/private/Find-AppsByNameOrDescription.ps1
+++ b/functions/private/Find-AppsByNameOrDescription.ps1
@@ -34,7 +34,8 @@ function Find-AppsByNameOrDescription {
         if ($_.Tag -like "CategoryWrapPanel_*") {
             # Search for Apps that match the search string
             $_.Children | Foreach-Object {
-                if ($sync.configs.applicationsHashtable.$($_.Tag).Content -like "*$SearchString*") {
+                $appEntry = $sync.configs.applicationsHashtable.$($_.Tag)
+                if ($appEntry.Content -like "*$SearchString*" -or $appEntry.Description -like "*$SearchString*") {
                     # Show the App and the parent CategoryWrapPanel if the string is found
                     $_.Visibility = [Windows.Visibility]::Visible
                     $_.parent.Visibility = [Windows.Visibility]::Visible

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -376,12 +376,15 @@ if ($sync["ISOLanguage"].Items.Count -eq 1) {
 }
 $sync["ISOLanguage"].SelectedIndex = 0
 
-$sync["SearchBar"].Add_TextChanged({
-    if ($sync.SearchBar.Text -ne "") {
-        $sync.SearchBarClearButton.Visibility = "Visible"
-    } else {
-        $sync.SearchBarClearButton.Visibility = "Collapsed"
-    }
+# The SearchBarTimer is used to delay the search operation until the user has stopped typing for a short period
+# This prevents the ui from stuttering when the user types quickly as it dosnt need to update the ui for every keystroke
+
+$searchBarTimer = New-Object System.Windows.Threading.DispatcherTimer
+$searchBarTimer.Interval = [TimeSpan]::FromMilliseconds(300)
+$searchBarTimer.IsEnabled = $false
+
+$searchBarTimer.add_Tick({
+    $searchBarTimer.Stop()
     switch ($sync.currentTab) {
         "Install" {
             Find-AppsByNameOrDescription -SearchString $sync.SearchBar.Text
@@ -390,6 +393,17 @@ $sync["SearchBar"].Add_TextChanged({
             Find-TweaksByNameOrDescription -SearchString $sync.SearchBar.Text
         }
     }
+})
+$sync["SearchBar"].Add_TextChanged({
+    if ($sync.SearchBar.Text -ne "") {
+        $sync.SearchBarClearButton.Visibility = "Visible"
+    } else {
+        $sync.SearchBarClearButton.Visibility = "Collapsed"
+    }
+    if ($searchBarTimer.IsEnabled) {
+        $searchBarTimer.Stop()
+    }
+    $searchBarTimer.Start()
 })
 
 $sync["Form"].Add_Loaded({


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://christitustech.github.io/winutil/contribute/ -->

## Type of Change
- [x] New feature
- [x] UI/UX improvement

## Description
<!--[Provide a detailed explanation of the changes you have made. Include the reasons behind these changes and any relevant context. Link any related issues.]-->
This PR introduces a delay for the search field functionality, implementing a 300ms debounce effect. With this change, the UI will only initiate a search for matching entries after the user has stopped typing for 300 milliseconds.
This enhancement improves the responsiveness of the user interface by preventing the script from filtering the applications on every keystroke. As a result, users will experience a smoother and more fluid interaction when searching for entries.

Also this changes allows us to include the app description in the fields being searched. 

Resolves: #3065