### PR TITLE
Fix Get Installed toggle detection (#3762)

### DIFF
--- a/functions/private/Get-WinUtilToggleStatus.ps1
+++ b/functions/private/Get-WinUtilToggleStatus.ps1
@@ -45,7 +45,7 @@ Function Get-WinUtilToggleStatus {
                 } else {
                     Write-Debug "$($regentry.Name) is false (state: $regstate, value: $($regentry.Value), original: $($regentry.OriginalValue))"
                 }
-                if (!$regstate) {
+                if ($null -eq $regstate) {
                     switch ($regentry.DefaultState) {
                         "true" {
                             $regstate = $regentry.Value


### PR DESCRIPTION
## Summary

Fixes the issue where "Get Installed" in the Tweaks tab was not correctly pulling all toggle states, as reported in #3762.

The root cause was a logic mismatch between how the UI initializes toggle states versus how "Get Installed" detects applied tweaks.

## Changes

### 1. **Unified Toggle Detection Logic**
- `Invoke-WinUtilCurrentSystem` now uses `Get-WinUtilToggleStatus` for `Type: "Toggle"` tweaks
- This ensures "Get Installed" uses the same logic as UI initialization, eliminating inconsistencies

### 2. **Fixed Registry Value Detection**
- **Critical Bug Fix**: Changed null checks from `if(!$regstate)` to `if($null -eq $regstate)` in both:
  - `functions/private/Invoke-WinUtilCurrentSystem.ps1`
  - `functions/private/Get-WinUtilToggleStatus.ps1`
- Previously, registry values of `0` were incorrectly treated as missing because `0` is falsy in PowerShell
- Now correctly distinguishes between missing keys and legitimate `0` values

### 3. **Added DefaultState Support**
- Registry detection now properly handles `DefaultState` for tweaks with missing registry keys
- Matches the behavior already present in `Get-WinUtilToggleStatus`

### 4. **Non-Detectable Tweaks Handling**
- Added debug logging for tweaks with only `InvokeScript` or `appx` entries
- These tweaks are skipped (as there's no deterministic way to detect their state)

## Technical Details

**Before:**
```powershell
if(test-path $tweak.Path) {
    $actualValue = Get-ItemProperty ...
    if ($expectedValue -notlike $actualValue) {
        $values += $False
    }
} else {
    $values += $False  // Missing = not applied
}
```

**After:**
```powershell
if($entryType -eq "Toggle") {
    if(-not (Get-WinUtilToggleStatus $Config)) {
        $values += $False
    }
} else {
    // Count matches with DefaultState support
    if($null -eq $regstate) {
        switch ($tweak.DefaultState) {
            "true" { $regstate = $tweak.Value }
            "false" { $regstate = $tweak.OriginalValue }
            default { $regstate = $tweak.OriginalValue }
        }
    }
}
```

## Testing

### Manual Verification Steps:
1. Open Tweaks tab and note initial toggle states (especially those with `DefaultState`)
2. Click "Get Installed"
3. Verify toggle states remain consistent and accurate
4. Test with tweaks that have registry values of `0` (e.g., dark mode toggles)

### Files Changed:
- `functions/private/Invoke-WinUtilCurrentSystem.ps1` (+45/-13)
- `functions/private/Get-WinUtilToggleStatus.ps1` (+1/-1)

## Impact

- ✅ Fixes toggle state detection inconsistency
- ✅ Resolves issue with `0` values being treated as missing
- ✅ Makes "Get Installed" behavior match UI initialization
- ✅ No breaking changes - purely additive/corrective logic

Closes #3762