### PR TITLE
Fix DisableWindowsConsumerFeatures in Microwin-NewUnattend.ps1

### DIFF
--- a/functions/microwin/Microwin-NewUnattend.ps1
+++ b/functions/microwin/Microwin-NewUnattend.ps1
@@ -264,7 +264,7 @@ function Microwin-NewUnattend {
                 </RunSynchronousCommand>
                 <RunSynchronousCommand wcm:action="add">
                     <Order>45</Order>
-                    <Path>reg.exe add "HKLM\Software\Policies\Microsoft\Windows\CloudContent" /v "DisableWindowsConsumerFeatures" /t REG_DWORD /d 0 /f</Path>
+                    <Path>reg.exe add "HKLM\Software\Policies\Microsoft\Windows\CloudContent" /v "DisableWindowsConsumerFeatures" /t REG_DWORD /d 1 /f</Path>
                 </RunSynchronousCommand>
                 <RunSynchronousCommand wcm:action="add">
                     <Order>46</Order>


### PR DESCRIPTION
DisableWindowsConsumerFeatures should be set to '1' to block unwanted Windows Consumer Features.

<!--Before you make this PR have you followed the docs here? - https://christitustech.github.io/winutil/contribute/ -->

## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
The DisableWindowsConsumerFeatures registry value should be a '1' but the code is set to '0'. This has an unintended effect as you are allowing Windows update to install the unwanted 'Consumer Features'. Where as elsewhere your debloat code sets this registry value to '1' as intended.

## Testing
Ran a test using a local build and made a MicroWin image with this small change. Desired effect worked as expected.

## Impact
Minimal impact. Only sets the registry value to the intended desired value.

## Issue related to PR
- Resolves # 3488
https://github.com/ChrisTitusTech/winutil/issues/3488

## Additional Information
This is my first pull request. If I made errors following the procedure as you documented on the Docs page, please let me know. I'm interested in providing more helpful Pull Requests once I feel more confident I'm doing this completely correctly.

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [X] I have performed a self-review of my own code.
- [N/A] I have commented my code, particularly in hard-to-understand areas.
- [N/A] I have made corresponding changes to the documentation.
- [X] My changes generate no errors/warnings/merge conflicts.
