### PR TITLE
Fixes to Invoke-WinUtilCurrentSystem function that gets installed tweaks does not handle <RemoveEntry> value

### DIFF
--- a/functions/private/Invoke-WinUtilCurrentSystem.ps1
+++ b/functions/private/Invoke-WinUtilCurrentSystem.ps1
@@ -64,7 +64,11 @@ Function Invoke-WinUtilCurrentSystem {
                         if(test-path $tweak.Path) {
                             $actualValue = Get-ItemProperty -Name $tweak.Name -Path $tweak.Path -ErrorAction SilentlyContinue | Select-Object -ExpandProperty $($tweak.Name)
                             $expectedValue = $tweak.Value
-                            if ($expectedValue -notlike $actualValue) {
+                            if ($expectedValue -eq "<RemoveEntry>") {
+                              if ($null -ne $actualValue) {
+                                $values += $False
+                              }
+                            } elseif ($expectedValue -notlike $actualValue) {
                                 $values += $False
                             }
                         } else {


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://winutil.christitus.com/contributing/ -->

## Type of Change
- [ ] New feature
- [*] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
There is no tweak that removes registry value but they are added later this resolves the issue 

## Issue related to PR

## Checklist
- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no errors/warnings/merge conflicts.
