### PR TITLE
Fixed typo - 'there' to 'their'

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -807,7 +807,7 @@
   },
   "WPFTweaksDeBloat": {
     "Content": "Unwanted Pre-Installed Apps - Remove",
-    "Description": "This will remove a bunch of Windows pre-installed applications which most people dont want on there system.",
+    "Description": "This will remove a bunch of Windows pre-installed applications which most people dont want on their system.",
     "category": "Essential Tweaks",
     "panel": "1",
     "appx": [

--- a/docs/content/dev/tweaks/Essential-Tweaks/DeBloat.md
+++ b/docs/content/dev/tweaks/Essential-Tweaks/DeBloat.md
@@ -6,7 +6,7 @@ description: ""
 ```json {filename="config/tweaks.json",linenos=inline,linenostart=808}
   "WPFTweaksDeBloat": {
     "Content": "Unwanted Pre-Installed Apps - Remove",
-    "Description": "This will remove a bunch of Windows pre-installed applications which most people dont want on there system.",
+    "Description": "This will remove a bunch of Windows pre-installed applications which most people dont want on their system.",
     "category": "Essential Tweaks",
     "panel": "1",
     "appx": [


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://winutil.christitus.com/contributing/ -->
<!--Documentation is auto-generated from configs - no manual documentation updates needed -->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [x] Documentation update
- [ ] UI/UX improvement

<!-- This automatically adds labels to your PR based on the selections above. -->

## Description
<!--[What does this PR do? Provide Screenshots when possible.]-->
Updates a typo in a tooltip from "there" to "their" in DeBloat.md

## Issue related to PR
<!--[List any ISSUES this is related to as it AUTO-CLOSES Them!]-->
- Resolves #
