### PR TITLE
Add minimize button to WinUtil window

### DIFF
--- a/functions/public/Invoke-WPFButton.ps1
+++ b/functions/public/Invoke-WPFButton.ps1
@@ -65,6 +65,7 @@ function Invoke-WPFButton {
         "WPFGetInstalled" {Invoke-WPFGetInstalled -CheckBox "winget"}
         "WPFGetInstalledTweaks" {Invoke-WPFGetInstalled -CheckBox "tweaks"}
         "WPFCloseButton" {$sync.Form.Close(); Write-Host "Bye bye!"}
+        "WPFMinimizeButton" {$sync.Form.WindowState = [Windows.WindowState]::Minimized}
         "WPFselectedAppsButton" {$sync.selectedAppsPopup.IsOpen = -not $sync.selectedAppsPopup.IsOpen}
         "WPFToggleFOSSHighlight" {
             if ($sync.WPFToggleFOSSHighlight.IsChecked) {

--- a/xaml/inputXML.xaml
+++ b/xaml/inputXML.xaml
@@ -1187,6 +1187,16 @@
                 </Popup>
 
                     <Button
+                    Content="&#x2212;" BorderThickness="0"
+                    BorderBrush="Transparent"
+                    Background="{DynamicResource MainBackgroundColor}"
+                    Width="{DynamicResource IconButtonSize}" Height="{DynamicResource IconButtonSize}"
+                    HorizontalAlignment="Right" VerticalAlignment="Top"
+                    Margin="0,0,0,0"
+                    FontFamily="{DynamicResource FontFamily}"
+                    Foreground="{DynamicResource MainForegroundColor}" FontSize="{DynamicResource CloseIconFontSize}" Name="WPFMinimizeButton" />
+
+                    <Button
                     Content="&#xD7;" BorderThickness="0"
                 BorderBrush="Transparent"
                 Background="{DynamicResource MainBackgroundColor}"


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://winutil.christitus.com/contributing/ -->
<!--Documentation is auto-generated from configs - no manual documentation updates needed -->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [x] UI/UX improvement

<!-- This automatically adds labels to your PR based on the selections above. -->

## Description
<!--[What does this PR do? Provide Screenshots when possible.]-->

Adds a minimize button, allowing the GUI to be minimized to the taskbar without closing the app. Earlier, could only be minimized by clicking the taskbar icon, which is unintuitive to some(atleast me).


<img width="1431" height="749" alt="image" src="https://github.com/user-attachments/assets/ba897ea9-b3da-4f3d-84e4-b0d929c82819" />
<img width="194" height="59" alt="image" src="https://github.com/user-attachments/assets/4d59d949-9d8a-48f6-bb20-7daf129bced9" />