### PR TITLE
Add FilePilot application entry

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -3242,7 +3242,7 @@
         "description": "FilePilot is a modern, fast file explorer for Windows with tabs, dual-pane, and advanced file management. Can be set as the default Windows Explorer replacement.",
         "link": "https://filepilot.tech/",
         "winget": "Voidstar.FilePilot"
-    }
+    },
     "LLLVM": {
         "category": "Development",
         "choco": "llvm",


### PR DESCRIPTION
Adds FilePilot to the application installer list under the Utilities category.

FilePilot is a modern Windows file explorer with tabs, dual-pane support, 
and advanced file management features. It can be set as a Windows Explorer 
replacement after install.

## Type of Change
- Installs via winget (Voidstar.FilePilot)
- No Chocolatey package available (choco field left empty)

![Capture](https://github.com/user-attachments/assets/d629f608-a498-49d9-a0db-a68d438cc923)
