### PR TITLE
Removed WaaSMedicSvc from Invoke-WPFUpdatesdisable.ps1

### DIFF
--- a/functions/public/Invoke-WPFUpdatesdisable.ps1
+++ b/functions/public/Invoke-WPFUpdatesdisable.ps1
@@ -28,9 +28,6 @@ function Invoke-WPFUpdatesdisable {
     Write-Host "Disabled UsoSvc Service"
     Set-Service -Name UsoSvc -StartupType Disabled
 
-    Write-Host "Disabled WaaSMedicSvc Service"
-    Set-Service -Name WaaSMedicSvc -StartupType Disabled
-
     Remove-Item "C:\Windows\SoftwareDistribution\*" -Recurse -Force
     Write-Host "Cleared SoftwareDistribution folder"
 


### PR DESCRIPTION
## Description
<!--[What does this PR do? Provide Screenshots when possible.]-->
We can't even change `WaaSMedicSvc`
```powershell
PowerShell 7.6.0
PS C:\Users\User> Set-Service -Name WaaSMedicSvc -StartupType Disabled
Set-Service: Service 'WaaSMedicSvc (WaaSMedicSvc)' cannot be configured due to the following error: Access is denied.
PS C:\Users\User>
```
