### PR TITLE
Fix scaling of UI Elements when applying Font Scaling

### DIFF
--- a/config/themes.json
+++ b/config/themes.json
@@ -32,6 +32,7 @@
         "ButtonFontFamily": "Arial",
         "ButtonWidth":      "200",
         "ButtonHeight":     "25",
+        "ConfigTabButtonFontSize":   "14",
         "ConfigUpdateButtonFontSize":   "14",
         "SearchBarWidth":               "200",
         "SearchBarHeight":              "26",

--- a/functions/private/Invoke-WinUtilFontScaling.ps1
+++ b/functions/private/Invoke-WinUtilFontScaling.ps1
@@ -29,6 +29,7 @@ function Invoke-WinUtilFontScaling {
         "ButtonFontSize",
         "HeaderFontSize",
         "TabButtonFontSize",
+        "ConfigTabButtonFontSize",
         "IconFontSize",
         "SettingsIconFontSize",
         "CloseIconFontSize",

--- a/functions/private/Invoke-WinUtilFontScaling.ps1
+++ b/functions/private/Invoke-WinUtilFontScaling.ps1
@@ -38,7 +38,21 @@ function Invoke-WinUtilFontScaling {
         "CustomDialogFontSize",
         "CustomDialogFontSizeHeader",
         "ConfigUpdateButtonFontSize",
-        "CheckBoxBulletDecoratorSize"
+        "CheckBoxBulletDecoratorSize",
+        "ButtonWidth",
+        "ButtonHeight",
+        "TabButtonWidth",
+        "TabButtonHeight",
+        "IconButtonSize",
+        "AppEntryWidth",
+        "SearchBarWidth",
+        "SearchBarHeight",
+        "CustomDialogWidth",
+        "CustomDialogHeight",
+        "CustomDialogLogoSize",
+        "MicroWinLogoSize",
+        "TabRowHeightInPixels",
+        "ToolTipWidth"
     )
 
     # Apply scaling to each resource

--- a/functions/private/Invoke-WinUtilFontScaling.ps1
+++ b/functions/private/Invoke-WinUtilFontScaling.ps1
@@ -25,6 +25,7 @@ function Invoke-WinUtilFontScaling {
 
     # Define an array for resources to be scaled
     $fontResources = @(
+        # Fonts
         "FontSize",
         "ButtonFontSize",
         "HeaderFontSize",
@@ -39,6 +40,7 @@ function Invoke-WinUtilFontScaling {
         "CustomDialogFontSize",
         "CustomDialogFontSizeHeader",
         "ConfigUpdateButtonFontSize",
+        # Buttons and UI
         "CheckBoxBulletDecoratorSize",
         "ButtonWidth",
         "ButtonHeight",

--- a/functions/private/Invoke-WinUtilFontScaling.ps1
+++ b/functions/private/Invoke-WinUtilFontScaling.ps1
@@ -52,7 +52,6 @@ function Invoke-WinUtilFontScaling {
         "CustomDialogHeight",
         "CustomDialogLogoSize",
         "MicroWinLogoSize",
-        "TabRowHeightInPixels",
         "ToolTipWidth"
     )
 


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://christitustech.github.io/winutil/contribute/ -->

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [x] Hotfix
- [ ] Security patch
- [x] UI/UX improvement

## Description
<!--[Provide a detailed explanation of the changes you have made. Include the reasons behind these changes and any relevant context. Link any related issues.]-->
This improves the Font scaling function from the PR I created couple of weeks ago. #3505

This now scales the UI elements with the font such as buttons and search bar.

## Testing
<!--[Detail the testing you have performed to ensure that these changes function as intended. Include information about any added tests.]-->
Tested on 24H2

## Issue related to PR
<!--[What issue/discussion is related to this PR (if any)]-->
- Resolves #3501 

## Additional Information
<!--[Any additional information that reviewers should be aware of.]-->
There are some things that still don't work as expected such as the sidebar and topbar doesn't scale and causes text overflow on large scaling options and the search icon in search bar doesn't align after applying scaling because it has a fixed margin. I couldn't fix them without breaking stuff or overcomplicating things.

I think 150% scaling is the sweet spot but I still haven't tested it on a high-res monitor so I'm not sure.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
