### PR TITLE
fix(microwin): Prevent removal of User-Mode Driver Framework

### DIFF
--- a/functions/microwin/Microwin-RemoveFeatures.ps1
+++ b/functions/microwin/Microwin-RemoveFeatures.ps1
@@ -27,6 +27,7 @@ function Microwin-RemoveFeatures() {
                 $_.FeatureName -NotLike "*NetFx*" -AND
                 $_.FeatureName -NotLike "*Media*" -AND
                 $_.FeatureName -NotLike "*NFS*" -AND
+                $_.FeatureName -NotLike "*UserModeDriverFramework*" -AND
                 $_.FeatureName -NotLike "*SearchEngine*" -AND
                 $_.FeatureName -NotLike "*RemoteDesktop*" -AND
                 $_.State -ne "Disabled"
@@ -45,6 +46,7 @@ function Microwin-RemoveFeatures() {
                     $_ -NotLike "*NetFx*" -AND
                     $_ -NotLike "*Media*" -AND
                     $_ -NotLike "*NFS*" -AND
+                    $_ -NotLike "*UserModeDriverFramework*" -AND
                     $_ -NotLike "*SearchEngine*" -AND
                     $_ -NotLike "*RemoteDesktop*"
                 }


### PR DESCRIPTION
## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
This pull request addresses an issue where the MicroWin debloating process over-aggressively removes the User-Mode Driver Framework (WUDFsvc). This service is critical for the proper functioning of certain applications, such as Parsec, which rely on it to communicate with hardware like the GPU.

The removal of `WUDFsvc` leads to poor performance, errors like `DXGI_ERROR_ACCESS_LOST`, and Event Viewer logs indicating that `\Driver\WUDFRd` failed to load.

The fix involves modifying `Microwin-RemoveFeatures.ps1` to explicitly exclude `UserModeDriverFramework` from the list of features to be removed during the MicroWin process. This ensures that the necessary service remains intact, allowing applications that depend on it to function correctly.

## Testing
To test this fix, I performed the following steps:
1.  Applied the changes to `functions/microwin/Microwin-RemoveFeatures.ps1`.
2.  Ran `Compile.ps1` to build a new `winutil.ps1` script.
3.  Created a new MicroWin ISO using a fresh Windows 11 ISO.
4.  Installed the new MicroWin build in a virtual machine.
5.  Verified that the `WUDFsvc` service is present and set to "Manual" in the services panel (`services.msc`).
6.  Confirmed that Parsec no longer produces errors in its console and that performance has been restored to expected levels.

## Impact
This change has a positive impact on the usability of MicroWin builds for users who rely on applications that require the User-Mode Driver Framework. It prevents the system from being in a state where certain hardware-accelerated applications fail to work correctly. There are no new dependencies or negative performance impacts introduced by this change.

## Issue related to PR
- Resolves issue #3618 

## Additional Information
This fix ensures that the `tweaks.json` configuration, which correctly sets `wudfsvc` to "Manual", can be properly applied, as the service will no longer be removed before the tweaks are executed.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.