### PR TITLE
Update OpenRGB Winget ID to OpenRGB.OpenRGB

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -1509,7 +1509,7 @@
         "content": "OpenRGB",
         "description": "OpenRGB is an open-source RGB lighting control software designed to manage and control RGB lighting for various components and peripherals.",
         "link": "https://openrgb.org/",
-        "winget": "CalcProgrammer1.OpenRGB"
+    "winget": "OpenRGB.OpenRGB"
     },
     "openscad": {
         "category": "Multimedia Tools",

--- a/xaml/inputXML.xaml
+++ b/xaml/inputXML.xaml
@@ -1238,7 +1238,7 @@
                             <!-- Default Settings -->
                             <Border Grid.Column="0" Style="{StaticResource BorderStyle}">
                                 <StackPanel>
-                                    <Button Name="Invoke-WPFUpdatesdefault"
+                                    <Button Name="WPFUpdatesdefault"
                                             FontSize="{DynamicResource ConfigTabButtonFontSize}"
                                             Content="Default Settings"
                                             Margin="10,5"


### PR DESCRIPTION
This PR updates the Winget ID for OpenRGB from CalcProgrammer1.OpenRGB to OpenRGB.OpenRGB, ensuring correct installation via Winget. Resolves #3540.