### PR TITLE
[Applications] Fixed invalid winget install name for the Session application.

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -1885,7 +1885,7 @@
         "content": "Session",
         "description": "Session is a private and secure messaging app built on a decentralized network for user privacy and data protection.",
         "link": "https://getsession.org/",
-        "winget": "Oxen.Session"
+        "winget": "Session.Session"
     },
     "sharex": {
         "category": "Multimedia Tools",


### PR DESCRIPTION
## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
The current winget package name for Session is way out of date, the new package name is Session.Session.

## Testing
Ensured that the previous package name was out of date before attempting a winget search session, which brought up the correct page. Installed manually and obtained the correct piece of software.

## Impact
Ensures that individuals that are seeking to install Session from this tool, that they are not met with the package not found error during the install process.

## Issue related to PR
- N/A

## Additional Information
N/A

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [X] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [X] My changes generate no errors/warnings/merge conflicts.
