### PR TITLE
Removing Borderless Gaming and updating UnigetUI

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -2944,8 +2944,8 @@
         "choco": "wingetui",
         "content": "UniGetUI",
         "description": "UniGetUI is a GUI for WinGet, Chocolatey, and other Windows CLI package managers.",
-        "link": "https://www.marticliment.com/wingetui/",
-        "winget": "MartiCliment.UniGetUI",
+        "link": "https://devolutions.net/unigetui/",
+        "winget": "Devolutions.UniGetUI",
         "foss": true
     },
     "winmerge": {


### PR DESCRIPTION
## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] UI/UX improvement


## Description
Remove Borderless gaming due to owner making BG paid only via steam, so this PR just removes BG from applications.json

EDIT: I have also updated UniGetUI winget and link, official statement from https://www.marticliment.com/wingetui/ says:
"From now on, [Devolutions Inc](https://devolutions.net/) will be in charge of developing and maintaining UniGetUI.

Therefore, this web site is not UniGetUI's official web site anymore. You can check out UniGetUI's new official web site on https://devolutions.net/unigetui"
