### PR TITLE
[Adding again] Add WPFToggleScrollbars tweak to Always show scrollbars

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -1391,6 +1391,24 @@
     ],
     "link": "https://winutil.christitus.com/dev/tweaks/customize-preferences/newoutlook"
   },
+    "WPFToggleScrollbars": {
+    "Content": "Always Show Scrollbars",
+    "Description": "If enabled, scrollbars will always be visible. If disabled, Windows will automatically hide scrollbars when not in use.",
+    "category": "Customize Preferences",
+    "panel": "2",
+    "Type": "Toggle",
+    "registry": [
+      {
+        "Path": "HKCU:\\Control Panel\\Accessibility",
+        "Name": "DynamicScrollbars",
+        "Value": "0",
+        "Type": "DWord",
+        "OriginalValue": "1",
+        "DefaultState": "false"
+      }
+    ],
+    "link": "https://winutil.christitus.com/dev/tweaks/customize-preferences/scrollbars"
+  },
   "WPFToggleMultiplaneOverlay": {
     "Content": "Multiplane Overlay",
     "Description": "Enable or disable the Multiplane Overlay, which can sometimes cause issues with graphics cards.",


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://winutil.christitus.com/contributing/ -->

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] UI/UX improvement


## Description

**Added again as it was closed due to errors**

Adds a new toggle "Always Show Scrollbars" under the Customize Preferences panel. When enabled, sets DynamicScrollbars to 0 in HKCU:\Control Panel\Accessibility, preventing Windows from auto-hiding scrollbars. Useful especially when you're tired of searching for the scrollbar, when the page/window have a lot of data or is a long document. Speeds up things (at least for me). Also adds some oldschool look, if you like and are dinosaur