### PR TITLE
remove spotube

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -1983,14 +1983,6 @@
         "link": "http://www.uderzo.it/main_products/space_sniffer/",
         "winget": "UderzoSoftware.SpaceSniffer"
     },
-    "spotube": {
-        "category": "Multimedia Tools",
-        "choco": "spotube",
-        "content": "Spotube",
-        "description": "Open source Spotify client that doesn't require Premium nor uses Electron! Available for both desktop & mobile! ",
-        "link": "https://github.com/KRTirtho/spotube",
-        "winget": "KRTirtho.Spotube"
-    },
     "starship": {
         "category": "Development",
         "choco": "starship",


### PR DESCRIPTION
🚨 Spotube is banned from using "Spotify™ API" 🚨

The developer of Spotube has received a cease and desist letter from Spotify USA Inc. and Spotify AB, asserting a legal threat concerning the distribution and development of any application that utilizes Spotify’s data API in conjunction with content from YouTube® to facilitate ad-free playback of music tracks. The letter contends that this specific use of the Spotify™ APIs contravenes the Spotify™ Agreements and may also infringe upon the rights of music rights holders.

Consequently, as the official maintainer of Spotube, I will immediately cease all forms of official distribution and development of Spotube that continue to employ the aforementioned 'Spotify™ APIs'

Their exact reasoning: (any) "uses of Spotify’s data API in connection with content from YouTube to provide ad-free playback of music tracks. The use of the Spotify APIs in this manner violates the Spotify Agreements and may also violate the rights of music rights holders."

https://spotube.krtirtho.dev/
