### PR TITLE
Omit Brave sync on Brave debloat

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -1585,13 +1585,6 @@
         "Type": "DWord",
         "Value": "0",
         "OriginalValue": "<RemoveEntry>"
-      },
-            {
-        "Path": "HKLM:\\SOFTWARE\\Policies\\BraveSoftware\\Brave",
-        "Name": "SyncDisabled",
-        "Type": "DWord",
-        "Value": "1",
-        "OriginalValue": "<RemoveEntry>"
       }
     ]
   },


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://christitustech.github.io/winutil/contribute/ -->

## Description
<!--[Provide a detailed explanation of the changes you have made. Include the reasons behind these changes and any relevant context. Link any related issues.]-->
Removed Brave Sync from the options that were being disabled by the Brave debloat tweak, because it isn't really an annoyance like the others, where you need to sign up to a service (e.g. VPN) but rather a fairly solid option to sync browser data across multiple devices. 
Also it was not mentioned in the description that the setting would be affected in the first place.

https://support.brave.app/hc/en-us/articles/360059793111-Understanding-Brave-Sync

## Issue related to PR
<!--[What issue/discussion is related to this PR (if any)]-->
- Resolves #3527


## Additional Information
<!--[Any additional information that reviewers should be aware of.]-->
For anyone who wants to reenable the sync feature, manually, please run the following command in an administrative Powershell/Terminal window. 

`Remove-ItemProperty -Path "HKLM:\SOFTWARE\Policies\BraveSoftware\Brave" -Name "SyncDisabled"`
