### PR TITLE
Remove Xtreme Download Manager from applications.json

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -3070,15 +3070,6 @@
         "link": "https://wiztreefree.com/",
         "winget": "AntibodySoftware.WizTree"
     },
-    "xdm": {
-        "category": "Utilities",
-        "choco": "xdm",
-        "content": "Xtreme Download Manager",
-        "description": "Xtreme Download Manager is an advanced download manager with support for various protocols and browsers. *Browser integration deprecated by google store. No official release.*",
-        "link": "https://xtremedownloadmanager.com/",
-        "winget": "subhra74.XtremeDownloadManager",
-        "foss": true
-    },
     "xeheditor": {
         "category": "Utilities",
         "choco": "HxD",


### PR DESCRIPTION
Removed Xtreme Download Manager.

It hasn't been updated in almost 6 years and most likely won't get any updates anymore.

