### PR TITLE
[Microwin] Adaptive Busy Icon + Message

### DIFF
--- a/config/themes.json
+++ b/config/themes.json
@@ -58,6 +58,7 @@
         "ScrollBarHoverColor": "#5A5D62",
         "ScrollBarDraggingColor": "#6A6D72",
 
+        "MicrowinBusyColor": "#2e77ff",
         "ProgressBarForegroundColor": "#2e77ff",
         "ProgressBarBackgroundColor": "Transparent",
         "ProgressBarTextColor": "#232629",
@@ -97,6 +98,7 @@
         "ScrollBarHoverColor": "#3B4252",
         "ScrollBarDraggingColor": "#5E81AC",
 
+        "MicrowinBusyColor": "#2e77ff",
         "ProgressBarForegroundColor": "#222222",
         "ProgressBarBackgroundColor": "Transparent",
         "ProgressBarTextColor": "#cccccc",

--- a/functions/microwin/Invoke-Microwin.ps1
+++ b/functions/microwin/Invoke-Microwin.ps1
@@ -39,12 +39,15 @@ public class PowerManagement {
     $SaveDialog.ShowDialog() | Out-Null
 
     if ($SaveDialog.FileName -eq "") {
-        Write-Host "No file name for the target image was specified"
+        $msg = "No file name for the target image was specified"
+        Write-Host $msg
+        Invoke-MicrowinBusyInfo -warning $msg
         Set-WinUtilTaskbaritem -state "Error" -value 1 -overlay "warning"
         return
     }
 
     Set-WinUtilTaskbaritem -state "Indeterminate" -overlay "logo"
+    Invoke-MicrowinBusyInfo -wip "Busy... (not interactive)"
 
     Write-Host "Target ISO location: $($SaveDialog.FileName)"
 
@@ -70,9 +73,10 @@ public class PowerManagement {
             $index = 1
         } else {
             $msg = "The export process has failed and MicroWin processing cannot continue"
-            Write-Host "Failed to export the image"
-            [System.Windows.MessageBox]::Show($msg, "Winutil", [System.Windows.MessageBoxButton]::OK, [System.Windows.MessageBoxImage]::Error)
+            Write-Host $msg
             Set-WinUtilTaskbaritem -state "Error" -value 1 -overlay "warning"
+            Invoke-MicrowinBusyInfo -warning $msg
+            [System.Windows.MessageBox]::Show($msg, "Winutil", [System.Windows.MessageBoxButton]::OK, [System.Windows.MessageBoxImage]::Error)
             return
         }
     }
@@ -87,6 +91,7 @@ public class PowerManagement {
         Write-Host $msg
         [System.Windows.MessageBox]::Show($dlg_msg, "Winutil", [System.Windows.MessageBoxButton]::OK, [System.Windows.MessageBoxImage]::Exclamation)
         Set-WinUtilTaskbaritem -state "Error" -value 1 -overlay "warning"
+        Invoke-MicrowinBusyInfo -warning $msg
         return
     }
 
