### PR TITLE
Update Invoke-WPFUltimatePerformance.ps1

### DIFF
--- a/functions/public/Invoke-WPFUltimatePerformance.ps1
+++ b/functions/public/Invoke-WPFUltimatePerformance.ps1
@@ -6,10 +6,10 @@ function Invoke-WPFUltimatePerformance {
     if ($Do) {
         powercfg /restoredefaultschemes
         powercfg /setactive e9a42b02-d5df-448d-aa00-03f14749eb61
-        Write-Host "Ultimate Power Plan plan installed and activated." -ForegroundColor Green
+        [System.Windows.MessageBox]::Show("Ultimate Power Plan installed and activated.")
     } else {
         powercfg /setactive SCHEME_BALANCED
         powercfg /delete e9a42b02-d5df-448d-aa00-03f14749eb61
-        Write-Host "Ultimate Power Plan plan was removed." -ForegroundColor Red
+        [System.Windows.MessageBox]::Show("Ultimate Power Plan plan was removed.")
     }
 }

--- a/functions/public/Invoke-WPFUltimatePerformance.ps1
+++ b/functions/public/Invoke-WPFUltimatePerformance.ps1
@@ -4,32 +4,11 @@ function Invoke-WPFUltimatePerformance {
     )
 
     if ($Do) {
-        if (-not (powercfg /list | Select-String "ChrisTitus - Ultimate Power Plan")) {
-            if (-not (powercfg /list | Select-String "8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c")) {
-                powercfg /restoredefaultschemes
-                if (-not (powercfg /list | Select-String "8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c")) {
-                    Write-Host "Failed to restore High Performance plan. Default plans do not include high performance. If you are on a laptop, do NOT use High Performance or Ultimate Performance plans." -ForegroundColor Red
-                    return
-                }
-            }
-            $guid = ((powercfg /duplicatescheme 8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c) -split '\s+')[3]
-            powercfg /changename $guid "ChrisTitus - Ultimate Power Plan"
-            powercfg /setacvalueindex $guid SUB_PROCESSOR IDLEDISABLE 1
-            powercfg /setacvalueindex $guid 54533251-82be-4824-96c1-47b60b740d00 4d2b0152-7d5c-498b-88e2-34345392a2c5 1
-            powercfg /setacvalueindex $guid SUB_PROCESSOR PROCTHROTTLEMIN 100
-            powercfg /setactive $guid
-            Write-Host "ChrisTitus - Ultimate Power Plan plan installed and activated." -ForegroundColor Green
-        } else {
-            Write-Host "ChrisTitus - Ultimate Power Plan plan is already installed." -ForegroundColor Red
-            return
-        }
+        powercfg /restoredefaultschemes
+        powercfg /setactive e9a42b02-d5df-448d-aa00-03f14749eb61
+        Write-Host "Ultimate Power Plan plan installed and activated." -ForegroundColor Green
     } else {
-        if (powercfg /list | Select-String "ChrisTitus - Ultimate Power Plan") {
-            powercfg /setactive SCHEME_BALANCED
-            powercfg /delete ((powercfg /list | Select-String "ChrisTitus - Ultimate Power Plan").ToString().Split()[3])
-            Write-Host "ChrisTitus - Ultimate Power Plan plan was removed." -ForegroundColor Red
-        } else {
-            Write-Host "ChrisTitus - Ultimate Power Plan plan is not installed." -ForegroundColor Yellow
-        }
+        powercfg /setactive SCHEME_BALANCED
+        Write-Host "Ultimate Power Plan plan was removed." -ForegroundColor Red
     }
 }

--- a/functions/public/Invoke-WPFUltimatePerformance.ps1
+++ b/functions/public/Invoke-WPFUltimatePerformance.ps1
@@ -9,6 +9,7 @@ function Invoke-WPFUltimatePerformance {
         Write-Host "Ultimate Power Plan plan installed and activated." -ForegroundColor Green
     } else {
         powercfg /setactive SCHEME_BALANCED
+        powercfg /delete e9a42b02-d5df-448d-aa00-03f14749eb61
         Write-Host "Ultimate Power Plan plan was removed." -ForegroundColor Red
     }
 }


### PR DESCRIPTION
## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] UI/UX improvement

## Description
This is simpler and more reliable:

Running powercfg /restoredefaultschemes restores the built-in power plans, including Ultimate Performance (on supported desktop). After that, you can activate it directly with:
```ps1
powercfg /setactive e9a42b02-d5df-448d-aa00-03f14749eb61
```
If you later want to remove it, just switch back to Balanced and delete the Ultimate Performance plan.

Key points:
- restoredefaultschemes ensures all default plans exist
- setactive only switches the current plan; it does not duplicate anything
- running the same commands multiple times is safe and has no cumulative effect
- no additional checks are required because repeated execution does not change state after the first successful application
## Issue related to PR
- Resolves #4459
