### PR TITLE
Add WPFToggleScrollbars tweak to Always show scrollbars

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -2299,6 +2299,24 @@
     ],
     "link": "https://winutil.christitus.com/dev/tweaks/customize-preferences/stickykeys"
   },
+  "WPFToggleScrollbars": {
+    "Content": "Always Show Scrollbars",
+    "Description": "If enabled, scrollbars will always be visible. If disabled, Windows will automatically hide scrollbars when not in use.",
+    "category": "Customize Preferences",
+    "panel": "2",
+    "Type": "Toggle",
+    "registry": [
+      {
+        "Path": "HKCU:\\Control Panel\\Accessibility",
+        "Name": "DynamicScrollbars",
+        "Value": "0",
+        "Type": "DWord",
+        "OriginalValue": "1",
+        "DefaultState": "false"
+      }
+    ],
+    "link": "https://winutil.christitus.com/dev/tweaks/customize-preferences/scrollbars"
+  },
   "WPFToggleNewOutlook": {
     "Content": "New Outlook",
     "Description": "If disabled, it removes the new Outlook toggle, disables the new Outlook migration, and ensures the classic Outlook application is used.",


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://winutil.christitus.com/contributing/ -->

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] UI/UX improvement

## Description
Adds a new toggle "Always Show Scrollbars" under the Customize Preferences panel. When enabled, sets DynamicScrollbars to 0 in HKCU:\Control Panel\Accessibility, preventing Windows from auto-hiding scrollbars. Useful especially when you're tired of searching for the scrollbar, when the page/window have a lot of data or is a long document. Speeds up things (at least for me). Also adds some oldschool look, if you like and are dinosaur

<img width="765" height="547" alt="sb1" src="https://github.com/user-attachments/assets/6ccaaaba-25c3-43ef-bc07-4757d333c6c5" />

<img width="1028" height="144" alt="sb2" src="https://github.com/user-attachments/assets/38e93a5d-9d43-420f-b2ee-57a930a41642" />


## Issue related to PR
- Resolves #
