### PR TITLE
Remove Hibernation Tweak from standard preset

### DIFF
--- a/config/preset.json
+++ b/config/preset.json
@@ -4,7 +4,6 @@
     "WPFTweaksConsumerFeatures",
     "WPFTweaksDisableExplorerAutoDiscovery",
     "WPFTweaksDVR",
-    "WPFTweaksHiber",
     "WPFTweaksHome",
     "WPFTweaksLoc",
     "WPFTweaksServices",


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://christitustech.github.io/winutil/contribute/ -->

## Type of Change
- [x] Hotfix


## Description
<!--[Provide a detailed explanation of the changes you have made. Include the reasons behind these changes and any relevant context. Link any related issues.]-->
As the Preset names are not "Desktop" and "Laptop" anymore, I think it would be best to remove the Hibernation Tweak from the Standard selection since it is not really plausible for Laptop users.

- Resolves #2786

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
