### PR TITLE
add disable Admin Approval Mode in advanced tweaks

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -2725,5 +2725,22 @@
       }
     ],
     "link": "https://winutil.christitus.com/dev/tweaks/customize-preferences/disablecrossdeviceresume"
+  },
+
+  "WPFTweaksDisableUAC": {
+    "Content": "Disable UAC (Admin Approval Mode)",
+    "Description": "Disables User Account Control (UAC) for all administrators. This automatically runs tasks (like the Win+R Run dialog) with full administrative privileges.[requires restarting Windows] CAUTION: This removes a major security layer and is known to break Microsoft Store apps and built-in Windows features.",
+    "category": "z__Advanced Tweaks - CAUTION",
+    "panel": "1",
+    "registry": [
+      {
+        "Path": "HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System",
+        "Name": "EnableLUA",
+        "Value": "0",
+        "Type": "DWord",
+        "OriginalValue": "1"
+      }
+    ],
+    "link": "https://winutil.christitus.com/dev/tweaks/z--advanced-tweaks---caution/disableuac"
   }
 }


### PR DESCRIPTION
- [x] New feature
Sets a registry value to 0 to give admin privileges to multiple apps (primarily useful for the Windows Run dialog). Also adds a reference link similar to previous examples in the file.
<img width="329" height="184" alt="Screenshot 2026-03-28 122306" src="https://github.com/user-attachments/assets/5aefdbe3-1f70-4a8b-a630-ffbf93df7568" />
<img width="397" height="226" alt="Screenshot 2026-03-28 120905" src="https://github.com/user-attachments/assets/29da86b6-6b04-4fb1-a80b-49d5b5eff994" />
