### PR TITLE
Allow Users to Bail Out on WinGet

### DIFF
--- a/functions/public/Invoke-WPFInstall.ps1
+++ b/functions/public/Invoke-WPFInstall.ps1
@@ -29,6 +29,7 @@ function Invoke-WPFInstall {
 
         $packagesWinget = $packagesSorted[[PackageManagers]::Winget]
         $packagesChoco = $packagesSorted[[PackageManagers]::Choco]
+        $wasProcessCancelled = $false
 
         try {
             $sync.ProcessRunning = $true
@@ -84,14 +85,25 @@ function Invoke-WPFInstall {
                                     }
                                 })
                                 $form.Controls.Add($button)
+                                $cancel =  = New-Object System.Windows.Forms.Button
+                                $cancel.Text = 'Cancel'
+                                $cancel.Size = New-Object System.Drawing.Size(75, 23)
+                                $cancel.Location = New-Object System.Drawing.Point(25, 125)
+                                $button.Add_Click({
+                                    $wasProcessCancelled = $true
+                                    break
+                                })
                                 $form.ShowDialog() | Out-Null
                             }
                         }
                 }
-
-                Show-WPFInstallAppBusy -text "Installing apps..."
-                Install-WinUtilWinget
-                Install-WinUtilProgramWinget -Action Install -Programs $packagesWinget
+                if($wasProcessCancelled) {
+                    Show-WPFInstallAppBusy -text "Skipping Winget Apps..."
+                }else{
+                    Show-WPFInstallAppBusy -text "Installing apps..."
+                    Install-WinUtilWinget
+                    Install-WinUtilProgramWinget -Action Install -Programs $packagesWinget
+                }
             }
             if($packagesChoco.Count -gt 0) {
                 Install-WinUtilChoco


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://christitustech.github.io/winutil/contribute/ -->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [x] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
If a process isn't going as a user expects, they should have the option to gracefully cancel it instead of the existing options of

* Set a Password
* Forcibly kill the WinUtil process

## Testing
In Progress, PR set as draft

## Impact
Resolves incidents [as seen in the discord](https://discord.com/channels/1258696348413329449/1258703953936515127/1425567500690657430
)

## Issue related to PR
See Above

## Additional Information
<!--[Any additional information that reviewers should be aware of.]-->

## Checklist
- [ ] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no errors/warnings/merge conflicts.
