### PR TITLE
Fix missing dism metadata

### DIFF
--- a/functions/private/Get-WinUtilToggleStatus.ps1
+++ b/functions/private/Get-WinUtilToggleStatus.ps1
@@ -1,11 +1,21 @@
 Function Get-WinUtilToggleStatus {
-    if (-not $ToggleSwitchReg) {
+    param(
+        [string]$ToggleSwitch
+    )
+
+    $toggleSwitchReg = if ($ToggleSwitch) {
+        $sync.configs.tweaks.$ToggleSwitch.registry
+    } else {
+        $ToggleSwitchReg
+    }
+
+    if (-not $toggleSwitchReg) {
         return $false
     }
 
     New-PSDrive -Name HKU -PSProvider Registry -Root HKEY_USERS
 
-    foreach ($regentry in $ToggleSwitchReg) {
+    foreach ($regentry in $toggleSwitchReg) {
 
         if (-not (Test-Path $regentry.Path)) {
             New-Item -Path $regentry.Path -Force | Out-Null

--- a/functions/private/Invoke-WinUtilISO.ps1
+++ b/functions/private/Invoke-WinUtilISO.ps1
@@ -213,6 +213,90 @@ function Invoke-WinUtilISOModify {
             })
         }
 
+        function Get-DismImageInfoMap {
+            param(
+                [Parameter(Mandatory)][string]$ImagePath,
+                [int]$Index = 1
+            )
+
+            $map = @{}
+            $lines = & dism /English "/Get-ImageInfo" "/ImageFile:$ImagePath" "/Index:$Index"
+            foreach ($line in $lines) {
+                if ($line -match '^\s*([^:]+?)\s*:\s*(.*)$') {
+                    $key = $Matches[1].Trim()
+                    $val = $Matches[2].Trim()
+                    if (-not $map.ContainsKey($key)) {
+                        $map[$key] = $val
+                    }
+                }
+            }
+            return $map
+        }
+
+        function Invoke-WinUtilWimMetadataHydration {
+            param(
+                [Parameter(Mandatory)][string]$ImagePath,
+                [Parameter(Mandatory)][string]$EditionName,
+                [scriptblock]$Logger
+            )
+
+            function LogMeta([string]$Message) {
+                if ($Logger) {
+                    $null = $Logger.Invoke($Message)
+                }
+            }
+
+            $before = Get-DismImageInfoMap -ImagePath $ImagePath -Index 1
+            $undefinedBefore = @($before.GetEnumerator() | Where-Object { $_.Value -eq '<undefined>' } | ForEach-Object { $_.Key })
+
+            if ($undefinedBefore.Count -eq 0) {
+                LogMeta "Metadata check: no undefined DISM fields detected."
+                return
+            }
+
+            LogMeta "Metadata check: undefined DISM fields detected: $($undefinedBefore -join ', ')"
+            LogMeta "Attempting best-effort metadata hydration for install.wim..."
+
+            $setImage = Get-Command Set-WindowsImage -ErrorAction SilentlyContinue
+            if (-not $setImage) {
+                LogMeta "Set-WindowsImage is unavailable on this host; cannot write additional WIM metadata fields."
+                return
+            }
+
+            $targetName = if ($EditionName -and $EditionName -ne 'Unknown') { $EditionName } else { $before['Name'] }
+            if (-not $targetName) { $targetName = 'Windows 11' }
+
+            $targetDescription = if ($before['Description'] -and $before['Description'] -ne '<undefined>') {
+                $before['Description']
+            } else {
+                $targetName
+            }
+
+            $setArgs = @{
+                ImagePath   = $ImagePath
+                Index       = 1
+                Name        = $targetName
+                Description = $targetDescription
+                ErrorAction = 'Stop'
+            }
+
+            try {
+                Set-WindowsImage @setArgs | Out-Null
+                LogMeta "Applied Set-WindowsImage metadata updates (Name/Description)."
+            } catch {
+                LogMeta "Warning: Set-WindowsImage metadata update failed: $_"
+            }
+
+            $after = Get-DismImageInfoMap -ImagePath $ImagePath -Index 1
+            $undefinedAfter = @($after.GetEnumerator() | Where-Object { $_.Value -eq '<undefined>' } | ForEach-Object { $_.Key })
+            if ($undefinedAfter.Count -eq 0) {
+                LogMeta "Metadata hydration complete: no undefined DISM fields remain."
+            } else {
+                LogMeta "Metadata hydration complete. Remaining undefined DISM fields: $($undefinedAfter -join ', ')"
+                LogMeta "Note: some DISM metadata fields are read-only and come from Microsoft image internals."
+            }
+        }
+
         try {
             $sync["WPFWin11ISOStatusLog"].Dispatcher.Invoke([action]{
                 $sync["WPFWin11ISOSelectSection"].Visibility = "Collapsed"
@@ -260,6 +344,9 @@ function Invoke-WinUtilISOModify {
             Rename-Item -Path $exportWim -NewName "install.wim" -Force
             $localWim = Join-Path $isoContents "sources\install.wim"
             Log "Unused editions removed. install.wim now contains only '$selectedEditionName'."
+
+            SetProgress "Hydrating WIM metadata..." 76
+            Invoke-WinUtilWimMetadataHydration -ImagePath $localWim -EditionName $selectedEditionName -Logger ${function:Log}
 
             SetProgress "Dismounting source ISO..." 80
             Log "Dismounting original ISO..."


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://winutil.christitus.com/contributing/ -->
<!--Documentation is auto-generated from configs - no manual documentation updates needed -->

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] UI/UX improvement

<!-- This automatically adds labels to your PR based on the selections above. -->

## Description
<!--[What does this PR do? Provide Screenshots when possible.]-->
Some modern Windows 11 ISOs (Generally Multi language) have missing metadata from microsoft. This patch fills in the missing metadata so you no longer get "invalid product key messages"

Side note this fixes light mode from #4497 Gabi toggle cleanup

## Issue related to PR
<!--[List any ISSUES this is related to as it AUTO-CLOSES Them!]-->
- Resolves #4443 
