### PR TITLE
fix(iso): unlock taskbar customization in Settings

### DIFF
--- a/tools/autounattend.xml
+++ b/tools/autounattend.xml
@@ -102,37 +102,19 @@ foreach( $file in $Document.unattend.Extensions.File ) {
 HKU = &amp;H80000003
 Set reg = GetObject("winmgmts://./root/default:StdRegProv")
 
-Sub LogError(sid, valueName, errCode)
-    On Error Resume Next
-    Dim fso, logFile
-    Set fso = CreateObject("Scripting.FileSystemObject")
-    Set logFile = fso.OpenTextFile("C:\Windows\Setup\Scripts\UnlockStartLayout.log", 8, True)
-    If Err.Number = 0 Then
-        logFile.WriteLine Now &amp; " - Error: Failed to delete '" &amp; valueName &amp; "' for SID " &amp; sid &amp; ". Return code: " &amp; errCode
-        logFile.Close
-    End If
-    On Error GoTo 0
-End Sub
-
 If reg.EnumKey(HKU, "", sids) = 0 Then
     If Not IsNull(sids) Then
         For Each sid In sids
             key = sid + "\Software\Policies\Microsoft\Windows\Explorer"
             
-            errCode = 0
-            On Error Resume Next
-            errCode = reg.DeleteValue(HKU, key, "LockedStartLayout")
-            On Error GoTo 0
-            If errCode &lt;&gt; 0 And errCode &lt;&gt; 2 Then
-                LogError sid, "LockedStartLayout", errCode
+            result = reg.DeleteValue(HKU, key, "LockedStartLayout")
+            If result &lt;&gt; 0 And result &lt;&gt; 2 Then
+                Err.Raise vbObjectError + result, "UnlockStartLayout.vbs", "Failed to delete LockedStartLayout from " &amp; key &amp; " (code " &amp; result &amp; ")"
             End If
 
-            errCode = 0
-            On Error Resume Next
-            errCode = reg.DeleteValue(HKU, key, "StartLayoutFile")
-            On Error GoTo 0
-            If errCode &lt;&gt; 0 And errCode &lt;&gt; 2 Then
-                LogError sid, "StartLayoutFile", errCode
+            result = reg.DeleteValue(HKU, key, "StartLayoutFile")
+            If result &lt;&gt; 0 And result &lt;&gt; 2 Then
+                Err.Raise vbObjectError + result, "UnlockStartLayout.vbs", "Failed to delete StartLayoutFile from " &amp; key &amp; " (code " &amp; result &amp; ")"
             End If
         Next
     End If

--- a/tools/autounattend.xml
+++ b/tools/autounattend.xml
@@ -99,7 +99,6 @@ foreach( $file in $Document.unattend.Extensions.File ) {
 &lt;/LayoutModificationTemplate&gt;
         </File>
         <File path="C:\Windows\Setup\Scripts\UnlockStartLayout.vbs">
-On Error Resume Next
 HKU = &amp;H80000003
 Set reg = GetObject("winmgmts://./root/default:StdRegProv")
 

--- a/tools/autounattend.xml
+++ b/tools/autounattend.xml
@@ -99,18 +99,16 @@ foreach( $file in $Document.unattend.Extensions.File ) {
 &lt;/LayoutModificationTemplate&gt;
         </File>
         <File path="C:\Windows\Setup\Scripts\UnlockStartLayout.vbs">
+On Error Resume Next
 HKU = &amp;H80000003
 Set reg = GetObject("winmgmts://./root/default:StdRegProv")
-Set fso = CreateObject("Scripting.FileSystemObject")
 
 If reg.EnumKey(HKU, "", sids) = 0 Then
     If Not IsNull(sids) Then
         For Each sid In sids
             key = sid + "\Software\Policies\Microsoft\Windows\Explorer"
-            name = "LockedStartLayout"
-            If reg.GetDWORDValue(HKU, key, name, existing) = 0 Then
-                reg.SetDWORDValue HKU, key, name, 0
-            End If
+            reg.DeleteValue HKU, key, "LockedStartLayout"
+            reg.DeleteValue HKU, key, "StartLayoutFile"
         Next
     End If
 End If

--- a/tools/autounattend.xml
+++ b/tools/autounattend.xml
@@ -102,14 +102,38 @@ foreach( $file in $Document.unattend.Extensions.File ) {
 HKU = &amp;H80000003
 Set reg = GetObject("winmgmts://./root/default:StdRegProv")
 
+Sub LogError(sid, valueName, errCode)
+    On Error Resume Next
+    Dim fso, logFile
+    Set fso = CreateObject("Scripting.FileSystemObject")
+    Set logFile = fso.OpenTextFile("C:\Windows\Setup\Scripts\UnlockStartLayout.log", 8, True)
+    If Err.Number = 0 Then
+        logFile.WriteLine Now &amp; " - Error: Failed to delete '" &amp; valueName &amp; "' for SID " &amp; sid &amp; ". Return code: " &amp; errCode
+        logFile.Close
+    End If
+    On Error GoTo 0
+End Sub
+
 If reg.EnumKey(HKU, "", sids) = 0 Then
     If Not IsNull(sids) Then
         For Each sid In sids
             key = sid + "\Software\Policies\Microsoft\Windows\Explorer"
+            
+            errCode = 0
             On Error Resume Next
-            reg.DeleteValue HKU, key, "LockedStartLayout"
-            reg.DeleteValue HKU, key, "StartLayoutFile"
+            errCode = reg.DeleteValue(HKU, key, "LockedStartLayout")
             On Error GoTo 0
+            If errCode &lt;&gt; 0 And errCode &lt;&gt; 2 Then
+                LogError sid, "LockedStartLayout", errCode
+            End If
+
+            errCode = 0
+            On Error Resume Next
+            errCode = reg.DeleteValue(HKU, key, "StartLayoutFile")
+            On Error GoTo 0
+            If errCode &lt;&gt; 0 And errCode &lt;&gt; 2 Then
+                LogError sid, "StartLayoutFile", errCode
+            End If
         Next
     End If
 End If

--- a/tools/autounattend.xml
+++ b/tools/autounattend.xml
@@ -106,8 +106,16 @@ If reg.EnumKey(HKU, "", sids) = 0 Then
     If Not IsNull(sids) Then
         For Each sid In sids
             key = sid + "\Software\Policies\Microsoft\Windows\Explorer"
-            reg.DeleteValue HKU, key, "LockedStartLayout"
-            reg.DeleteValue HKU, key, "StartLayoutFile"
+            
+            result = reg.DeleteValue(HKU, key, "LockedStartLayout")
+            If result &lt;&gt; 0 And result &lt;&gt; 2 Then
+                WScript.Echo "Warning: Failed to delete LockedStartLayout from " &amp; key &amp; " (code " &amp; result &amp; ")"
+            End If
+
+            result = reg.DeleteValue(HKU, key, "StartLayoutFile")
+            If result &lt;&gt; 0 And result &lt;&gt; 2 Then
+                WScript.Echo "Warning: Failed to delete StartLayoutFile from " &amp; key &amp; " (code " &amp; result &amp; ")"
+            End If
         Next
     End If
 End If

--- a/tools/autounattend.xml
+++ b/tools/autounattend.xml
@@ -99,7 +99,6 @@ foreach( $file in $Document.unattend.Extensions.File ) {
 &lt;/LayoutModificationTemplate&gt;
         </File>
         <File path="C:\Windows\Setup\Scripts\UnlockStartLayout.vbs">
-On Error Resume Next
 HKU = &amp;H80000003
 Set reg = GetObject("winmgmts://./root/default:StdRegProv")
 
@@ -107,8 +106,10 @@ If reg.EnumKey(HKU, "", sids) = 0 Then
     If Not IsNull(sids) Then
         For Each sid In sids
             key = sid + "\Software\Policies\Microsoft\Windows\Explorer"
+            On Error Resume Next
             reg.DeleteValue HKU, key, "LockedStartLayout"
             reg.DeleteValue HKU, key, "StartLayoutFile"
+            On Error GoTo 0
         Next
     End If
 End If

--- a/tools/autounattend.xml
+++ b/tools/autounattend.xml
@@ -99,6 +99,7 @@ foreach( $file in $Document.unattend.Extensions.File ) {
 &lt;/LayoutModificationTemplate&gt;
         </File>
         <File path="C:\Windows\Setup\Scripts\UnlockStartLayout.vbs">
+On Error Resume Next
 HKU = &amp;H80000003
 Set reg = GetObject("winmgmts://./root/default:StdRegProv")
 
@@ -106,16 +107,8 @@ If reg.EnumKey(HKU, "", sids) = 0 Then
     If Not IsNull(sids) Then
         For Each sid In sids
             key = sid + "\Software\Policies\Microsoft\Windows\Explorer"
-            
-            result = reg.DeleteValue(HKU, key, "LockedStartLayout")
-            If result &lt;&gt; 0 And result &lt;&gt; 2 Then
-                Err.Raise vbObjectError + result, "UnlockStartLayout.vbs", "Failed to delete LockedStartLayout from " &amp; key &amp; " (code " &amp; result &amp; ")"
-            End If
-
-            result = reg.DeleteValue(HKU, key, "StartLayoutFile")
-            If result &lt;&gt; 0 And result &lt;&gt; 2 Then
-                Err.Raise vbObjectError + result, "UnlockStartLayout.vbs", "Failed to delete StartLayoutFile from " &amp; key &amp; " (code " &amp; result &amp; ")"
-            End If
+            reg.DeleteValue HKU, key, "LockedStartLayout"
+            reg.DeleteValue HKU, key, "StartLayoutFile"
         Next
     End If
 End If


### PR DESCRIPTION
## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] UI/UX improvement

## Description
Fixes the taskbar settings page being broken/disabled on custom ISO installations. Applying a custom layout via the StartLayoutFile policy permanently locks down the taskbar and start menu settings in Windows 11. This updates UnlockStartLayout.vbs to delete the LockedStartLayout and StartLayoutFile values after applying the initial pins, restoring full customization to the taskbar Settings page.

Updates the script to check registry deletion status codes and raise VBScript errors for genuine failures.

## Issue related to PR
- Resolves #4543
