### PR TITLE
[Tweaks] Cross Device Resume

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -3914,5 +3914,23 @@
       Write-Host Please sign out and back in, or restart your computer to apply the changes!
       "
     ]
+  },
+  "WPFTweaksDisableCrossDeviceResume": {
+    "Content": "Cross-Device Resume",
+    "Description": "This tweak controls the Resume function in Windows 11 24H2 and later, which allows you to resume an activity from a mobile device and vice-versa.",
+    "category": "Customize Preferences",
+    "panel": "2",
+    "Order": "a207_",
+    "Type": "Toggle",
+    "registry": [
+      {
+        "Path": "HKCU:\\Software\\Microsoft\\Windows\\CurrentVersion\\CrossDeviceResume\\Configuration",
+        "Name": "IsResumeAllowed",
+        "Value": "1",
+        "OriginalValue": "0",
+        "DefaultState": "true",
+        "Type": "DWord"
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Type of Change
- [X] New feature

## Description
This PR adds an option to control the Resume feature introduced in Windows 11 24H2:

![imagen](https://github.com/user-attachments/assets/5ba523bc-eedd-49d8-ada2-147acd216a2c)

## Testing
It works successfully on Windows 11 24H2.

## Impact
A new feature

## Issue related to PR
No issues resolved

## Additional Information
Since this is my first tweak, feel free to provide feedback in case I screwed up with the properties.

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no errors/warnings/merge conflicts.
