### PR TITLE
Add Game Mode toggle and fix MPO overlay for 25H2

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -1461,6 +1461,14 @@
         "Type": "DWord",
         "OriginalValue": "5",
         "DefaultState": "true"
+      },
+      {
+        "Path": "HKLM:\\SYSTEM\\CurrentControlSet\\Control\\GraphicsDrivers",
+        "Name": "DisableOverlays",
+        "Value": "1",
+        "Type": "DWord",
+        "OriginalValue": "0",
+        "DefaultState": "false"
       }
     ],
     "link": "https://winutil.christitus.com/dev/tweaks/customize-preferences/multiplaneoverlay"
@@ -1740,6 +1748,32 @@
       }
     ],
     "link": "https://winutil.christitus.com/dev/tweaks/customize-preferences/taskview"
+  },
+  "WPFToggleGameMode": {
+    "Content": "Game Mode",
+    "Description": "If enabled, Windows prioritizes gaming performance by allocating system resources. Disable for audio/video production to prevent interference.",
+    "category": "Customize Preferences",
+    "panel": "2",
+    "Type": "Toggle",
+    "registry": [
+      {
+        "Path": "HKCU:\\Software\\Microsoft\\GameBar",
+        "Name": "AllowAutoGameMode",
+        "Value": "1",
+        "Type": "DWord",
+        "OriginalValue": "0",
+        "DefaultState": "true"
+      },
+      {
+        "Path": "HKCU:\\Software\\Microsoft\\GameBar",
+        "Name": "AutoGameModeEnabled",
+        "Value": "1",
+        "Type": "DWord",
+        "OriginalValue": "0",
+        "DefaultState": "true"
+      }
+    ],
+    "link": "https://winutil.christitus.com/dev/tweaks/customize-preferences/gamemode"
   },
   "WPFOOSUbutton": {
     "Content": "O&O ShutUp10++ - Run",


### PR DESCRIPTION
## Type of Change
- New feature
- Bug fix

## Description
Two changes to tweaks.json:

### 1. Added Game Mode toggle (WPFToggleGameMode)
New toggle under Customize Preferences to enable/disable Windows Game Mode via registry. Disabling Game Mode is useful for audio/video production users who find it interferes with recording/streaming performance.

Registry keys:
- \HKCU\Software\Microsoft\GameBar\AllowAutoGameMode\
- \HKCU\Software\Microsoft\GameBar\AutoGameModeEnabled\

### 2. Fixed MPO overlay for Windows 11 25H2
The existing \WPFToggleMultiplaneOverlay\ only used \Dwm\OverlayTestMode\ which is deprecated on 25H2. Added the new working path:
- \HKLM\...\GraphicsDrivers\DisableOverlays = 1\

Both registry entries are included so the toggle works on both old and new builds.