### PR TITLE
Unify file calls to global winutildir variable

### DIFF
--- a/functions/private/Invoke-WinutilThemeChange.ps1
+++ b/functions/private/Invoke-WinutilThemeChange.ps1
@@ -129,8 +129,8 @@ function Invoke-WinutilThemeChange {
         }
     }
 
-    $LightPreferencePath = "$env:LOCALAPPDATA\winutil\LightTheme.ini"
-    $DarkPreferencePath = "$env:LOCALAPPDATA\winutil\DarkTheme.ini"
+    $LightPreferencePath = "$winutildir\LightTheme.ini"
+    $DarkPreferencePath = "$winutildir\DarkTheme.ini"
 
     if ($init) {
         Set-WinutilTheme -currentTheme "shared"

--- a/functions/private/Set-PackageManagerPreference.ps1
+++ b/functions/private/Set-PackageManagerPreference.ps1
@@ -14,8 +14,8 @@ function Set-PackageManagerPreference {
         [PackageManagers]$preferredPackageManager
     )
 
-    $preferencePath = "$env:LOCALAPPDATA\winutil\preferences.ini"
-    $oldChocoPath = "$env:LOCALAPPDATA\winutil\preferChocolatey.ini"
+    $preferencePath = "$winutildir\preferences.ini"
+    $oldChocoPath = "$winutildir\preferChocolatey.ini"
 
     #Try loading from file if no argument given.
     if ($null -eq $preferredPackageManager) {

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -425,12 +425,6 @@ $sync["Form"].Add_Loaded({
 $NavLogoPanel = $sync["Form"].FindName("NavLogoPanel")
 $NavLogoPanel.Children.Add((Invoke-WinUtilAssets -Type "logo" -Size 25)) | Out-Null
 
-# Initialize the hashtable
-$winutildir = @{}
-
-# Set the path for the winutil directory
-$winutildir = "$env:LocalAppData\winutil\"
-New-Item $winutildir -ItemType Directory -Force | Out-Null
 
 if (Test-Path "$winutildir\logo.ico") {
     $sync["logorender"] = "$winutildir\logo.ico"

--- a/scripts/start.ps1
+++ b/scripts/start.ps1
@@ -79,7 +79,11 @@ if (!([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]:
 
 $dateTime = Get-Date -Format "yyyy-MM-dd_HH-mm-ss"
 
-$logdir = "$env:localappdata\winutil\logs"
+# Set the path for the winutil directory
+$winutildir = "$env:LocalAppData\winutil"
+New-Item $winutildir -ItemType Directory -Force | Out-Null
+
+$logdir = "$winutildir\logs"
 New-Item $logdir -ItemType Directory -Force | Out-Null
 Start-Transcript -Path "$logdir\winutil_$dateTime.log" -Append -NoClobber | Out-Null
 


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://winutil.christitus.com/contributing/ -->

## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Hotfix
- [ ] UI/UX improvement

<!-- This automatically adds labels to your PR based on the selections above. -->

## Description
Instead of calling `env:LOCALAPPDATA\winutil` in multiple places, use the already written `$winutildir`. Moved to `start.ps1` so it is global and initialized early.


## Issue related to PR
<!--[What issue/discussion is related to this PR (if any)]-->
- Resolves #

## Checklist
- [X] My code adheres to the coding and style guidelines of the project.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
