### PR TITLE
Fix explanation logic in 'WPFToggleSnapFlyout'

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -3551,7 +3551,7 @@
   },
   "WPFToggleSnapFlyout": {
     "Content": "Snap Assist Flyout",
-    "Description": "If enabled then Snap preview is disabled when maximize button is hovered.",
+    "Description": "If disabled then Snap preview is disabled when maximize button is hovered.",
     "category": "Customize Preferences",
     "panel": "2",
     "Order": "a107_",


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://winutil.christitus.com/contributing/ -->

## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
<!--[Provide a detailed explanation of the changes you have made. Include the reasons behind these changes and any relevant context. Link any related issues.]-->
Fixing description of tweak. It was doing the opposite thing. Changed the first part, since default value is ENABLED, so telling what it does when disabled is more accurate

## Testing
<!--[Detail the testing you have performed to ensure that these changes function as intended. Include information about any added tests.]-->
It's just description change :^)

## Issue related to PR
<!--[What issue/discussion is related to this PR (if any)]-->
- Resolves #3647 

## Checklist
- [ ] My code adheres to the coding and style guidelines of the project.
- [X] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [X] My changes generate no errors/warnings/merge conflicts.
