### PR TITLE
Remove mentions of Windows 11 Edition and pull latest

### DIFF
--- a/functions/microwin/Invoke-MicrowinGetIso.ps1
+++ b/functions/microwin/Invoke-MicrowinGetIso.ps1
@@ -73,7 +73,7 @@ function Invoke-MicrowinGetIso {
         }
 
         Invoke-MicrowinBusyInfo -action "wip" -message "Downloading Windows ISO... (This may take a long time)" -interactive $false
-        & $fidopath -Win 'Windows 11' -Rel $sync["ISORelease"].SelectedItem -Arch "x64" -Lang $lang -Ed "Windows 11 Home/Pro/Edu"
+        & $fidopath -Win 'Windows 11' -Rel Latest -Arch "x64" -Lang $lang
         if (-not $?)
         {
             Write-Host "Could not download the ISO file. Look at the output of the console for more information."

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -359,17 +359,12 @@ $sync["Form"].Add_ContentRendered({
 
 # Add event handlers for the RadioButtons
 $sync["ISOdownloader"].add_Checked({
-    $sync["ISORelease"].Visibility = [System.Windows.Visibility]::Visible
     $sync["ISOLanguage"].Visibility = [System.Windows.Visibility]::Visible
 })
 
 $sync["ISOmanual"].add_Checked({
-    $sync["ISORelease"].Visibility = [System.Windows.Visibility]::Collapsed
     $sync["ISOLanguage"].Visibility = [System.Windows.Visibility]::Collapsed
 })
-
-$sync["ISORelease"].Items.Add("24H2") | Out-Null
-$sync["ISORelease"].SelectedItem = "24H2"
 
 $sync["ISOLanguage"].Items.Add("System Language ($(Microwin-GetLangFromCulture -langName $((Get-Culture).Name)))") | Out-Null
 if ($currentCulture -ne "English International") {

--- a/xaml/inputXML.xaml
+++ b/xaml/inputXML.xaml
@@ -1375,7 +1375,6 @@
                             />
                             <RadioButton x:Name="ISOmanual" Content="Select your own ISO" GroupName="Options" Margin="0,10,0,0" IsChecked="True"/>
                             <RadioButton x:Name="ISOdownloader" Content="Get newest ISO automatically" GroupName="Options" Margin="0,5,0,5"/>
-                            <ComboBox x:Name="ISORelease" Visibility="Collapsed"/>
                             <ComboBox x:Name="ISOLanguage" Visibility="Collapsed"/>
                             <Button Name="WPFGetIso" Margin="2" Padding="15">
                                 <Button.Content>


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://christitustech.github.io/winutil/contribute/ -->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [x] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Remove mentions of Windows 11 Edition and pull latest edition and pull all editions without the extra variables in the command.

## Testing
Tested locally and fully works

## Impact
People now won't only see 1 option on the Windows 11 Version.

## Issue related to PR
<!--[What issue/discussion is related to this PR (if any)]-->
- Resolves #

## Additional Information
<!--[Any additional information that reviewers should be aware of.]-->

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
