### PR TITLE
Fix Multiplane Overlay toggle

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -3690,7 +3690,7 @@
   },
 
   "WPFToggleMultiplaneOverlay": {
-    "Content": "Multiplane Overlay",
+    "Content": "Disable Multiplane Overlay",
     "Description": "Disable the Multiplane Overlay which can sometimes cause issues with Graphics Cards.",
     "category": "Customize Preferences",
     "panel": "2",
@@ -3702,7 +3702,7 @@
         "Name": "OverlayTestMode",
         "Value": "5",
         "OriginalValue": "<RemoveEntry>",
-        "DefaultState": "true",
+        "DefaultState": "false",
         "Type": "DWord"
       }
     ],


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://christitustech.github.io/winutil/contribute/ -->

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Right now the tool defaults to Multiplane Overlay disabled (toggle is on) when in fact this will cause an error if trying to toggle it (trying to remove the key) because Multiplane Overlay is not actually disabled (the key doesn't exist)

## Testing
Works as intended

## Impact
None that I can think of

## Issue related to PR
<!--[What issue/discussion is related to this PR (if any)]-->
- Resolves #

## Additional Information
Could either make the toggle "Disable Multiplane Overlay" or make it so the default state is on and swap the OriginalValue and Value around. That would also fix it.

Going by the current description of the toggle, this seems more appropriate.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
