### PR TITLE
feat: add optional WinUtil command launchers (production & dev)

### DIFF
--- a/docs/content/dev/features/Powershell-Profile-Powershell-7--Only/InstallPSProfile.md
+++ b/docs/content/dev/features/Powershell-Profile-Powershell-7--Only/InstallPSProfile.md
@@ -17,6 +17,6 @@ function Invoke-WinUtilInstallPSProfile {
         winget install Microsoft.PowerShell --source winget --silent
     }
 
-    wt new-tab pwsh -NoExit -Command "irm https://github.com/ChrisTitusTech/powershell-profile/raw/main/setup.ps1 | iex"
+    wt new-tab pwsh -NoExit -Command "irm https://github.com/ChrisTitusTech/powershell-profile/raw/main/setup.ps1 | iex \; if (Test-Path `$PROFILE) { (Get-Content `$PROFILE -Raw) -replace 'Invoke-RestMethod https://christitus.com/win \| Invoke-Expression', '& ([ScriptBlock]::Create((Invoke-RestMethod https://christitus.com/win))) `@args' -replace 'Invoke-RestMethod https://christitus.com/windev \| Invoke-Expression', '& ([ScriptBlock]::Create((Invoke-RestMethod https://christitus.com/windev))) `@args }; function winutil-dev { & ([ScriptBlock]::Create((Invoke-RestMethod https://christitus.com/windev))) `@args' | Set-Content `$PROFILE }"
 }
 ```

--- a/functions/private/Invoke-WinUtilInstallPSProfile.ps1
+++ b/functions/private/Invoke-WinUtilInstallPSProfile.ps1
@@ -11,5 +11,5 @@ function Invoke-WinUtilInstallPSProfile {
         winget install Microsoft.PowerShell --source winget --silent
     }
 
-    wt new-tab pwsh -NoExit -Command "irm https://github.com/ChrisTitusTech/powershell-profile/raw/main/setup.ps1 | iex"
+    wt new-tab pwsh -NoExit -Command "irm https://github.com/ChrisTitusTech/powershell-profile/raw/main/setup.ps1 | iex \; if (Test-Path `$PROFILE) { (Get-Content `$PROFILE -Raw) -replace 'Invoke-RestMethod https://christitus.com/win \| Invoke-Expression', '& ([ScriptBlock]::Create((Invoke-RestMethod https://christitus.com/win))) `@args' -replace 'Invoke-RestMethod https://christitus.com/windev \| Invoke-Expression', '& ([ScriptBlock]::Create((Invoke-RestMethod https://christitus.com/windev))) `@args }; function winutil-dev { & ([ScriptBlock]::Create((Invoke-RestMethod https://christitus.com/windev))) `@args' | Set-Content `$PROFILE }"
 }


### PR DESCRIPTION
## Description
Updates the CTT PowerShell Profile installer to patch the local `$PROFILE` after setup so that:
1. Both `winutil` and `winutildev` functions support proper argument forwarding (using `ScriptBlock::Create` and `@args`).
2. Adds a matching `winutil-dev` function to the profile for easier command-line testing of the dev branch.

This is implemented dynamically during profile installation, keeping the codebase completely clean without any separate launcher scripts, complex PATH edits, or new GUI toggles.

### Example:
Instead of running a full scriptblock command to test dev presets, you can just do:
```powershell
winutil-dev -Preset Standard
```
