### PR TITLE
Added WPFTweaksWindowsAI

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -966,6 +966,22 @@
     "Description": "Removes or disables all ai features and packages",
     "category": "z__Advanced Tweaks - CAUTION",
     "panel": "1",
+    "registry": [
+      {
+        "Path": "HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer",
+        "Name": "SettingsPageVisibility",
+        "Value": "hide:aicomponents",
+        "Type": "String",
+        "OriginalValue": "<RemoveEntry>"
+      },
+      {
+        "Path": "HKLM:\\SOFTWARE\\Policies\\WindowsNotepad",
+        "Name": "DisableAIFeatures",
+        "Value": 1,
+        "Type": "DWord",
+        "OriginalValue": "<RemoveEntry>"
+      }
+    ],
     "InvokeScript": [
       "
       $Appx = (Get-AppxPackage MicrosoftWindows.Client.CoreAI).PackageFullName

--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -961,32 +961,29 @@
     ],
     "link": "https://winutil.christitus.com/dev/tweaks/z--advanced-tweaks---caution/storage"
   },
-  "WPFTweaksRemoveCopilot": {
-    "Content": "Microsoft Copilot - Disable",
-    "Description": "Removes Copilot AppXPackages and related ai packages",
+  "WPFTweaksWindowsAI": {
+    "Content": "Windows AI - Disable",
+    "Description": "Removes or disables all ai features and packages",
     "category": "z__Advanced Tweaks - CAUTION",
     "panel": "1",
     "InvokeScript": [
       "
-      Get-AppxPackage -AllUsers *Copilot* | Remove-AppxPackage -AllUsers
-      Get-AppxPackage -AllUsers Microsoft.MicrosoftOfficeHub | Remove-AppxPackage -AllUsers
-
       $Appx = (Get-AppxPackage MicrosoftWindows.Client.CoreAI).PackageFullName
       $Sid = (Get-LocalUser $Env:UserName).Sid.Value
 
       New-Item \"HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Appx\\AppxAllUserStore\\EndOfLife\\$Sid\\$Appx\" -Force
+
+      Get-AppxPackage -AllUsers *Copilot* | Remove-AppxPackage -AllUsers
+      Get-AppxPackage -AllUsers Microsoft.MicrosoftOfficeHub | Remove-AppxPackage -AllUsers
       Remove-AppxPackage $Appx
 
-      Write-Host \"Copilot Removed\"
+      Set-Service -Name WSAIFabricSvc -StartupType Disabled
+      Disable-WindowsOptionalFeature -FeatureName Recall -Online
+
+      Write-Host \"Windows AI Disabled\"
       "
     ],
-    "UndoScript": [
-      "
-      Write-Host \"Installing Copilot...\"
-      winget install --name Copilot --source msstore --accept-package-agreements --accept-source-agreements --silent
-      "
-    ],
-    "link": "https://winutil.christitus.com/dev/tweaks/z--advanced-tweaks---caution/removecopilot"
+    "link": "https://winutil.christitus.com/dev/tweaks/z--advanced-tweaks---caution/WindowsAI"
   },
   "WPFTweaksWPBT": {
     "Content": "Windows Platform Binary Table (WPBT) - Disable",


### PR DESCRIPTION
## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] UI/UX improvement

## Description
This is all ai features i was able to find

i didn't add a undo tweak because i dont know a single person who would want winutil to enable and install these

`WSAIFabricSvc` Service is for AIFabric which we dont know anything about

`Recall` will be automaticly enabled in older windows versions like on ltsc (aka me)
```ps1
PS C:\Users\User> (Get-WindowsOptionalFeature -FeatureName Recall -Online).State
Enabled
PS C:\Users\User>
```