### PR TITLE
[App OpenRGB] Fix winget package ID

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -1509,7 +1509,7 @@
         "content": "OpenRGB",
         "description": "OpenRGB is an open-source RGB lighting control software designed to manage and control RGB lighting for various components and peripherals.",
         "link": "https://openrgb.org/",
-        "winget": "CalcProgrammer1.OpenRGB"
+        "winget": "OpenRGB.OpenRGB"
     },
     "openscad": {
         "category": "Multimedia Tools",


### PR DESCRIPTION
Change winget package ID from CalcProgrammer1.OpenRGB to OpenRGB.OpenRGB.

Fixes #3540

<!--Before you make this PR have you followed the docs here? - https://christitustech.github.io/winutil/contribute/ -->

## Type of Change
- [x] Bug fix

## Description
<!--[Provide a detailed explanation of the changes you have made. Include the reasons behind these changes and any relevant context. Link any related issues.]-->
Fixes the winget package ID for OpenRGB

## Testing
<!--[Detail the testing you have performed to ensure that these changes function as intended. Include information about any added tests.]-->
Works. Tested using winget search.

## Impact
<!--[Discuss the impact of your changes on the project. This might include effects on performance, new dependencies, or changes in behaviour.]-->

## Issue related to PR
<!--[What issue/discussion is related to this PR (if any)]-->
- Resolves #3540 

## Additional Information
<!--[Any additional information that reviewers should be aware of.]-->

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
