### PR TITLE
Add Disable Edge Tweak

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -2129,6 +2129,36 @@
     ],
     "link": "https://winutil.christitus.com/dev/tweaks/essential-tweaks/wifi"
   },
+  "WPFTweaksDisableEdge": {
+    "Content": "Disable Edge",
+    "Description": "Disables Microsoft Edge via the registry and prevents scheduled tasks from running Edge updates",
+    "Category": "z__Advanced Tweaks - CAUTION",
+    "Panel": "1",
+    "Order": "a016_",
+    "Registry": [
+      {
+        "Path": "HKCU:\\Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer\\DisallowRun",
+        "Name": "DisableEdge",
+        "Type": "String",
+        "Value": "msedge.exe",
+        "OriginalValue": "<RemoveEntry>"
+      },
+      {
+        "Path": "HKLM:\\Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer",
+        "Name": "DisallowRun",
+        "Type": "DWord",
+        "Value": 1,
+        "OriginalValue": "<RemoveEntry>"
+      }
+    ],
+    "InvokeScript": [
+      "Get-ScheduledTask -TaskPath '\\' | Where-Object {$_.TaskName -like 'MicrosoftEdge*'} | ForEach-Object { Disable-ScheduledTask -TaskName $_.TaskName -TaskPath '\\' }"
+    ],
+    "UndoScript": [
+      "Get-ScheduledTask -TaskPath '\\' | Where-Object {$_.TaskName -like 'MicrosoftEdge*'} | ForEach-Object { Enable-ScheduledTask -TaskName $_.TaskName -TaskPath '\\' }"
+    ],
+    "Link": ""
+  },
   "WPFTweaksUTC": {
     "Content": "Set Time to UTC (Dual Boot)",
     "Description": "Essential for computers that are dual booting. Fixes the time sync with Linux Systems.",

--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -2131,11 +2131,11 @@
   },
   "WPFTweaksDisableEdge": {
     "Content": "Disable Edge",
-    "Description": "Disables Microsoft Edge via the registry and prevents scheduled tasks from running Edge updates",
-    "Category": "z__Advanced Tweaks - CAUTION",
-    "Panel": "1",
+    "Description": "Disables Microsoft Edge via the registry and prevents scheduled tasks from running Edge updates.",
+    "category": "z__Advanced Tweaks - CAUTION",
+    "panel": "1",
     "Order": "a016_",
-    "Registry": [
+    "registry": [
       {
         "Path": "HKCU:\\Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer\\DisallowRun",
         "Name": "DisableEdge",
@@ -2147,17 +2147,17 @@
         "Path": "HKLM:\\Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer",
         "Name": "DisallowRun",
         "Type": "DWord",
-        "Value": 1,
+        "Value": "1",
         "OriginalValue": "<RemoveEntry>"
       }
     ],
-    "InvokeScript": [
+    "invokeScript": [
       "Get-ScheduledTask -TaskPath '\\' | Where-Object {$_.TaskName -like 'MicrosoftEdge*'} | ForEach-Object { Disable-ScheduledTask -TaskName $_.TaskName -TaskPath '\\' }"
     ],
-    "UndoScript": [
+    "undoScript": [
       "Get-ScheduledTask -TaskPath '\\' | Where-Object {$_.TaskName -like 'MicrosoftEdge*'} | ForEach-Object { Enable-ScheduledTask -TaskName $_.TaskName -TaskPath '\\' }"
     ],
-    "Link": ""
+    "link": ""
   },
   "WPFTweaksUTC": {
     "Content": "Set Time to UTC (Dual Boot)",


### PR DESCRIPTION
# Safe Edge Disable / Undo Tweak

You removed "remove edge tweak" since it’s unstable, so instead of reinventing the wheel this provides a **safe way to disable Edge from running and stop Edge updates** — and it’s easily undoable.  

Having Edge and Edge Update running in the background may take up a lot of resources, so disabling it is useful.  

I marked this as an **advanced tweak** since I don’t want people to disable Edge and not be able to get it back if they don’t know about the undo tweak.  