### PR TITLE
Updates to the "Disable Telemetry" tweak

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -1957,7 +1957,7 @@
       },
       {
         "Path": "HKLM:\\SOFTWARE\\Policies\\Microsoft\\Windows\\DeliveryOptimization",
-        "OriginalValue": "1",
+        "OriginalValue": "<RemoveEntry>",
         "Name": "DODownloadMode",
         "Value": "0",
         "Type": "DWord"

--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -1824,10 +1824,10 @@
     "registry": [
       {
         "Path": "HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\DataCollection",
-        "Type": "DWord",
-        "Value": "0",
+        "OriginalValue": "<RemoveEntry>",
         "Name": "AllowTelemetry",
-        "OriginalValue": "<RemoveEntry>"
+        "Value": "0",
+        "Type": "DWord"
       },
       {
         "Path": "HKLM:\\SOFTWARE\\Policies\\Microsoft\\Windows\\DataCollection",
@@ -1914,6 +1914,13 @@
         "Type": "DWord"
       },
       {
+        "Path": "HKCU:\\SOFTWARE\\Microsoft\\Siuf\\Rules",
+        "OriginalValue": "<RemoveEntry>",
+        "Name": "PeriodInNanoSeconds",
+        "Value": "<RemoveEntry>",
+        "Type": "QWord"
+      },
+      {
         "Path": "HKLM:\\SOFTWARE\\Policies\\Microsoft\\Windows\\DataCollection",
         "OriginalValue": "<RemoveEntry>",
         "Name": "DoNotShowFeedbackNotifications",
@@ -1945,7 +1952,14 @@
         "Path": "HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\DeliveryOptimization\\Config",
         "OriginalValue": "1",
         "Name": "DODownloadMode",
-        "Value": "1",
+        "Value": "0",
+        "Type": "DWord"
+      },
+      {
+        "Path": "HKLM:\\SOFTWARE\\Policies\\Microsoft\\Windows\\DeliveryOptimization",
+        "OriginalValue": "1",
+        "Name": "DODownloadMode",
+        "Value": "0",
         "Type": "DWord"
       },
       {


### PR DESCRIPTION
## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
- Minor formatting change for `AllowTelemetry` tweak.
- Added `PeriodInNanoSeconds`, which is related to "Feedback Frequency". When setting it to "Never", this should also be deleted (if present).
- Added new policy entry for `DODownloadMode`, in addition to the normal `Config` registry path one, and set the value to `0` instead of `1`. `0` completely disables "Delivery Optimization" and ensures updates are only download from official Microsoft servers. `1` allows for local network downloads, which can result in upload activity randomly on Windows.

## Testing
No extensive testing needed.

## Impact
No major impacts.

## Issue related to PR
N/A

## Additional Information
N/A

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
