### PR TITLE
Added Clouflare DNS as internal DNS for Edge

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -1625,6 +1625,27 @@
       },
       {
         "Path": "HKLM:\\SOFTWARE\\Policies\\Microsoft\\Edge",
+        "Name": "BuiltInDnsClientEnabled",
+        "Type": "DWord",
+        "Value": "1",
+        "OriginalValue": "<RemoveEntry>"
+      },
+      {
+        "Path": "HKLM:\\SOFTWARE\\Policies\\Microsoft\\Edge",
+        "Name": "DnsOverHttpsMode",
+        "Type": "String",
+        "Value": "secure"
+        // This setting forces secure DNS mode to be active.
+      },
+      {
+        "Path": "HKLM:\\SOFTWARE\\Policies\\Microsoft\\Edge",
+        "Name": "DnsOverHttpsTemplates",
+        "Type": "String",
+        "Value": "https://cloudflare-dns.com/dns-query"
+        // This enforces Cloudflare DNS, the fastest and can connnect to any website. Even the user system is not secured with a secure at least there browser should be secure
+      },
+      {
+        "Path": "HKLM:\\SOFTWARE\\Policies\\Microsoft\\Edge",
         "Name": "UserFeedbackAllowed",
         "Type": "DWord",
         "Value": "0",


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://winutil.christitus.com/contributing/ -->

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
<!--[Provide a detailed explanation of the changes you have made. Include the reasons behind these changes and any relevant context. Link any related issues.]-->
In the [`tweaks.json`](config/tweaks.json) file I have just added these 3 paragraph of codes
```
      {
        "Path": "HKLM:\\SOFTWARE\\Policies\\Microsoft\\Edge",
        "Name": "BuiltInDnsClientEnabled",
        "Type": "DWord",
        "Value": "1",
        "OriginalValue": "<RemoveEntry>"
      },
      {
        "Path": "HKLM:\\SOFTWARE\\Policies\\Microsoft\\Edge",
        "Name": "DnsOverHttpsMode",
        "Type": "String",
        "Value": "secure"
        // This setting forces secure DNS mode to be active.
      },
      {
        "Path": "HKLM:\\SOFTWARE\\Policies\\Microsoft\\Edge",
        "Name": "DnsOverHttpsTemplates",
        "Type": "String",
        "Value": "https://cloudflare-dns.com/dns-query"
        // This enforces Cloudflare DNS, the fastest and can connnect to any website. Even the user system is not secured with a secure at least there browser should be secure
      },
```

This is the only change made in the entire repository. And I have also added the comment of what these do.
It creates 3 Registry Key in the location `HKLM:\\SOFTWARE\\Policies\\Microsoft\\Edge`

| S. No. | Key | Type | Comment |
| :------------: | :------------: | :------------: | :------------ | 
| 1. |  BuiltInDnsClientEnabled | DWord | Tries to enable the DNS Client built in Edge |
| 2. | DnsOverHttpsMode | String | It enables the DoH mode in Edge |
| 3. | DnsOverHttpsTemplates | String | This is the backbone that provides the link to connect to Cloudflare DNS |

### Reason
When `Debloat Edge` option is executed. It also disable the option to use a **Use Secure DNS** option and display a line saying,**"It is managed by your organization"** and now in the browser you can't change DNS. Edge will use the default DNS settings from your system. But this poses a inconvenience.

Eg - I use NextDNS for my system wide DNS provider across all devices to block ads, phishing links, malware sites, etc. But some websites just doesn't open like Government Sites, School/College Websites, and other sites that don't utilize secure communication. Now to configure for every website is a hassle and time consuming task. So my solution is to add these new entries in to debloat category so that it uses **Cloudflare** as the DNS provider for just _Edge Browser_ so that these websites can open and run.

## Testing
<!--[Detail the testing you have performed to ensure that these changes function as intended. Include information about any added tests.]-->
<img width="1346" height="488" alt="Testing Works ✅" src="https://github.com/user-attachments/assets/63547d6d-6682-4810-8046-f7f1785990f4" />
The test has been performed on many PC in an repetition of 10 times to check the efficiency of the code. And every time it performs as expected.

## Impact
<!--[Discuss the impact of your changes on the project. This might include effects on performance, new dependencies, or changes in behavior.]-->
Rather than using the system wide DNS configurations it uses Cloudflare as DoH provider. Then many websites that uses Ads, Malware, phishing sites can also be reached. It is advised to use AdBlock extension or use [Brave Browser](https://brave.com/) 
<br>
It has one more effect and that every website will launch with the maximum speed the system hardware and network can achieve

## Issue related to PR
<!--[What issue/discussion is related to this PR (if any)]-->
- Resolves #

## Additional Information
<!--[Any additional information that reviewers should be aware of.]-->
I was unable to remove the bar saying. **"It is managed by your organization"** and in my testing I have found that any other entry on  `HKLM:\\SOFTWARE\\Policies\\Microsoft\\Edge` this location in the Registry other than the `Default` Key will result in that bar showing and it is designed such a way that it will disable the **Use Secure DNS** option. But if you wanna use other DNS provider here are the steps below

### Other DNS Provider
1. `Win` + `R`
2. Type `regedit`
3. Search and go to this location `HKLM:\\SOFTWARE\\Policies\\Microsoft\\Edge`
4. Click on `DnsOverHttpsTemplates` 
5. Remove the cloudflare link and enter the DoH link of your desired provider

### Use system DNS
Follow the steps of **Other DNS Provider** till step 3
Then delete the `DnsOverHttpsTemplates` 


## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no errors/warnings/merge conflicts.
