### PR TITLE
Add x64dbg to applications config

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -303,6 +303,14 @@
         "link": "https://crystalmark.info/en/software/crystaldiskinfo/",
         "winget": "CrystalDewWorld.CrystalDiskInfo"
     },
+    "x64dbg": {
+        "category": "Development",
+        "choco": "na",
+        "content": "x64dbg",
+        "description": "An open-source x64/x32 debugger for windows.",
+        "link": "https://x64dbg.com/",
+        "winget": "x64dbg.x64dbg"
+    },
     "capframex": {
         "category": "Utilities",
         "choco": "na",


### PR DESCRIPTION
Introduced x64dbg as a new entry in config/applications.json under the Development category, including its description, website link, and winget identifier.

<!--Before you make this PR have you followed the docs here? - https://christitustech.github.io/winutil/contribute/ -->

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
<!--[Provide a detailed explanation of the changes you have made. Include the reasons behind these changes and any relevant context. Link any related issues.]-->
I added x64dbg which is a an open-source x64/x32 debugger for windows.

## Testing
<!--[Detail the testing you have performed to ensure that these changes function as intended. Include information about any added tests.]-->
I ran Compile.ps1, ran winutil.ps1 as admin and installed x64dbg.

## Impact
<!--[Discuss the impact of your changes on the project. This might include effects on performance, new dependencies, or changes in behaviour.]-->
Users can now install x64dbg via the winutil.

## Issue related to PR
<!--[What issue/discussion is related to this PR (if any)]-->
None.

## Additional Information
<!--[Any additional information that reviewers should be aware of.]-->
This isn't a major change.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
