### PR TITLE
Make WPFTweaksServices do what it says

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -174,7 +174,7 @@
   },
   "WPFTweaksServices": {
     "Content": "Services - Set to Manual",
-    "Description": "Turns a bunch of system services to manual that don't need to be running all the time. This is pretty harmless as if the service is needed, it will simply start on demand.",
+    "Description": "Sets some services to Manual startup and adjusts the SvcHostSplitThresholdInKB registry value to better match system memory, which can significantly reduce the number of svchost.exe processes.",
     "category": "Essential Tweaks",
     "panel": "1",
     "service": [

--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -194,16 +194,6 @@
         "OriginalType": "Automatic"
       },
       {
-        "Name": "RemoteAccess",
-        "StartupType": "Disabled",
-        "OriginalType": "Disabled"
-      },
-      {
-        "Name": "RemoteRegistry",
-        "StartupType": "Disabled",
-        "OriginalType": "Disabled"
-      },
-      {
         "Name": "StorSvc",
         "StartupType": "Manual",
         "OriginalType": "Automatic"
@@ -212,26 +202,6 @@
         "Name": "SharedAccess",
         "StartupType": "Disabled",
         "OriginalType": "Automatic"
-      },
-      {
-        "Name": "TermService",
-        "StartupType": "Manual",
-        "OriginalType": "Manual"
-      },
-      {
-        "Name": "TroubleshootingSvc",
-        "StartupType": "Manual",
-        "OriginalType": "Manual"
-      },
-      {
-        "Name": "seclogon",
-        "StartupType": "Manual",
-        "OriginalType": "Manual"
-      },
-      {
-        "Name": "ssh-agent",
-        "StartupType": "Disabled",
-        "OriginalType": "Disabled"
       }
     ],
     "InvokeScript": [


### PR DESCRIPTION
## Description
The tweak says "Turns a bunch of system services to manual that don't need to be running all the time" so it dosen't make sense for it to do something like disable ssh or ensure attack vectors are disabled imagine you ran winutil than wanted to connect to someones else machine than boom you can't it just dosen't make sense

## Issue related to PR
- Resolves #4471