### PR TITLE
Add Ruby and Lua entries

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -3347,24 +3347,6 @@
         "winget": "xM4ddy.OFGB",
         "foss": true
     },
-    "Opera": {
-        "category": "Browsers",
-        "choco": "opera",
-        "content": "Opera",
-        "description": "The Opera browser includes everything you need for private, safe, and efficient browsing, along with a variety of unique features to enhance your capabilities online.",
-        "link": "https://www.opera.com",
-        "winget": "Opera.Opera",
-        "foss": false
-    },
-    "OperaGX": {
-        "category": "Browsers",
-        "choco": "opera-gx",
-        "content": "Opera GX",
-        "description": "Opera GX is a special version of the Opera browser which, on top of Opera’s great features for privacy, security and efficiency, includes special features designed to complement gaming.",
-        "link": "https://www.opera.com/gx",
-        "winget": "Opera.OperaGX",
-        "foss": false
-    },
     "PaleMoon": {
         "category": "Browsers",
         "choco": "paleMoon",


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://winutil.christitus.com/contributing/ -->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [x] UI/UX improvement

<!-- This automatically adds labels to your PR based on the selections above. -->

## Description
Update applications.json to include two development runtime entries (Ruby, Lua). These are apps I’ve wanted on Winutil for a while, so I thought I’d add them for anyone who might find them useful.