### PR TITLE
Removed onedrivesetup removal from Invoke-WinUtilISOScript.ps1

### DIFF
--- a/functions/private/Invoke-WinUtilISOScript.ps1
+++ b/functions/private/Invoke-WinUtilISOScript.ps1
@@ -169,13 +169,7 @@ function Invoke-WinUtilISOScript {
         & $Log "Driver injection skipped."
     }
 
-    # ── 3. Remove OneDrive ────────────────────────────────────────────────────
-    & $Log "Removing OneDrive..."
-    & takeown /f "$ScratchDir\Windows\System32\OneDriveSetup.exe" | Out-Null
-    & icacls    "$ScratchDir\Windows\System32\OneDriveSetup.exe" /grant "$($adminGroup.Value):(F)" /T /C | Out-Null
-    Remove-Item -Path "$ScratchDir\Windows\System32\OneDriveSetup.exe" -Force -ErrorAction SilentlyContinue
-
-    # ── 4. Registry tweaks ────────────────────────────────────────────────────
+    # ── 3. Registry tweaks ────────────────────────────────────────────────────
     & $Log "Loading offline registry hives..."
     reg load HKLM\zCOMPONENTS "$ScratchDir\Windows\System32\config\COMPONENTS"
     reg load HKLM\zDEFAULT    "$ScratchDir\Windows\System32\config\default"
@@ -329,7 +323,7 @@ function Invoke-WinUtilISOScript {
     reg unload HKLM\zSOFTWARE
     reg unload HKLM\zSYSTEM
 
-    # ── 5. Delete scheduled task definition files ─────────────────────────────
+    # ── 4. Delete scheduled task definition files ─────────────────────────────
     & $Log "Deleting scheduled task definition files..."
     $tasksPath = "$ScratchDir\Windows\System32\Tasks"
     Remove-Item "$tasksPath\Microsoft\Windows\Application Experience\Microsoft Compatibility Appraiser" -Force -ErrorAction SilentlyContinue
@@ -345,7 +339,7 @@ function Invoke-WinUtilISOScript {
     Remove-Item "$tasksPath\Microsoft\WindowsUpdate"                                                   -Recurse -Force -ErrorAction SilentlyContinue
     & $Log "Scheduled task files deleted."
 
-    # ── 6. Remove ISO support folder ─────────────────────────────────────────
+    # ── 5. Remove ISO support folder ─────────────────────────────────────────
     if ($ISOContentsDir -and (Test-Path $ISOContentsDir)) {
         & $Log "Removing ISO support\ folder..."
         Remove-Item -Path (Join-Path $ISOContentsDir "support") -Recurse -Force -ErrorAction SilentlyContinue

--- a/tools/autounattend.xml
+++ b/tools/autounattend.xml
@@ -460,6 +460,9 @@ $scripts = @(
         Remove-Item -Path $viveDir -Recurse -Force;
     };
     {
+        Start-Process C:\Windows\System32\OneDriveSetup.exe -ArgumentList /uninstall
+    };
+    {
         if( (Get-BitLockerVolume -MountPoint $Env:SystemDrive).ProtectionStatus -eq 'On' ) {
             Disable-BitLocker -MountPoint $Env:SystemDrive;
         }


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://winutil.christitus.com/contributing/ -->

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] UI/UX improvement

<!-- This automatically adds labels to your PR based on the selections above. -->

## Description
<!--[What does this PR do? Provide Screenshots when possible.]-->
If you remove OneDriveSetup.exe before setup than essential services for onedrive dont get installed and even if you reinstall onedrive it will still not function

so to fix this i made it remove onedrive after first login
## Issue related to PR
<!--[List any ISSUES this is related to as it AUTO-CLOSES Them!]-->
- Resolves #4354
