### PR TITLE
Fix mount disk error

### DIFF
--- a/functions/private/Invoke-WinUtilISO.ps1
+++ b/functions/private/Invoke-WinUtilISO.ps1
@@ -51,23 +51,11 @@ function Invoke-WinUtilISOMountAndVerify {
     try {
         Mount-DiskImage -ImagePath $isoPath -ErrorAction Stop | Out-Null
 
-        # Mount-DiskImage returns before Windows assigns a drive letter; retry until available.
-        $volume = $null
-        1..10 | ForEach-Object {
-            $v = Get-DiskImage -ImagePath $isoPath | Get-Volume
-            if ($v.DriveLetter) { $volume = $v; return }
+        do {
             Start-Sleep -Milliseconds 500
-        }
+        } until ((Get-DiskImage -ImagePath $isoPath | Get-Volume).DriveLetter)
 
-        if (-not $volume.DriveLetter) {
-            Dismount-DiskImage -ImagePath $isoPath | Out-Null
-            Write-Win11ISOLog "ERROR: Could not determine the mounted drive letter."
-            [System.Windows.MessageBox]::Show("The ISO was mounted but Windows did not assign a drive letter.`n`nPlease try again.", "Mount Failed", "OK", "Error")
-            Set-WinUtilProgressBar -Label "" -Percent 0
-            return
-        }
-
-        $driveLetter = $volume.DriveLetter + ":"
+        $driveLetter = (Get-DiskImage -ImagePath $isoPath | Get-Volume).DriveLetter + ":"
         Write-Win11ISOLog "Mounted at drive $driveLetter"
 
         Set-WinUtilProgressBar -Label "Verifying ISO contents..." -Percent 30


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://winutil.christitus.com/contributing/ -->

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] UI/UX improvement

<!-- This automatically adds labels to your PR based on the selections above. -->

## Description
<!--[What does this PR do? Provide Screenshots when possible.]-->
On some systems when creating the Win11 ISO it will fail during the Mount & Verify phase. This is because it tries to use the ISO Drive letter before mounting is complete. Common issue with low end systems.

## Issue related to PR
<!--[List any ISSUES this is related to as it AUTO-CLOSES Them!]-->
- Resolves #
