### PR TITLE
Fix App references

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -349,7 +349,7 @@
         "content": "Display Driver Uninstaller",
         "description": "Display Driver Uninstaller (DDU) is a tool for completely uninstalling graphics drivers from NVIDIA, AMD, and Intel. It is useful for troubleshooting graphics driver-related issues.",
         "link": "https://www.wagnardsoft.com/display-driver-uninstaller-DDU-",
-        "winget": "ddu"
+        "winget": "Wagnardsoft.DisplayDriverUninstaller"
     },
     "deluge": {
         "category": "Utilities",

--- a/config/applications.json
+++ b/config/applications.json
@@ -1863,14 +1863,6 @@
         "link": "https://sagethumbs.en.lo4d.com/windows",
         "winget": "CherubicSoftware.SageThumbs"
     },
-    "samsungmagician": {
-        "category": "Utilities",
-        "choco": "samsung-magician",
-        "content": "Samsung Magician",
-        "description": "Samsung Magician is a utility for managing and optimizing Samsung SSDs.",
-        "link": "https://semiconductor.samsung.com/consumer-storage/magician/",
-        "winget": "Samsung.SamsungMagician"
-    },
     "sandboxie": {
         "category": "Utilities",
         "choco": "sandboxie",

--- a/functions/public/Initialize-WPFUI.ps1
+++ b/functions/public/Initialize-WPFUI.ps1
@@ -7,7 +7,7 @@ function Initialize-WPFUI {
 
     switch ($TargetGridName) {
         "appscategory"{
-            # TODO 
+            # TODO
             # Switch UI generation of the sidebar to this function
             # $sync.ItemsControl = Initialize-InstallAppArea -TargetElement $TargetGridName
             # ...


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://christitustech.github.io/winutil/contribute/ -->

## Type of Change
- [x] Bug fix

## Description
<!--[Provide a detailed explanation of the changes you have made. Include the reasons behind these changes and any relevant context. Link any related issues.]-->
- Update DDU Winget Reference
- Remove Samsung Magician as it has been removed from the winget repos. (also remove the Chocolatey install target, as the install logic dosnt handle it very well when the winget target does not exist. (requires a check that the action is not null) and also because samsung magician does not support a silent installation which means that chocolatey has to fallback to a autohotkey script which is error prone and breaks the "silent" install flow of winutil. Also the version provided by chocolatey is not up to date anymore.)

## Issue related to PR
<!--[What issue/discussion is related to this PR (if any)]-->
- Resolves #3300
- Closes #3353