### PR TITLE
Re-add debug to start.ps1

### DIFF
--- a/scripts/start.ps1
+++ b/scripts/start.ps1
@@ -7,10 +7,16 @@
 #>
 
 param (
+    [switch]$Debug,
     [string]$Config,
     [switch]$Run,
     [switch]$Noui
 )
+
+# Set DebugPreference based on the -Debug switch
+if ($Debug) {
+    $DebugPreference = "Continue"
+}
 
 if ($Config) {
     $PARAM_CONFIG = $Config


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://winutil.christitus.com/contributing/ -->

## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] UI/UX improvement

<!-- This automatically adds labels to your PR based on the selections above. -->

## Description
<!--[What does this PR do? Provide Screenshots when possible.]-->
There are 77 `Write-Debug` statements in winutil that `-debug` is needed to see. 

Trying to run winutil.ps1 with a debugger only works if the user is logged in to Administrator. Otherwise the debugger does not attach due to a new process getting started.

Also debug statements are good for the multi-threaded nature of runspaces.

## Issue related to PR
<!--[List any ISSUES this is related to as it AUTO-CLOSES Them!]-->
