### PR TITLE
Fix/epic games launcher version

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -517,7 +517,7 @@
         "content": "Epic Games Launcher",
         "description": "Epic Games Launcher is the client for accessing and playing games from the Epic Games Store.",
         "link": "https://www.epicgames.com/store/en-US/",
-        "winget": "EpicGames.EpicGamesLauncher"
+        "winget": "XP9D2F6P292W0T"
     },
     "esearch": {
         "category": "Utilities",


### PR DESCRIPTION
Type of Change
[ ] New feature

[x] Bug fix

[ ] Documentation update

[ ] Refactoring

[ ] Hotfix

[ ] Security patch

[ ] UI/UX improvement

Description
Updates the winget package ID for the Epic Games Launcher to resolve an installation issue on Windows 11.

The previous package ID (EpicGames.EpicGamesLauncher) installs a version from the Epic Games website that causes an "EOS-ERR-1603" error when users attempt to install online services.

This change replaces it with the Microsoft Store package ID (XP9D2F6P292W0T), which ensures the correct version is installed and allows online services to function properly.

Testing
Impact
This change will ensure that the correct version of the Epic Games Launcher is installed on Windows 11, which will allow users to install online services without any issues.

Issue related to PR:
Resolves #3194 

Additional Information
Checklist
[X] My code adheres to the coding and style guidelines of the project.

[X] I have performed a self-review of my own code.

[X] I have commented my code, particularly in hard-to-understand areas.

[ ] I have made corresponding changes to the documentation.

[X] My changes generate no errors/warnings/merge conflicts.