### PR TITLE
The MouseHoverTime setting does not appear to have any relevance to Telemetry

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -1997,13 +1997,6 @@
         "Type": "DWord"
       },
       {
-        "Path": "HKCU:\\Control Panel\\Mouse",
-        "OriginalValue": "400",
-        "Name": "MouseHoverTime",
-        "Value": "400",
-        "Type": "String"
-      },
-      {
         "Path": "HKLM:\\SYSTEM\\CurrentControlSet\\Services\\LanmanServer\\Parameters",
         "OriginalValue": "20",
         "Name": "IRPStackSize",


### PR DESCRIPTION
`G:\projects\winutil\docs\dev\tweaks\Essential-Tweaks\Tele.md` is this file can be auto-updated ?
`.\Compile.ps1` do not update it.
