### PR TITLE
chore: Update outdated GitHub Actions version

### DIFF
--- a/.github/workflows/close-old-issues.yaml
+++ b/.github/workflows/close-old-issues.yaml
@@ -14,7 +14,7 @@ jobs:
       contents: none
     steps:
     - name: Close inactive issues
-      uses: actions/stale@v8
+      uses: actions/stale@v10
       with:
         # A list of labels to reference when looking through issues,
         # and only when one (or even more) of these labels are found..


### PR DESCRIPTION
## Type of Change
- [x] CI

## Description
- Updated the `actions/stale` action from version `v8` to `v10` in the `close-old-issues.yaml` workflow file to align with the latest version requirements.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.