### PR TITLE
Update `Invoke-WinUtilRemoveEdge.ps1`

### DIFF
--- a/functions/public/Invoke-WinUtilRemoveEdge.ps1
+++ b/functions/public/Invoke-WinUtilRemoveEdge.ps1
@@ -1,7 +1,7 @@
 function Invoke-WinUtilRemoveEdge {
   New-Item -Path "$Env:SystemRoot\SystemApps\Microsoft.MicrosoftEdge_8wekyb3d8bbwe\MicrosoftEdge.exe" -Force
 
-  $Path = Resolve-Path -Path "$Env:ProgramFiles (x86)\Microsoft\Edge\Application\*\Installer\setup.exe" | Select-Object -First 1
+  $Path = Resolve-Path -Path "$Env:ProgramFiles (x86)\Microsoft\Edge\Application\*\Installer\setup.exe" | Select-Object -Last 1
   Start-Process -FilePath $Path -ArgumentList '--uninstall --system-level --force-uninstall --delete-profile' -Wait
 
   Write-Host "Microsoft Edge was removed" -ForegroundColor Green

--- a/functions/public/Invoke-WinUtilRemoveEdge.ps1
+++ b/functions/public/Invoke-WinUtilRemoveEdge.ps1
@@ -1,7 +1,7 @@
 function Invoke-WinUtilRemoveEdge {
-  $Path = Get-ChildItem -Path "$Env:ProgramFiles (x86)\Microsoft\Edge\Application\*\Installer\setup.exe" | Select-Object -First 1
-
   New-Item -Path "$Env:SystemRoot\SystemApps\Microsoft.MicrosoftEdge_8wekyb3d8bbwe\MicrosoftEdge.exe" -Force
+
+  $Path = Resolve-Path -Path "$Env:ProgramFiles (x86)\Microsoft\Edge\Application\*\Installer\setup.exe"
   Start-Process -FilePath $Path -ArgumentList '--uninstall --system-level --force-uninstall --delete-profile' -Wait
 
   Write-Host "Microsoft Edge was removed" -ForegroundColor Green

--- a/functions/public/Invoke-WinUtilRemoveEdge.ps1
+++ b/functions/public/Invoke-WinUtilRemoveEdge.ps1
@@ -1,7 +1,7 @@
 function Invoke-WinUtilRemoveEdge {
   New-Item -Path "$Env:SystemRoot\SystemApps\Microsoft.MicrosoftEdge_8wekyb3d8bbwe\MicrosoftEdge.exe" -Force
 
-  $Path = Resolve-Path -Path "$Env:ProgramFiles (x86)\Microsoft\Edge\Application\*\Installer\setup.exe"
+  $Path = Resolve-Path -Path "$Env:ProgramFiles (x86)\Microsoft\Edge\Application\*\Installer\setup.exe" | Select-Object -First 1
   Start-Process -FilePath $Path -ArgumentList '--uninstall --system-level --force-uninstall --delete-profile' -Wait
 
   Write-Host "Microsoft Edge was removed" -ForegroundColor Green


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://winutil.christitus.com/contributing/ -->

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] UI/UX improvement

## Description
Replace `Get-ChildItem` with `Resolve-Path` for resolving installer paths. Improves performance and consistency when expanding wildcard paths.

Update selection logic from `-First` to `-Last` to ensure latest version is chosen instead of earliest match.

Example:
```ps1
Resolve-Path -Path "C:\Program Files (x86)\Microsoft\Edge\Application\*\Installer\setup.exe" | Select-Object -First 1

Path
----
C:\Program Files (x86)\Microsoft\Edge\Application\145.0.3800.97\Installer\setup.exe


Resolve-Path -Path "C:\Program Files (x86)\Microsoft\Edge\Application\*\Installer\setup.exe" | Select-Object -Last 1

Path
----
C:\Program Files (x86)\Microsoft\Edge\Application\147.0.3912.60\Installer\setup.exe
```

Result: latest installed version reliably selected.

## Issue related to PR
- Resolves #

do you prefer my slop description or my barely readable man made description?