### PR TITLE
[MicroWin/FIDO] Replace 24H2 with 25H2

### DIFF
--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -368,8 +368,8 @@ $sync["ISOmanual"].add_Checked({
     $sync["ISOLanguage"].Visibility = [System.Windows.Visibility]::Collapsed
 })
 
-$sync["ISORelease"].Items.Add("24H2") | Out-Null
-$sync["ISORelease"].SelectedItem = "24H2"
+$sync["ISORelease"].Items.Add("25H2") | Out-Null
+$sync["ISORelease"].SelectedItem = "25H2"
 
 $sync["ISOLanguage"].Items.Add("System Language ($(Microwin-GetLangFromCulture -langName $((Get-Culture).Name)))") | Out-Null
 if ($currentCulture -ne "English International") {


### PR DESCRIPTION
## Type of Change
- [X] New feature

## Description
When Windows 11 25H2 is released, Microsoft will most likely do the same thing they did for 24H2, which was to remove 23H2 downloads upon the release.

Microsoft will remove 24H2 downloads when 25H2 is released, so Fido won't work once it is out.

## Testing
This should work

## Issue related to PR
None

## Additional Information
This will be a draft to indicate that it can't be merged. It must NOT be merged until 25H2 is released as GA.

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no errors/warnings/merge conflicts.
