### PR TITLE
[Legacy Panel] Computer Management

### DIFF
--- a/config/feature.json
+++ b/config/feature.json
@@ -258,6 +258,14 @@
     "ButtonWidth": "300",
     "link": "https://winutil.christitus.com/dev/features/legacy-windows-panels/control"
   },
+  "WPFPanelcomputer": {
+    "Content": "Computer Management",
+    "category": "Legacy Windows Panels",
+    "panel": "2",
+    "Type": "Button",
+    "ButtonWidth": "300",
+    "link": "https://winutil.christitus.com/dev/features/legacy-windows-panels/computer"
+  },
   "WPFPanelpower": {
     "Content": "Power Panel",
     "category": "Legacy Windows Panels",

--- a/functions/public/Invoke-WPFButton.ps1
+++ b/functions/public/Invoke-WPFButton.ps1
@@ -35,6 +35,7 @@ function Invoke-WPFButton {
         "WPFFeatureInstall" {Invoke-WPFFeatureInstall}
         "WPFPanelDISM" {Invoke-WPFSystemRepair}
         "WPFPanelAutologin" {Invoke-WPFPanelAutologin}
+        "WPFPanelcomputer" {Invoke-WPFControlPanel -Panel $button}
         "WPFPanelcontrol" {Invoke-WPFControlPanel -Panel $button}
         "WPFPanelnetwork" {Invoke-WPFControlPanel -Panel $button}
         "WPFPanelpower" {Invoke-WPFControlPanel -Panel $button}

--- a/functions/public/Invoke-WPFControlPanel.ps1
+++ b/functions/public/Invoke-WPFControlPanel.ps1
@@ -11,14 +11,15 @@ function Invoke-WPFControlPanel {
     param($Panel)
 
     switch ($Panel) {
-        "WPFPanelcontrol" {cmd /c control}
-        "WPFPanelnetwork" {cmd /c ncpa.cpl}
-        "WPFPanelpower"   {cmd /c powercfg.cpl}
-        "WPFPanelregion"  {cmd /c intl.cpl}
-        "WPFPanelsound"   {cmd /c mmsys.cpl}
+        "WPFPanelcontrol" {control}
+        "WPFPanelcomputer" {compmgmt.msc}
+        "WPFPanelnetwork" {ncpa.cpl}
+        "WPFPanelpower"   {powercfg.cpl}
+        "WPFPanelregion"  {intl.cpl}
+        "WPFPanelsound"   {mmsys.cpl}
         "WPFPanelprinter" {Start-Process "shell:::{A8A91A66-3A7D-4424-8D24-04E180695C7A}"}
-        "WPFPanelsystem"  {cmd /c sysdm.cpl}
-        "WPFPaneluser"    {cmd /c "control userpasswords2"}
+        "WPFPanelsystem"  {sysdm.cpl}
+        "WPFPaneluser"    {control userpasswords2}
         "WPFPanelGodMode" {Start-Process "shell:::{ED7BA470-8E54-465E-825C-99712043E01C}"}
     }
 }


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://christitustech.github.io/winutil/contribute/ -->

## Type of Change
- [x] New feature

## Description
<!--[Provide a detailed explanation of the changes you have made. Include the reasons behind these changes and any relevant context. Link any related issues.]-->
- even tho it is still more or less easily accessible I'd like to add the Computer Management Console to the Legacy panels as it combines many helpfull windows tools into one gui and not many people actually use it.
- i also removed unneccessary code from the WPFControlPanel Function

## Testing
- everything still works as expected

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
