### PR TITLE
[Offline] Fixed invalid command in PWSH 5

### DIFF
--- a/functions/private/Test-WinUtilInternetConnection.ps1
+++ b/functions/private/Test-WinUtilInternetConnection.ps1
@@ -14,7 +14,7 @@ function Test-WinUtilInternetConnection {
         )
 
         foreach ($site in $testSites) {
-            if (Test-Connection -ComputerName $site -Count 1 -Quiet -TimeoutSeconds 3 -ErrorAction SilentlyContinue) {
+            if (Test-Connection -ComputerName $site -Count 1 -Quiet -ErrorAction SilentlyContinue) {
                 return $true
             }
         }


### PR DESCRIPTION
## Type of Change
- [X] Bug fix

## Description
`-TimeoutSeconds` is not a parameter in Test-Connection for PWSH 5.

## Testing
It works.

## Additional Information
@ChrisTitusTech, at least test whatever BS AI spits at you...

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no errors/warnings/merge conflicts.