@@ -101,8 +106,10 @@ public class PowerManagement {
     $mountDirExists = Test-Path $mountDir
     $scratchDirExists = Test-Path $scratchDir
     if (-not $mountDirExists -or -not $scratchDirExists) {
-        Write-Error "Required directories '$mountDirExists' '$scratchDirExists' and do not exist."
+        $msg = "Required directories '$mountDirExists' '$scratchDirExists' and do not exist."
+        Write-Error $msg
         Set-WinUtilTaskbaritem -state "Error" -value 1 -overlay "warning"
+        Invoke-MicrowinBusyInfo -warning $msg
         return
     }
 
@@ -113,8 +120,10 @@ public class PowerManagement {
         if ($?) {
             Write-Host "The Windows image has been mounted successfully. Continuing processing..."
         } else {
-            Write-Host "Could not mount image. Exiting..."
+            $msg = "Could not mount image. Exiting..."
+            Write-Host $msg
             Set-WinUtilTaskbaritem -state "Error" -value 1 -overlay "warning"
+            Invoke-MicrowinBusyInfo -warning $msg
             return
         }
 
@@ -368,7 +377,9 @@ public class PowerManagement {
         Rename-Item "$mountDir\sources\install2.wim" "$mountDir\sources\install.wim"
 
         if (-not (Test-Path -Path "$mountDir\sources\install.wim")) {
-            Write-Error "Something went wrong and '$mountDir\sources\install.wim' doesn't exist. Please report this bug to the devs"
+            $msg = "Something went wrong and '$mountDir\sources\install.wim' doesn't exist. Please report this bug to the devs"
+            Write-Error $msg
+            Invoke-MicrowinBusyInfo -warning $msg
             Set-WinUtilTaskbaritem -state "Error" -value 1 -overlay "warning"
             return
         }
@@ -459,6 +470,7 @@ public class PowerManagement {
             $msg = "Done. ISO image is located here: $($SaveDialog.FileName)"
             Write-Host $msg
             Set-WinUtilTaskbaritem -state "None" -overlay "checkmark"
+            Invoke-MicrowinBusyInfo -done "Finished!"
             [System.Windows.MessageBox]::Show($msg, "Winutil", [System.Windows.MessageBoxButton]::OK, [System.Windows.MessageBoxImage]::Information)
         } else {
             Write-Host "ISO creation failed. The "$($mountDir)" directory has not been removed."
@@ -467,6 +479,8 @@ public class PowerManagement {
                 # Now, this will NOT throw an exception
                 $exitCode = New-Object System.ComponentModel.Win32Exception($LASTEXITCODE)
                 Write-Host "Reason: $($exitCode.Message)"
+                Invoke-MicrowinBusyInfo -warning $exitCode.Message
+                Set-WinUtilTaskbaritem -state "Error" -value 1 -overlay "warning"
             } catch {
                 # Could not get error description from Windows APIs
             }

--- a/functions/microwin/Invoke-MicrowinBusyInfo.ps1
+++ b/functions/microwin/Invoke-MicrowinBusyInfo.ps1
@@ -1,0 +1,36 @@
+function Invoke-MicrowinBusyInfo {
+    <#
+    .DESCRIPTION
+    Function to display the busy info for the Microwin process
+    #>
+    param(
+        [string]$wip,
+        [string]$warning,
+        [string]$done,
+        [string]$hide
+    )
+    if($wip) {
+        $sync.MicrowinBusyIndicator.Visibility="Visible"
+        $sync.BusyText.Text=$wip
+        $sync.BusyIcon.Foreground="#FFA500"
+        $sync.BusyText.Foreground="#FFA500"
+    } elseif($warning) {
+        $sync.MicrowinBusyIndicator.Visibility="Visible"
+        $sync.BusyText.Text=$warning
+        $sync.BusyText.Foreground="#FF0000"
+        $sync.BusyIcon.Foreground="#FF0000"
+    }
+    elseif($done) {
+        $sync.MicrowinBusyIndicator.Visibility="Visible"
+        $sync.BusyText.Text=$done
+        $sync.BusyText.Foreground="#00FF00"
+        $sync.BusyIcon.Foreground="#00FF00"
+    }
+    elseif($hide) {
+        $sync.MicrowinBusyIndicator.Visibility="Hidden"
+        $sync.BusyText.Foreground=$sync.Form.Resources.MicrowinBusyColor
+        $sync.BusyIcon.Foreground=$sync.Form.Resources.MicrowinBusyColor
+    } else {
+        Write-Error "Invalid parameter"
+    }
+}

--- a/functions/microwin/Invoke-MicrowinGetIso.ps1
+++ b/functions/microwin/Invoke-MicrowinGetIso.ps1
@@ -12,55 +12,14 @@ function Invoke-MicrowinGetIso {
         return
     }
 
-    $sync.BusyMessage.Visibility="Visible"
-    $sync.BusyText.Text="N Busy"
-
-
+    Set-WinUtilTaskbaritem -state "Indeterminate" -overlay "logo"
+    Invoke-MicrowinBusyInfo -wip "Busy... (not interactive)"
 
     Write-Host "         _                     __    __  _         "
     Write-Host "  /\/\  (_)  ___  _ __   ___  / / /\ \ \(_) _ __   "
     Write-Host " /    \ | | / __|| '__| / _ \ \ \/  \/ /| || '_ \  "
     Write-Host "/ /\/\ \| || (__ | |   | (_) | \  /\  / | || | | | "
     Write-Host "\/    \/|_| \___||_|    \___/   \/  \/  |_||_| |_| "
-
-    $oscdimgPath = Join-Path $env:TEMP 'oscdimg.exe'
-    $oscdImgFound = [bool] (Get-Command -ErrorAction Ignore -Type Application oscdimg.exe) -or (Test-Path $oscdimgPath -PathType Leaf)
-    Write-Host "oscdimg.exe on system: $oscdImgFound"
-
-    if (!$oscdImgFound) {
-        $downloadFromGitHub = $sync.WPFMicrowinDownloadFromGitHub.IsChecked
-        $sync.BusyMessage.Visibility="Hidden"
-
-        if (!$downloadFromGitHub) {
-            # only show the message to people who did check the box to download from github, if you check the box
-            # you consent to downloading it, no need to show extra dialogs
-            [System.Windows.MessageBox]::Show("oscdimge.exe is not found on the system, winutil will now attempt do download and install it using choco. This might take a long time.")
-            # the step below needs choco to download oscdimg
-            # Install Choco if not already present
-            Install-WinUtilChoco
-            $chocoFound = [bool] (Get-Command -ErrorAction Ignore -Type Application choco)
-            Write-Host "choco on system: $chocoFound"
-            if (!$chocoFound) {
-                [System.Windows.MessageBox]::Show("choco.exe is not found on the system, you need choco to download oscdimg.exe")
-                return
-            }
-
-            Start-Process -Verb runas -FilePath powershell.exe -ArgumentList "choco install windows-adk-oscdimg"
-            [System.Windows.MessageBox]::Show("oscdimg is installed, now close, reopen PowerShell terminal and re-launch winutil.ps1")
-            return
-        } else {
-            [System.Windows.MessageBox]::Show("oscdimge.exe is not found on the system, winutil will now attempt do download and install it from github. This might take a long time.")
-            Microwin-GetOscdimg -oscdimgPath $oscdimgPath
-            $oscdImgFound = Test-Path $oscdimgPath -PathType Leaf
-            if (!$oscdImgFound) {
-                $msg = "oscdimg was not downloaded can not proceed"
-                [System.Windows.MessageBox]::Show($msg, "Winutil", [System.Windows.MessageBoxButton]::OK, [System.Windows.MessageBoxImage]::Error)
-                return
-            } else {
-                Write-Host "oscdimg.exe was successfully downloaded from github"
-            }
-        }
-    }
 
     if ($sync["ISOmanual"].IsChecked) {
         # Open file dialog to let user choose the ISO file
@@ -73,9 +32,9 @@ function Invoke-MicrowinGetIso {
 
         if ([string]::IsNullOrEmpty($filePath)) {
             Write-Host "No ISO is chosen"
-            $sync.BusyMessage.Visibility="Hidden"
             return
         }
+
     } elseif ($sync["ISOdownloader"].IsChecked) {
         # Create folder browsers for user-specified locations
         [System.Reflection.Assembly]::LoadWithPartialName("System.Windows.Forms") | Out-Null
@@ -110,6 +69,8 @@ function Invoke-MicrowinGetIso {
         {
             Write-Host "Could not download the ISO file. Look at the output of the console for more information."
             $msg = "The ISO file could not be downloaded"
+            Invoke-MicrowinBusyInfo -warning $msg
+            Set-WinUtilTaskbaritem -state "Error" -value 1 -overlay "warning"
             [System.Windows.MessageBox]::Show($msg, "Winutil", [System.Windows.MessageBoxButton]::OK, [System.Windows.MessageBoxImage]::Error)
             return
         }
@@ -131,8 +92,11 @@ function Invoke-MicrowinGetIso {
             }
             catch
             {
-                Write-Host "Unable to move the ISO file to the location you specified. The downloaded ISO is in the `"$env:TEMP`" folder"
+                $msg = "Unable to move the ISO file to the location you specified. The downloaded ISO is in the `"$env:TEMP`" folder"
+                Write-Host $msg
                 Write-Host "Error information: $($_.Exception.Message)" -ForegroundColor Yellow
+                Invoke-MicrowinBusyInfo -warning $msg
+                return
             }
         }
     }
@@ -140,11 +104,51 @@ function Invoke-MicrowinGetIso {
     Write-Host "File path $($filePath)"
     if (-not (Test-Path -Path "$filePath" -PathType Leaf)) {
         $msg = "File you've chosen doesn't exist"
+        Invoke-MicrowinBusyInfo -warning $msg
         [System.Windows.MessageBox]::Show($msg, "Winutil", [System.Windows.MessageBoxButton]::OK, [System.Windows.MessageBoxImage]::Error)
         return
     }
 
-    Set-WinUtilTaskbaritem -state "Indeterminate" -overlay "logo"
+    $oscdimgPath = Join-Path $env:TEMP 'oscdimg.exe'
+    $oscdImgFound = [bool] (Get-Command -ErrorAction Ignore -Type Application oscdimg.exe) -or (Test-Path $oscdimgPath -PathType Leaf)
+    Write-Host "oscdimg.exe on system: $oscdImgFound"
+
+    if (!$oscdImgFound) {
+        $downloadFromGitHub = $sync.WPFMicrowinDownloadFromGitHub.IsChecked
+
+        if (!$downloadFromGitHub) {
+            # only show the message to people who did check the box to download from github, if you check the box
+            # you consent to downloading it, no need to show extra dialogs
+            [System.Windows.MessageBox]::Show("oscdimge.exe is not found on the system, winutil will now attempt do download and install it using choco. This might take a long time.")
+            # the step below needs choco to download oscdimg
+            # Install Choco if not already present
+            Install-WinUtilChoco
+            $chocoFound = [bool] (Get-Command -ErrorAction Ignore -Type Application choco)
+            Write-Host "choco on system: $chocoFound"
+            if (!$chocoFound) {
+                [System.Windows.MessageBox]::Show("choco.exe is not found on the system, you need choco to download oscdimg.exe")
+                return
+            }
+
+            Start-Process -Verb runas -FilePath powershell.exe -ArgumentList "choco install windows-adk-oscdimg"
+            $msg = "oscdimg is installed, now close, reopen PowerShell terminal and re-launch winutil.ps1"
+            Invoke-MicrowinBusyInfo -wip $msg
+            [System.Windows.MessageBox]::Show($msg)
+            return
+        } else {
+            [System.Windows.MessageBox]::Show("oscdimge.exe is not found on the system, winutil will now attempt do download and install it from github. This might take a long time.")
+            Microwin-GetOscdimg -oscdimgPath $oscdimgPath
+            $oscdImgFound = Test-Path $oscdimgPath -PathType Leaf
+            if (!$oscdImgFound) {
+                $msg = "oscdimg was not downloaded can not proceed"
+                Invoke-MicrowinBusyInfo -warning $msg
+                [System.Windows.MessageBox]::Show($msg, "Winutil", [System.Windows.MessageBoxButton]::OK, [System.Windows.MessageBoxImage]::Error)
+                return
+            } else {
+                Write-Host "oscdimg.exe was successfully downloaded from github"
+            }
+        }
+    }
 
     # Detect the file size of the ISO and compare it with the free space of the system drive
     $isoSize = (Get-Item -Path "$filePath").Length
@@ -159,8 +163,10 @@ function Invoke-MicrowinGetIso {
     }
     elseif ($driveSpace -lt $isoSize) {
         # It's critical and we can't continue. Output an error
-        Write-Host "You don't have enough space for this operation. You need at least $([Math]::Round(($isoSize / ([Math]::Pow(1024, 2))) * 2, 2)) MB of free space to copy the ISO files to a temp directory and to be able to perform additional operations."
+        $msg = "You don't have enough space for this operation. You need at least $([Math]::Round(($isoSize / ([Math]::Pow(1024, 2))) * 2, 2)) MB of free space to copy the ISO files to a temp directory and to be able to perform additional operations."
+        Write-Host $msg
         Set-WinUtilTaskbaritem -state "Error" -value 1 -overlay "warning"
+        Invoke-MicrowinBusyInfo -warning $msg
         return
     } else {
         Write-Host "You have enough space for this operation."
@@ -174,10 +180,12 @@ function Invoke-MicrowinGetIso {
         Write-Host "Iso mounted to '$driveLetter'"
     } catch {
         # @ChrisTitusTech  please copy this wiki and change the link below to your copy of the wiki
-        Write-Error "Failed to mount the image. Error: $($_.Exception.Message)"
+        $msg = "Failed to mount the image. Error: $($_.Exception.Message)"
+        Write-Error $msg
         Write-Error "This is NOT winutil's problem, your ISO might be corrupt, or there is a problem on the system"
         Write-Host "Please refer to this wiki for more details: https://christitustech.github.io/winutil/KnownIssues/#troubleshoot-errors-during-microwin-usage" -ForegroundColor Red
         Set-WinUtilTaskbaritem -state "Error" -value 1 -overlay "warning"
+        Invoke-MicrowinBusyInfo -warning $msg
         return
     }
     # storing off values in hidden fields for further steps
@@ -251,8 +259,9 @@ function Invoke-MicrowinGetIso {
         if ((-not (Test-Path -Path "$wimFile" -PathType Leaf)) -and (-not (Test-Path -Path "$($wimFile.Replace(".wim", ".esd").Trim())" -PathType Leaf))) {
             $msg = "Neither install.wim nor install.esd exist in the image, this could happen if you use unofficial Windows images. Please don't use shady images from the internet, use only official images. Here are instructions how to download ISO images if the Microsoft website is not showing the link to download and ISO. https://www.techrepublic.com/article/how-to-download-a-windows-10-iso-file-without-using-the-media-creation-tool/"
             Write-Host $msg
-            [System.Windows.MessageBox]::Show($msg, "Winutil", [System.Windows.MessageBoxButton]::OK, [System.Windows.MessageBoxImage]::Error)
+            Invoke-MicrowinBusyInfo -warning $msg
             Set-WinUtilTaskbaritem -state "Error" -value 1 -overlay "warning"
+            [System.Windows.MessageBox]::Show($msg, "Winutil", [System.Windows.MessageBoxButton]::OK, [System.Windows.MessageBoxImage]::Error)
             throw
         }
         elseif ((-not (Test-Path -Path $wimFile -PathType Leaf)) -and (Test-Path -Path $wimFile.Replace(".wim", ".esd").Trim() -PathType Leaf)) {
@@ -282,6 +291,9 @@ function Invoke-MicrowinGetIso {
         Get-Volume $driveLetter | Get-DiskImage | Dismount-DiskImage
         Remove-Item -Recurse -Force "$($scratchDir)"
         Remove-Item -Recurse -Force "$($mountDir)"
+        Invoke-MicrowinBusyInfo -warning "Failed to read and unpack ISO"
+        Set-WinUtilTaskbaritem -state "Error" -value 1 -overlay "warning"
+
     }
 
     Write-Host "Done reading and unpacking ISO"
@@ -289,7 +301,7 @@ function Invoke-MicrowinGetIso {
     Write-Host "*********************************"
     Write-Host "Check the UI for further steps!!!"
 
-    $sync.BusyMessage.Visibility="Hidden"
+    Invoke-MicrowinBusyInfo -done "Done! Proceed with customization."
     $sync.ProcessRunning = $false
     Set-WinUtilTaskbaritem -state "None" -overlay "checkmark"
 }

--- a/xaml/inputXML.xaml
+++ b/xaml/inputXML.xaml
@@ -1395,11 +1395,16 @@
                         Grid.Row="0" Grid.Column="1">
                         <StackPanel HorizontalAlignment="Left" Background="{DynamicResource MainBackgroundColor}" SnapsToDevicePixels="True" Visibility="Visible">
 
-                            <Grid Name = "BusyMessage" Visibility="Collapsed">
-                              <TextBlock Name = "BusyText" Text="NBusy" Padding="22,2,1,1" />
-                              <TextBlock VerticalAlignment="Center" HorizontalAlignment="Left" FontFamily="Segoe MDL2 Assets"
-                                  FontSize="{DynamicResource IconFontSize}" Margin="16,0,0,0">&#xE701;</TextBlock>
-                            </Grid>
+                            <StackPanel x:Name="MicrowinBusyIndicator" Orientation="Horizontal" Margin="15,15,15,0">
+                                <TextBlock x:Name="BusyIcon" FontFamily="Segoe MDL2 Assets" Text="&#xE701;"
+                                         Margin="0,0,8,2"
+                                         FontSize="16"
+                                         VerticalAlignment="Center"
+                                         Foreground="{DynamicResource MicrowinBusyColor}"/>
+                                <TextBlock x:Name="BusyText" Text="Microwin"
+                                         VerticalAlignment="Center"
+                                         Foreground="{DynamicResource MicrowinBusyColor}"/>
+                            </StackPanel>
 
                             <TextBlock x:Name = "asciiTextBlock"
                                 xml:space ="preserve"


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://christitustech.github.io/winutil/contribute/ -->

## Type of Change
- [x] Refactoring
- [x] UI/UX improvement

## Description
<!--[Provide a detailed explanation of the changes you have made. Include the reasons behind these changes and any relevant context. Link any related issues.]-->
- fixed placement at some places for "Set-WinUtilTaskbaritem" as dialogbox which waits for user input came before
- moved installation of oscdImg to after choosing/downloading the ISO

## Added adaptive color & message of busy indicator:

Default:
![image](https://github.com/user-attachments/assets/af6b42ae-83cc-4a0b-888b-b19178682c45)

During Process:
![image](https://github.com/user-attachments/assets/38f1393d-2f7e-49cb-97c6-213c70eaae45)

Error:
![image](https://github.com/user-attachments/assets/6b69f8e9-467a-42bd-81f5-4c6847f999aa)

Done with first part:
![image](https://github.com/user-attachments/assets/921b88b1-c342-49e6-b4f0-e8ab76c03c41)

Finished:
![image](https://github.com/user-attachments/assets/23aab09b-b276-4d5c-9105-f0e7c3e78c03)

## Testing
<!--[Detail the testing you have performed to ensure that these changes function as intended. Include information about any added tests.]-->
- tested, works. Did not test out every exeption but it should work as expected.

## Impact
<!--[Discuss the impact of your changes on the project. This might include effects on performance, new dependencies, or changes in behaviour.]-->
- little indication in the UI which is now improved by showing state using colors and displaying errors with it.

## Issue related to PR
<!--[What issue/discussion is related to this PR (if any)]-->
- Idea from #2773

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
