### PR TITLE
[FEAT] Add scaling functionality for accessibility

### DIFF
--- a/functions/private/Invoke-WinUtilFontScaling.ps1
+++ b/functions/private/Invoke-WinUtilFontScaling.ps1
@@ -1,0 +1,72 @@
+function Invoke-WinUtilFontScaling {
+    <#
+
+    .SYNOPSIS
+        Applies UI and font scaling for accessibility
+
+    .PARAMETER ScaleFactor
+        Sets the scaling from 0.75 and 2.0.
+        Default is 1.0 (100% - no scaling)
+
+    .EXAMPLE
+        Invoke-WinUtilFontScaling -ScaleFactor 1.25
+        # Applies 125% scaling
+    #>
+
+    param (
+        [double]$ScaleFactor = 1.0
+    )
+
+    # Validate if scale factor is within the range
+    if ($ScaleFactor -lt 0.75 -or $ScaleFactor -gt 2.0) {
+        Write-Warning "Scale factor must be between 0.75 and 2.0. Using 1.0 instead."
+        $ScaleFactor = 1.0
+    }
+
+    # Define an array for resources to be scaled
+    $fontResources = @(
+        "FontSize",
+        "ButtonFontSize",
+        "HeaderFontSize",
+        "TabButtonFontSize",
+        "IconFontSize",
+        "SettingsIconFontSize",
+        "CloseIconFontSize",
+        "AppEntryFontSize",
+        "SearchBarTextBoxFontSize",
+        "SearchBarClearButtonFontSize",
+        "CustomDialogFontSize",
+        "CustomDialogFontSizeHeader",
+        "ConfigUpdateButtonFontSize",
+        "CheckBoxBulletDecoratorSize"
+    )
+
+    # Apply scaling to each resource
+    foreach ($resourceName in $fontResources) {
+        try {
+            # Get the default font size from the theme configuration
+            $originalValue = $sync.configs.themes.shared.$resourceName
+            if ($originalValue) {
+                # Convert string to double since values are stored as strings
+                $originalValue = [double]$originalValue
+                # Calculates and applies the new font size
+                $newValue = [math]::Round($originalValue * $ScaleFactor, 1)
+                $sync.Form.Resources[$resourceName] = $newValue
+                Write-Debug "Scaled $resourceName from original $originalValue to $newValue (factor: $ScaleFactor)"
+            }
+        }
+        catch {
+            Write-Warning "Failed to scale resource $resourceName : $_"
+        }
+    }
+
+    # Update the font scaling percentage displayed on the UI
+    if ($sync.FontScalingValue) {
+        $percentage = [math]::Round($ScaleFactor * 100)
+        $sync.FontScalingValue.Text = "$percentage%"
+    }
+
+    Write-Debug "Font scaling applied with factor: $ScaleFactor"
+}
+
+

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -261,7 +261,7 @@ $commonKeyEvents = {
 $sync["Form"].Add_PreViewKeyDown($commonKeyEvents)
 
 $sync["Form"].Add_MouseLeftButtonDown({
-    Invoke-WPFPopup -Action "Hide" -Popups @("Settings", "Theme")
+    Invoke-WPFPopup -Action "Hide" -Popups @("Settings", "Theme", "FontScaling")
     $sync["Form"].DragMove()
 })
 
@@ -279,7 +279,7 @@ $sync["Form"].Add_MouseDoubleClick({
 
 $sync["Form"].Add_Deactivated({
     Write-Debug "WinUtil lost focus"
-    Invoke-WPFPopup -Action "Hide" -Popups @("Settings", "Theme")
+    Invoke-WPFPopup -Action "Hide" -Popups @("Settings", "Theme", "FontScaling")
 })
 
 $sync["Form"].Add_ContentRendered({
@@ -441,7 +441,7 @@ $sync["Form"].Add_Activated({
 
 $sync["ThemeButton"].Add_Click({
     Write-Debug "ThemeButton clicked"
-    Invoke-WPFPopup -PopupActionTable @{ "Settings" = "Hide"; "Theme" = "Toggle" }
+    Invoke-WPFPopup -PopupActionTable @{ "Settings" = "Hide"; "Theme" = "Toggle"; "FontScaling" = "Hide" }
 })
 $sync["AutoThemeMenuItem"].Add_Click({
     Write-Debug "About clicked"
@@ -461,7 +461,7 @@ $sync["LightThemeMenuItem"].Add_Click({
 
 $sync["SettingsButton"].Add_Click({
     Write-Debug "SettingsButton clicked"
-    Invoke-WPFPopup -PopupActionTable @{ "Settings" = "Toggle"; "Theme" = "Hide" }
+    Invoke-WPFPopup -PopupActionTable @{ "Settings" = "Toggle"; "Theme" = "Hide"; "FontScaling" = "Hide" }
 })
 $sync["ImportMenuItem"].Add_Click({
     Write-Debug "Import clicked"
@@ -504,6 +504,31 @@ $sync["SponsorMenuItem"].Add_Click({
         $authorInfo += "An error occurred while fetching or processing the sponsors: $_`n"
     }
     Show-CustomDialog -Title "Sponsors" -Message $authorInfo -EnableScroll $true
+})
+
+# Font Scaling Event Handlers
+$sync["FontScalingButton"].Add_Click({
+    Write-Debug "FontScalingButton clicked"
+    Invoke-WPFPopup -PopupActionTable @{ "Settings" = "Hide"; "Theme" = "Hide"; "FontScaling" = "Toggle" }
+})
+
+$sync["FontScalingSlider"].Add_ValueChanged({
+    param($slider)
+    $percentage = [math]::Round($slider.Value * 100)
+    $sync.FontScalingValue.Text = "$percentage%"
+})
+
+$sync["FontScalingResetButton"].Add_Click({
+    Write-Debug "FontScalingResetButton clicked"
+    $sync.FontScalingSlider.Value = 1.0
+    $sync.FontScalingValue.Text = "100%"
+})
+
+$sync["FontScalingApplyButton"].Add_Click({
+    Write-Debug "FontScalingApplyButton clicked"
+    $scaleFactor = $sync.FontScalingSlider.Value
+    Invoke-WinUtilFontScaling -ScaleFactor $scaleFactor
+    Invoke-WPFPopup -Action "Hide" -Popups @("FontScaling")
 })
 
 $sync["Form"].ShowDialog() | out-null

--- a/xaml/inputXML.xaml
+++ b/xaml/inputXML.xaml
@@ -948,6 +948,7 @@
                     <ColumnDefinition Width="Auto"/><!-- Space for close button -->
                     <ColumnDefinition Width="Auto"/>
                     <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="Auto"/><!-- Space for Font Scaling button-->
                 </Grid.ColumnDefinitions>
 
                 <!--
@@ -1032,9 +1033,77 @@
                     </Border>
                 </Popup>
 
-                <Button Name="SettingsButton"
+                <Button Name="FontScalingButton"
                     Style="{StaticResource HoverButtonStyle}"
                     Grid.Column="3" BorderBrush="Transparent"
+                    Background="{DynamicResource MainBackgroundColor}"
+                    Foreground="{DynamicResource MainForegroundColor}"
+                    FontSize="{DynamicResource SettingsIconFontSize}"
+                    Width="{DynamicResource IconButtonSize}" Height="{DynamicResource IconButtonSize}"
+                    HorizontalAlignment="Right" VerticalAlignment="Top"
+                    Margin="0,5,5,0"
+                    FontFamily="Segoe MDL2 Assets"
+                    Content="&#xE8D3;"
+                    ToolTip="Adjust Font Scaling for Accessibility"
+                />
+                <Popup Grid.Column="3" Name="FontScalingPopup"
+                    IsOpen="False"
+                    PlacementTarget="{Binding ElementName=FontScalingButton}" Placement="Bottom"
+                    HorizontalAlignment="Right" VerticalAlignment="Top">
+                    <Border Background="{DynamicResource MainBackgroundColor}" BorderBrush="{DynamicResource MainForegroundColor}" BorderThickness="1" CornerRadius="0" Margin="0">
+                        <StackPanel Background="{DynamicResource MainBackgroundColor}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" MinWidth="200">
+                            <TextBlock Text="Font Scaling"
+                                       FontSize="{DynamicResource ButtonFontSize}"
+                                       Foreground="{DynamicResource MainForegroundColor}"
+                                       HorizontalAlignment="Center"
+                                       Margin="10,5,10,5"
+                                       FontWeight="Bold"/>
+                            <Separator Margin="5,0,5,5"/>
+                            <StackPanel Orientation="Horizontal" Margin="10,5,10,10">
+                                <TextBlock Text="Small"
+                                           FontSize="{DynamicResource ButtonFontSize}"
+                                           Foreground="{DynamicResource MainForegroundColor}"
+                                           VerticalAlignment="Center"
+                                           Margin="0,0,10,0"/>
+                                <Slider Name="FontScalingSlider"
+                                        Minimum="0.75" Maximum="2.0"
+                                        Value="1.0"
+                                        TickFrequency="0.25"
+                                        TickPlacement="BottomRight"
+                                        IsSnapToTickEnabled="True"
+                                        Width="120"
+                                        VerticalAlignment="Center"/>
+                                <TextBlock Text="Large"
+                                           FontSize="{DynamicResource ButtonFontSize}"
+                                           Foreground="{DynamicResource MainForegroundColor}"
+                                           VerticalAlignment="Center"
+                                           Margin="10,0,0,0"/>
+                            </StackPanel>
+                            <TextBlock Name="FontScalingValue"
+                                       Text="100%"
+                                       FontSize="{DynamicResource ButtonFontSize}"
+                                       Foreground="{DynamicResource MainForegroundColor}"
+                                       HorizontalAlignment="Center"
+                                       Margin="10,0,10,5"/>
+                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="10,0,10,10">
+                                <Button Name="FontScalingResetButton"
+                                        Content="Reset"
+                                        Style="{StaticResource HoverButtonStyle}"
+                                        Width="60" Height="25"
+                                        Margin="5,0,5,0"/>
+                                <Button Name="FontScalingApplyButton"
+                                        Content="Apply"
+                                        Style="{StaticResource HoverButtonStyle}"
+                                        Width="60" Height="25"
+                                        Margin="5,0,5,0"/>
+                            </StackPanel>
+                        </StackPanel>
+                    </Border>
+                </Popup>
+
+                <Button Name="SettingsButton"
+                    Style="{StaticResource HoverButtonStyle}"
+                    Grid.Column="4" BorderBrush="Transparent"
                     Background="{DynamicResource MainBackgroundColor}"
                     Foreground="{DynamicResource MainForegroundColor}"
                     FontSize="{DynamicResource SettingsIconFontSize}"
@@ -1067,7 +1136,7 @@
                 </Popup>
 
             <Button
-                Grid.Column="4"
+                Grid.Column="5"
                 Content="&#xD7;" BorderThickness="0"
                 BorderBrush="Transparent"
                 Background="{DynamicResource MainBackgroundColor}"


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://christitustech.github.io/winutil/contribute/ -->

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [x] UI/UX improvement

## Description
<!--[Provide a detailed explanation of the changes you have made. Include the reasons behind these changes and any relevant context. Link any related issues.]-->
This adds a new Font Scaling function in the utility. It adds a new button near settings with a dropdown slider to adjust scaling (Screenshots below)

It works by storing the default font size and then multiplying it by the chosen scaling factor.

## Testing
<!--[Detail the testing you have performed to ensure that these changes function as intended. Include information about any added tests.]-->
Tested on 24H2.
It functions just like other similar buttons, such as the dropdown closes when I clicked other buttons, etc.

## Issue related to PR
<!--[What issue/discussion is related to this PR (if any)]-->
- Resolves #3501

## Additional Information
<!--[Any additional information that reviewers should be aware of.]-->
I have kept a broad range of the scaling size because I am not sure what it'll look like on high resolution screens but the values are very easily tweakable.

Screenshots:

<img width="292" height="193" alt="image" src="https://github.com/user-attachments/assets/f2da9c89-a550-4f11-a4d1-7b0b7cf6653b" />
<br>
<br>
This is what 125% scaling looks like:-
<img width="1389" height="757" alt="image" src="https://github.com/user-attachments/assets/bb5427cc-bb92-476e-81bb-b80112f21b6c" />
<br>
<br>
This is my first contribution to open-source. I appreciate the feedback!


## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
