### PR TITLE
Adding Podman and Podman Desktop to applications config

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -391,6 +391,22 @@
         "link": "https://www.docker.com/products/docker-desktop",
         "winget": "Docker.DockerDesktop"
     },
+    "podman": {
+        "category": "Development",
+        "choco": "na",
+        "content": "Podman",
+        "description": "Podman is a tool for managing OCI containers and pods.",
+        "link": "https://podman.io/",
+        "winget": "RedHat.Podman"
+    },
+    "podmandesktop": {
+        "category": "Development",
+        "choco": "podman-desktop",
+        "content": "Podman Desktop",
+        "description": "Podman Desktop is a graphical interface that enables application developers to seamlessly work with containers and Kubernetes.",
+        "link": "https://podman-desktop.io/",
+        "winget": "RedHat.Podman-Desktop"
+    },
     "dotnet3": {
         "category": "Microsoft Tools",
         "choco": "dotnetcore3-desktop-runtime",


### PR DESCRIPTION
## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [x] UI/UX improvement

## Description
Add the Podman and Podman Desktop as a FOSS alternative to Docker Desktop.

## Testing
Executed them locally to ensure they installed and uninstalled.

## Impact
- WinUtil users don't have to manually install Podman and Podman Desktop.

## Issue related to PR
- Contributes to #1782

## Additional Information
Choco only has an approved package for Podman Desktop at the moment, so I set Podman to "na". Podman Desktop detects if Podman is missing during setup and offers to install it on the fly.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
