### PR TITLE
fix(iso): resolve windows update re-enabling failures on first boot

### DIFF
--- a/functions/private/Invoke-WinUtilISOScript.ps1
+++ b/functions/private/Invoke-WinUtilISOScript.ps1
@@ -305,10 +305,10 @@ function Invoke-WinUtilISOScript {
     Set-ISOScriptReg 'HKLM\zSOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Orchestrator\UScheduler_Oobe\WindowsUpdate' 'workCompleted' 'REG_DWORD' '1'
     Remove-ISOScriptReg 'HKLM\zSOFTWARE\Microsoft\WindowsUpdate\Orchestrator\UScheduler_Oobe\WindowsUpdate'
     Set-ISOScriptReg 'HKLM\zSOFTWARE\Microsoft\Windows\CurrentVersion\DeliveryOptimization\Config' 'DODownloadMode' 'REG_DWORD' '0'
-    # We only disable BITS and wuauserv offline.
-    # WaaSMedicSvc and UsoSvc are left at default start values to prevent SCM re-enabling lockout issues on first logon.
     Set-ISOScriptReg 'HKLM\zSYSTEM\ControlSet001\Services\BITS'         'Start' 'REG_DWORD' '4'
     Set-ISOScriptReg 'HKLM\zSYSTEM\ControlSet001\Services\wuauserv'     'Start' 'REG_DWORD' '4'
+    Set-ISOScriptReg 'HKLM\zSYSTEM\ControlSet001\Services\UsoSvc'       'Start' 'REG_DWORD' '4'
+    Set-ISOScriptReg 'HKLM\zSYSTEM\ControlSet001\Services\WaaSMedicSvc' 'Start' 'REG_DWORD' '4'
 
     & $Log "Preventing installation of Teams..."
     Set-ISOScriptReg 'HKLM\zSOFTWARE\Policies\Microsoft\Teams' 'DisableInstallation' 'REG_DWORD' '1'

--- a/functions/private/Invoke-WinUtilISOScript.ps1
+++ b/functions/private/Invoke-WinUtilISOScript.ps1
@@ -305,10 +305,10 @@ function Invoke-WinUtilISOScript {
     Set-ISOScriptReg 'HKLM\zSOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Orchestrator\UScheduler_Oobe\WindowsUpdate' 'workCompleted' 'REG_DWORD' '1'
     Remove-ISOScriptReg 'HKLM\zSOFTWARE\Microsoft\WindowsUpdate\Orchestrator\UScheduler_Oobe\WindowsUpdate'
     Set-ISOScriptReg 'HKLM\zSOFTWARE\Microsoft\Windows\CurrentVersion\DeliveryOptimization\Config' 'DODownloadMode' 'REG_DWORD' '0'
+    # We only disable BITS and wuauserv offline.
+    # WaaSMedicSvc and UsoSvc are left at default start values to prevent SCM re-enabling lockout issues on first logon.
     Set-ISOScriptReg 'HKLM\zSYSTEM\ControlSet001\Services\BITS'         'Start' 'REG_DWORD' '4'
     Set-ISOScriptReg 'HKLM\zSYSTEM\ControlSet001\Services\wuauserv'     'Start' 'REG_DWORD' '4'
-    Set-ISOScriptReg 'HKLM\zSYSTEM\ControlSet001\Services\UsoSvc'       'Start' 'REG_DWORD' '4'
-    Set-ISOScriptReg 'HKLM\zSYSTEM\ControlSet001\Services\WaaSMedicSvc' 'Start' 'REG_DWORD' '4'
 
     & $Log "Preventing installation of Teams..."
     Set-ISOScriptReg 'HKLM\zSOFTWARE\Policies\Microsoft\Teams' 'DisableInstallation' 'REG_DWORD' '1'

--- a/tools/autounattend.xml
+++ b/tools/autounattend.xml
@@ -433,10 +433,19 @@ $scripts = @(
         reg.exe delete "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\DeliveryOptimization\Config" /v DODownloadMode /f;
         reg.exe add "HKLM\Software\Policies\Microsoft\Windows\OneDrive" /v DisableFileSyncNGSC /t REG_DWORD /d 0 /f;
         reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\GameDVR" /v AppCaptureEnabled /t REG_DWORD /d 0 /f;
-        Set-Service -Name BITS -StartupType Manual -ErrorAction SilentlyContinue;
-        Set-Service -Name wuauserv -StartupType Manual -ErrorAction SilentlyContinue;
-        Set-Service -Name UsoSvc -StartupType Automatic -ErrorAction SilentlyContinue;
-        Set-Service -Name WaaSMedicSvc -StartupType Manual -ErrorAction SilentlyContinue;
+        $services = @(
+            @{ Name = 'BITS'; StartupType = 'Manual' },
+            @{ Name = 'wuauserv'; StartupType = 'Manual' },
+            @{ Name = 'UsoSvc'; StartupType = 'Automatic' },
+            @{ Name = 'WaaSMedicSvc'; StartupType = 'Manual' }
+        );
+        foreach ($svc in $services) {
+            try {
+                Set-Service -Name $svc.Name -StartupType $svc.StartupType -ErrorAction Stop;
+            } catch {
+                Write-Warning "Could not set startup type of $($svc.Name) to $($svc.StartupType): $_";
+            }
+        }
     };
     {
         reg.exe add "HKLM\SOFTWARE\Microsoft\PolicyManager\current\device\Education" /f;

--- a/tools/autounattend.xml
+++ b/tools/autounattend.xml
@@ -433,10 +433,10 @@ $scripts = @(
         reg.exe delete "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\DeliveryOptimization\Config" /v DODownloadMode /f;
         reg.exe add "HKLM\Software\Policies\Microsoft\Windows\OneDrive" /v DisableFileSyncNGSC /t REG_DWORD /d 0 /f;
         reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\GameDVR" /v AppCaptureEnabled /t REG_DWORD /d 0 /f;
-        reg.exe add "HKLM\SYSTEM\CurrentControlSet\Services\BITS" /v Start /t REG_DWORD /d 3 /f;
-        reg.exe add "HKLM\SYSTEM\CurrentControlSet\Services\wuauserv" /v Start /t REG_DWORD /d 3 /f;
-        reg.exe add "HKLM\SYSTEM\CurrentControlSet\Services\UsoSvc" /v Start /t REG_DWORD /d 2 /f;
-        reg.exe add "HKLM\SYSTEM\CurrentControlSet\Services\WaaSMedicSvc" /v Start /t REG_DWORD /d 3 /f;
+        Set-Service -Name BITS -StartupType Manual -ErrorAction SilentlyContinue;
+        Set-Service -Name wuauserv -StartupType Manual -ErrorAction SilentlyContinue;
+        Set-Service -Name UsoSvc -StartupType Automatic -ErrorAction SilentlyContinue;
+        Set-Service -Name WaaSMedicSvc -StartupType Manual -ErrorAction SilentlyContinue;
     };
     {
         reg.exe add "HKLM\SOFTWARE\Microsoft\PolicyManager\current\device\Education" /f;

--- a/tools/autounattend.xml
+++ b/tools/autounattend.xml
@@ -433,18 +433,9 @@ $scripts = @(
         reg.exe delete "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\DeliveryOptimization\Config" /v DODownloadMode /f;
         reg.exe add "HKLM\Software\Policies\Microsoft\Windows\OneDrive" /v DisableFileSyncNGSC /t REG_DWORD /d 0 /f;
         reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\GameDVR" /v AppCaptureEnabled /t REG_DWORD /d 0 /f;
-        $services = @(
-            @{ Name = 'BITS'; StartupType = 'Manual' },
-            @{ Name = 'wuauserv'; StartupType = 'Manual' },
-            @{ Name = 'UsoSvc'; StartupType = 'Automatic' },
-            @{ Name = 'WaaSMedicSvc'; StartupType = 'Manual' }
-        );
-        foreach ($svc in $services) {
-            try {
-                Set-Service -Name $svc.Name -StartupType $svc.StartupType -ErrorAction Stop;
-            } catch {
-                Write-Warning "Could not set startup type of $($svc.Name) to $($svc.StartupType): $_";
-            }
+        $services = @{ BITS = 'Manual'; wuauserv = 'Manual'; UsoSvc = 'Automatic'; WaaSMedicSvc = 'Manual' };
+        foreach ($name in $services.Keys) {
+            Set-Service -Name $name -StartupType $services[$name] -ErrorAction SilentlyContinue;
         }
     };
     {


### PR DESCRIPTION
## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] UI/UX improvement

## Description
Fixes the Windows Update settings page displaying 'something went wrong' on custom ISO setups (especially under offline/ARM conditions).
1. Bypasses Service Control Manager (SCM) tamper protection by using the Set-Service API in FirstLogon.ps1 rather than raw registry edits (reg.exe add) on the live system.
2. Uses error handling to catch setup failures on protected services (like UsoSvc/WaaSMedicSvc) and emits warnings rather than failing silently.

## Issue related to PR
- Resolves #4556
