### PR TITLE
Fix preference toggles defaulting to enabled on launch

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -1441,7 +1441,7 @@
     ],
     "link": "https://winutil.christitus.com/dev/tweaks/customize-preferences/newoutlook"
   },
-    "WPFToggleScrollbars": {
+  "WPFToggleScrollbars": {
     "Content": "Scrollbars Always Visible",
     "Description": "If enabled, scrollbars will always be visible. If disabled, Windows will automatically hide scrollbars when not in use.",
     "category": "Customize Preferences",
@@ -1454,8 +1454,7 @@
         "Value": "0",
         "Type": "DWord",
         "OriginalValue": "1",
-        "DefaultState": "false",
-      "link": "https://winutil.christitus.com/dev/tweaks/customize-preferences/scrollbars"
+        "DefaultState": "false"
       }
     ],
     "link": "https://winutil.christitus.com/dev/tweaks/customize-preferences/scrollbars"

--- a/functions/private/Get-WinUtilToggleStatus.ps1
+++ b/functions/private/Get-WinUtilToggleStatus.ps1
@@ -13,29 +13,20 @@ Function Get-WinUtilToggleStatus {
         return $false
     }
 
-    New-PSDrive -Name HKU -PSProvider Registry -Root HKEY_USERS
+    if (-not (Get-PSDrive -Name HKU -ErrorAction SilentlyContinue)) {
+        New-PSDrive -Name HKU -PSProvider Registry -Root HKEY_USERS | Out-Null
+    }
 
     foreach ($regentry in $toggleSwitchReg) {
 
-        if (-not (Test-Path $regentry.Path)) {
-            New-Item -Path $regentry.Path -Force | Out-Null
+        $regstate = $null
+        if (Test-Path $regentry.Path) {
+            $regstate = (Get-ItemProperty -Path $regentry.Path -ErrorAction SilentlyContinue).$($regentry.Name)
         }
 
-        $regstate = (Get-ItemProperty -Path $regentry.Path).$($regentry.Name)
-
         if ($null -eq $regstate) {
-            switch ($regentry.DefaultState) {
-                "true" {
-                    $regstate = $regentry.Value
-                }
-                "false" {
-                    $regstate = $regentry.OriginalValue
-                }
-                default {
-                    Write-Error "Entry $($regentry.Name): missing value and no DefaultState"
-                    $regstate = $regentry.OriginalValue
-                }
-            }
+            # Missing values should be treated as "not enabled" to avoid defaulting toggles on.
+            $regstate = $regentry.OriginalValue
         }
 
         if ($regstate -ne $regentry.Value) {


### PR DESCRIPTION
## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] UI/UX improvemens

## Description
Resolved an issue in the dev branch where the Tweaks tab incorrectly initialized all preference toggles to the 'enabled' state upon opening, instead of accurately reading and reflecting the actual system state.

This brings the dev branch behavior back in line with the stable release, ensuring toggles match the user's current environment configurations rather than defaulting to on. 

- Resolves #4518
