### PR TITLE
[REG FIX] MenuShowDelay

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -1971,13 +1971,6 @@
       {
         "Path": "HKCU:\\Control Panel\\Desktop",
         "OriginalValue": "1",
-        "Name": "MenuShowDelay",
-        "Value": "1",
-        "Type": "DWord"
-      },
-      {
-        "Path": "HKCU:\\Control Panel\\Desktop",
-        "OriginalValue": "1",
         "Name": "AutoEndTasks",
         "Value": "1",
         "Type": "DWord"
@@ -2155,7 +2148,7 @@
       },
       {
         "Path": "HKCU:\\Control Panel\\Desktop",
-        "OriginalValue": "1",
+        "OriginalValue": "400",
         "Name": "MenuShowDelay",
         "Value": "200",
         "Type": "String"


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://christitustech.github.io/winutil/contribute/ -->

## Type of Change
- [x] Hotfix

## Description
<!--[Provide a detailed explanation of the changes you have made. Include the reasons behind these changes and any relevant context. Link any related issues.]-->
- remove false MenuShowDelay
- replace original value with true default value

## Issue related to PR
<!--[What issue/discussion is related to this PR (if any)]-->
- Resolves #3423

## Additional Information
<!--[Any additional information that reviewers should be aware of.]-->
The way the removed entry works is just diffrent, it is no dword and does not work like that at all.
In addition to that in the edited one i fixed the original value to the one that is truly the default one.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
