### PR TITLE
[Fix] Force WinGet source

### DIFF
--- a/functions/private/Install-WinUtilProgramWinget.ps1
+++ b/functions/private/Install-WinUtilProgramWinget.ps1
@@ -41,7 +41,7 @@ Function Install-WinUtilProgramWinget {
         $arguments = if ($Action -eq "Install") {
             "install $commonArguments --accept-source-agreements --accept-package-agreements --source winget"
         } else {
-            "uninstall $commonArguments"
+            "uninstall $commonArguments --source winget"
         }
 
         $processParams = @{


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://winutil.christitus.com/contributing/ -->

## Type of Change
- [X] Bug fix

## Description
This PR fixes issues regarding WinGet app installation when it can't fetch the msstore source. This forces it to search the winget source.

It is still a draft as there may be more areas in which we need to specify the source.

## Issue related to PR
- Resolves all app installation issues caused by that error

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no errors/warnings/merge conflicts.
