### PR TITLE
Added OfficeToolPlus to Utilities in the app list

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -1960,6 +1960,15 @@
         "winget": "Obsidian.Obsidian",
         "foss": false
     },
+    "OfficeToolPlus": {
+        "category": "Utilities",
+        "choco": "na",
+        "winget": "Yerong.OfficeToolPlus",
+        "description": "Installs specific Office apps. Office Tool Plus is made based on Microsoft Office Deployment Tool",
+        "content": "Office Tool Plus",
+        "link": "https://otp.landian.vip/en-us/",
+        "foss": true
+    },
     "okular": {
         "category": "Document",
         "choco": "okular",

--- a/config/applications.json
+++ b/config/applications.json
@@ -1964,7 +1964,7 @@
         "category": "Utilities",
         "choco": "na",
         "winget": "Yerong.OfficeToolPlus",
-        "description": "Installs specific Office apps. Office Tool Plus is made based on Microsoft Office Deployment Tool",
+        "description": "Installs specific Office apps. Office Tool Plus is made based on Microsoft Office Deployment Tool.",
         "content": "Office Tool Plus",
         "link": "https://otp.landian.vip/en-us/",
         "foss": true


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://winutil.christitus.com/contributing/ -->

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] UI/UX improvement

<!-- This automatically adds labels to your PR based on the selections above. -->

## Description
There is a bug in the current winget pkg. Once a new update is done, will reopen PR.

Adds Office Tool Plus to the App List.
Installs specific apps from the Microsoft Office suite. Office Tool Plus is made based on Microsoft Office Deployment Tool.
Also modify Office configuration.
eg. For Office 365, only apps which are needed can be selected and installed. Word, Excel, PPT can be installed without OneDrive, Sticky Notes and One Note.

This app has 3 links :
Landing Page - https://otp.landian.vip/en-us/
Github - https://github.com/YerongAI/Office-Tool
Docs - https://www.officetool.plus/introduction/what-is-otp.html

## Issue related to PR
<!--[List any ISSUES this is related to as it AUTO-CLOSES Them!]-->
- Resolves #
