### PR TITLE
new win11creator docs

### DIFF
--- a/docs/content/userguide/win11Creator/_index.md
+++ b/docs/content/userguide/win11Creator/_index.md
@@ -15,7 +15,7 @@ Winutil includes a built-in **Win11 Creator** tool that lets you take an officia
 > You need an **official Windows 11 ISO** from [Microsoft's website](https://www.microsoft.com/en-us/software-download/windows11) before starting. Custom, modified, or non-official ISOs are not supported. The process uses ~10–15 GB of temporary disk space, so make sure you have room.
 
 > [!IMPORTANT]
-> An active internet connection is required at first logon so Winutil automation can complete successfully. Internet may also be required during ISO export if `oscdimg.exe` is not already installed.
+> An active internet connection is required at first logon so Winutil automation can complete successfully. Internet may also be required during ISO export.
 
 > [!NOTE]
 > This workflow is intended for fresh Windows installs, not in-place upgrades of an existing installation.
@@ -52,7 +52,7 @@ Winutil will:
 - **Inject `autounattend.xml`** into the ISO root for setup automation
 - **Disable hardware checks** — TPM, Secure Boot, CPU requirement checks are disabled during setup
 - **Enable local account setup** — skips Microsoft account requirement during OOBE
-- **Strip unused editions** — keeps only your selected edition, saving 1-2 GB per removed edition
+- **Strip unused editions** — keeps only your selected edition.
 - **Clean the component store** — runs DISM cleanup (`/StartComponentCleanup /ResetBase`) to reduce image size
 - **Remove ISO support files** — deletes the ISO `support` folder
 

--- a/docs/content/userguide/win11Creator/_index.md
+++ b/docs/content/userguide/win11Creator/_index.md
@@ -10,8 +10,12 @@ Winutil includes a built-in **Win11 Creator** tool that lets you take an officia
 
 {{< image src="images/win11creator-tab-new" alt="Win11 Creator tab in Winutil" >}}
 
+
 > [!IMPORTANT]
 > You need an **official Windows 11 ISO** from [Microsoft's website](https://www.microsoft.com/en-us/software-download/windows11) before starting. Custom, modified, or non-official ISOs are not supported. The process uses ~10–15 GB of temporary disk space, so make sure you have room.
+
+> [!IMPORTANT]
+> This workflow requires an active internet connection during image creation and first logon so Winutil automation can run correctly.
 
 > [!NOTE]
 > This workflow is intended for fresh Windows installs, not in-place upgrades of an existing installation.
@@ -42,11 +46,14 @@ Winutil includes a built-in **Win11 Creator** tool that lets you take an officia
 Click **Run Windows ISO Modification and Creator** to start the customization process.
 Winutil will:
 
+> [!IMPORTANT]
+> Keep the PC connected to the internet while this step runs and through first logon so Winutil automation can complete successfully.
+
 **ISO Build Actions:**
 - **Copy and prepare ISO contents** in a temporary working directory
 - **Mount your selected edition** from `install.wim`/`install.esd`
 - **Inject `autounattend.xml`** into the ISO root for setup automation
-- **Bypass hardware checks** — TPM, Secure Boot, CPU, RAM, and storage requirement checks are bypassed during setup
+- **Disable hardware checks** — TPM, Secure Boot, CPU, RAM, and storage requirement checks are disabled during setup
 - **Enable local account setup** — skips Microsoft account requirement during OOBE
 - **Strip unused editions** — keeps only your selected edition, saving 1-2 GB per removed edition
 - **Clean the component store** — runs DISM cleanup (`/StartComponentCleanup /ResetBase`) to reduce image size
@@ -54,7 +61,7 @@ Winutil will:
 
 **Post-OOBE Configuration (First Logon):**
 - **Run Winutil automation script at first logon** during setup finalization
-- **Apply Winutil advance preset after install** instead of baking most tweaks directly into `install.wim`
+- **Apply Winutil's advanced preset after installation** during first-logon setup
 - **Complete setup with an automatic reboot** into a preconfigured desktop
 
 >[!NOTE]
@@ -64,10 +71,7 @@ https://github.com/ChrisTitusTech/winutil/blob/main/config/preset.json
 **Optional: Driver Injection**
 - If enabled, it injects drivers from your current system into `install.wim` — useful for offline installations on machines with missing drivers. This is an optional checkbox in Step 3.
 
-
-
 ---
-
 
 ### Step 4 — Export Your Result
 
@@ -78,7 +82,7 @@ Once the modification is complete, choose how to save your image:
   {{< tab name="Save as ISO" selected=true >}}
   1. Click **Save as an ISO File**.
   2. Choose a save location (defaults to your Desktop as `Win11_Modified_yyyyMMdd.iso`).
-  3. Winutil builds a dual BIOS/UEFI bootable ISO using `oscdimg.exe`.
+  3. Winutil builds a dual BIOS/UEFI bootable ISO.
 
 
   {{< /tab >}}
@@ -109,6 +113,8 @@ Click **Clean & Reset** to delete the temporary working directory (~10–15 GB) 
 
 - Download official Windows 11 media from [Microsoft](https://www.microsoft.com/en-us/software-download/windows11).
 - If you prefer to write a finished ISO with another tool, common choices include [Rufus](https://rufus.ie/) or [Ventoy](https://www.ventoy.net/).
+
+
 
 > [!NOTE]
 > Always download Windows ISOs from official Microsoft sources or trusted tools like Rufus/UUP Dump to avoid tampered images.

--- a/docs/content/userguide/win11Creator/_index.md
+++ b/docs/content/userguide/win11Creator/_index.md
@@ -15,7 +15,7 @@ Winutil includes a built-in **Win11 Creator** tool that lets you take an officia
 > You need an **official Windows 11 ISO** from [Microsoft's website](https://www.microsoft.com/en-us/software-download/windows11) before starting. Custom, modified, or non-official ISOs are not supported. The process uses ~10–15 GB of temporary disk space, so make sure you have room.
 
 > [!IMPORTANT]
-> This workflow requires an active internet connection during image creation and first logon so Winutil automation can run correctly.
+> An active internet connection is required at first logon so Winutil automation can complete successfully. Internet may also be required during ISO export if `oscdimg.exe` is not already installed.
 
 > [!NOTE]
 > This workflow is intended for fresh Windows installs, not in-place upgrades of an existing installation.
@@ -47,13 +47,13 @@ Click **Run Windows ISO Modification and Creator** to start the customization pr
 Winutil will:
 
 > [!IMPORTANT]
-> Keep the PC connected to the internet while this step runs and through first logon so Winutil automation can complete successfully.
+> Keep the PC connected to the internet through first logon so Winutil automation can complete successfully. Internet may also be required during ISO export if `oscdimg.exe` is not already installed.
 
 **ISO Build Actions:**
 - **Copy and prepare ISO contents** in a temporary working directory
 - **Mount your selected edition** from `install.wim`/`install.esd`
 - **Inject `autounattend.xml`** into the ISO root for setup automation
-- **Disable hardware checks** — TPM, Secure Boot, CPU, RAM, and storage requirement checks are disabled during setup
+- **Disable hardware checks** — TPM, Secure Boot, CPU requirement checks are disabled during setup
 - **Enable local account setup** — skips Microsoft account requirement during OOBE
 - **Strip unused editions** — keeps only your selected edition, saving 1-2 GB per removed edition
 - **Clean the component store** — runs DISM cleanup (`/StartComponentCleanup /ResetBase`) to reduce image size
@@ -82,7 +82,7 @@ Once the modification is complete, choose how to save your image:
   {{< tab name="Save as ISO" selected=true >}}
   1. Click **Save as an ISO File**.
   2. Choose a save location (defaults to your Desktop as `Win11_Modified_yyyyMMdd.iso`).
-  3. Winutil builds a dual BIOS/UEFI bootable ISO.
+  3. Winutil builds a UEFI bootable ISO.
 
 
   {{< /tab >}}

--- a/docs/content/userguide/win11Creator/_index.md
+++ b/docs/content/userguide/win11Creator/_index.md
@@ -21,8 +21,11 @@ Winutil includes a built-in **Win11 Creator** tool that lets you take an officia
 ### Step 1 — Select Your Official Windows 11 ISO
 
 1. Open Winutil and go to the **Win11 Creator** tab.
-2. Click **Browse** and select your **official Windows 11 ISO file** from Microsoft (must be 4 GB or larger). Custom or modified ISOs are not supported.
+2. Click **Browse** and select your **official Windows 11 ISO file** from Microsoft.
 3. The file path and size will appear on screen once selected.
+
+> [!NOTE]
+> Custom or modified ISOs are not supported.
 
 ---
 
@@ -32,46 +35,10 @@ Winutil includes a built-in **Win11 Creator** tool that lets you take an officia
 2. Winutil mounts the ISO, checks for a valid `install.wim` or `install.esd`, and reads the available editions (Home, Pro, Enterprise, etc.).
 3. Once verified, select your desired **edition** from the dropdown — Pro is selected by default if available.
 
-> [!NOTE]
-> This step takes around 10–30 seconds depending on your drive speed.
-
 ---
 
-### Step 3 — Run the Modification
 
-Click **Run Windows ISO Modification and Creator** to start the customization process. Winutil will:
-
-**App & Component Removal:**
-- **Remove 40+ bloat apps** — Clipchamp, Teams, Copilot, Dev Home, new Outlook, Bing apps, Solitaire, and more
-- **Delete OneDrive setup** from the image
-
-**System Customization:**
-- **Bypass hardware checks** — removes TPM, Secure Boot, CPU, RAM, and storage requirement enforcement so the ISO installs on unsupported hardware
-- **Enable local account setup** — injects an `autounattend.xml` that skips the Microsoft account screen during OOBE
-- **Disable BitLocker and device encryption** — removes startup overhead
-- **Disable Chat icon** — removes chat taskbar button
-- **Strip unused editions** — keeps only your selected edition, saving 1–2 GB per removed edition
-- **Clean the component store** — runs DISM cleanup to reclaim another 300–800 MB
-
-**Privacy & Telemetry Tweaks:**
-- **Disable telemetry** — advertising ID, tailored experiences, input personalization, speech online privacy
-- **Disable cloud content features** — app suggestions, Microsoft Store recommendations
-- **Remove telemetry scheduled tasks** — CEIP, Appraiser, WaaSMedic, and others
-- **Disable OneDrive folder backup** — prevents automatic backups to cloud
-- **Prevent DevHome and Outlook post-setup installation**
-- **Prevent Teams installation** — blocks auto-install after OOBE
-- **Prevent new Outlook Mail app installation**
-- **Disable Windows Update during OOBE** — re-enabled automatically on first login
-- **Disable Copilot and search box suggestions**
-
-**Optional: Driver Injection**
-- If enabled, it injects all drivers from your current system into the install.wim and boot.wim — useful for offline installations on machines with missing drivers. This is an optional checkbox in Step 3.
-
-A live log shows progress as each step completes. This stage usually takes **10–30 minutes** depending on disk speed. The WIM dismount near the end is the slowest part, so do not close Winutil while it is running.
-
----
-
-### Step 4 — Export Your Result
+### Step 3 — Export Your Result
 
 Once the modification is complete, choose how to save your image:
 
@@ -104,7 +71,7 @@ Once the modification is complete, choose how to save your image:
 
 ---
 
-### Step 5 — Clean Up (Optional)
+### Step 4 — Clean Up (Optional)
 
 Click **Clean & Reset** to delete the temporary working directory (~10–15 GB) and return the tool to its initial state, ready for a new ISO. You will be asked to confirm before anything is deleted.
 
@@ -118,20 +85,6 @@ When you install Windows 11 from your modified ISO:
 - **No hardware checks** — installs on machines without TPM 2.0, Secure Boot, or supported CPUs
 - **Dark mode enabled by default**
 - **Empty taskbar and Start Menu** — no pinned apps, Chat icon removed
-- **Windows Update disabled during OOBE** — automatically re-enabled on first login to prevent setup interruptions
-- **BitLocker disabled** — removes startup overhead on first boot
-
----
-
-### Troubleshooting
-
-| Problem | Fix |
-|---------|-----|
-| "install.wim not found" | Not a valid Windows 11 ISO — download a fresh one from Microsoft |
-| "oscdimg.exe not found" | Run `winget install -e --id Microsoft.OSCDIMG` then retry |
-| USB drive not showing up | Plug it in, wait a few seconds, then click **Refresh** |
-| Modification seems stuck | The WIM dismount step is slow — wait at least 10 minutes before assuming it's frozen |
-| "Access Denied" error | Make sure Winutil is running as Administrator |
 
 ---
 

--- a/docs/content/userguide/win11Creator/_index.md
+++ b/docs/content/userguide/win11Creator/_index.md
@@ -69,7 +69,7 @@ Winutil will:
 https://github.com/ChrisTitusTech/winutil/blob/main/config/preset.json
 
 **Optional: Driver Injection**
-- If enabled, it injects drivers from your current system into `install.wim` — useful for offline installations on machines with missing drivers. This is an optional checkbox in Step 3.
+- If enabled, Winutil injects drivers from your current system into `install.wim` (and setup boot files), which helps when network/internet drivers are not automatically detected during setup or first boot. This is an optional checkbox in Step 3.
 
 ---
 

--- a/docs/content/userguide/win11Creator/_index.md
+++ b/docs/content/userguide/win11Creator/_index.md
@@ -47,7 +47,7 @@ Click **Run Windows ISO Modification and Creator** to start the customization pr
 Winutil will:
 
 > [!IMPORTANT]
-> Keep the PC connected to the internet through first logon so Winutil automation can complete successfully. Internet may also be required during ISO export if `oscdimg.exe` is not already installed.
+> Keep the PC connected to the internet through first logon so Winutil automation can complete successfully.
 
 **ISO Build Actions:**
 - **Copy and prepare ISO contents** in a temporary working directory

--- a/docs/content/userguide/win11Creator/_index.md
+++ b/docs/content/userguide/win11Creator/_index.md
@@ -46,9 +46,6 @@ Winutil includes a built-in **Win11 Creator** tool that lets you take an officia
 Click **Run Windows ISO Modification and Creator** to start the customization process.
 Winutil will:
 
-> [!IMPORTANT]
-> Keep the PC connected to the internet through first logon so Winutil automation can complete successfully.
-
 **ISO Build Actions:**
 - **Copy and prepare ISO contents** in a temporary working directory
 - **Mount your selected edition** from `install.wim`/`install.esd`
@@ -63,6 +60,9 @@ Winutil will:
 - **Run Winutil automation script at first logon** during setup finalization
 - **Apply Winutil's advanced preset after installation** during first-logon setup
 - **Complete setup with an automatic reboot** into a preconfigured desktop
+
+> [!IMPORTANT]
+> Keep the PC connected to the internet through first logon so Winutil automation can complete successfully.
 
 >[!NOTE]
 > To view exactly what advance preset does, see:

--- a/docs/content/userguide/win11Creator/_index.md
+++ b/docs/content/userguide/win11Creator/_index.md
@@ -49,9 +49,6 @@ Once the modification is complete, choose how to save your image:
   2. Choose a save location (defaults to your Desktop as `Win11_Modified_yyyyMMdd.iso`).
   3. Winutil builds a dual BIOS/UEFI bootable ISO using `oscdimg.exe`.
 
-  > [!NOTE]
-  > `oscdimg.exe` (part of the Windows ADK) is required. If it's not found, Winutil will attempt to install it automatically via winget. If that fails, install it manually: `winget install -e --id Microsoft.OSCDIMG`
-
 
   {{< /tab >}}
 

--- a/docs/content/userguide/win11Creator/_index.md
+++ b/docs/content/userguide/win11Creator/_index.md
@@ -39,7 +39,8 @@ Winutil includes a built-in **Win11 Creator** tool that lets you take an officia
 
 ### Step 3 — Run the Modification
 
-Click **Run Windows ISO Modification and Creator** to start the customization process. Winutil will:
+Click **Run Windows ISO Modification and Creator** to start the customization process.
+Winutil will:
 
 **ISO Build Actions:**
 - **Copy and prepare ISO contents** in a temporary working directory
@@ -53,15 +54,17 @@ Click **Run Windows ISO Modification and Creator** to start the customization pr
 
 **Post-OOBE Configuration (First Logon):**
 - **Run Winutil automation script at first logon** during setup finalization
-- **Apply Winutil advance preset after install** instead of baking most tweaks directly into offline `install.wim`
+- **Apply Winutil advance preset after install** instead of baking most tweaks directly into `install.wim`
 - **Complete setup with an automatic reboot** into a preconfigured desktop
-
-**Optional: Driver Injection**
-- If enabled, it injects drivers from your current system into `install.wim` — useful for offline installations on machines with missing drivers. This is an optional checkbox in Step 3.
 
 >[!NOTE]
 > To view exactly what advance preset does, see:
 https://github.com/ChrisTitusTech/winutil/blob/main/config/preset.json
+
+**Optional: Driver Injection**
+- If enabled, it injects drivers from your current system into `install.wim` — useful for offline installations on machines with missing drivers. This is an optional checkbox in Step 3.
+
+
 
 ---
 
@@ -99,17 +102,6 @@ Once the modification is complete, choose how to save your image:
 ### Step 5 — Clean Up (Optional)
 
 Click **Clean & Reset** to delete the temporary working directory (~10–15 GB) and return the tool to its initial state, ready for a new ISO. You will be asked to confirm before anything is deleted.
-
----
-
-### What the Modified ISO Does Differently
-
-When you install Windows 11 from your modified ISO:
-
-- **No Microsoft account required** — create a local account directly during setup
-- **No hardware checks** — installs on machines without TPM 2.0, Secure Boot, or supported CPUs
-- **Dark mode enabled by default**
-- **Empty taskbar and Start Menu** — no pinned apps, Chat icon removed
 
 ---
 

--- a/docs/content/userguide/win11Creator/_index.md
+++ b/docs/content/userguide/win11Creator/_index.md
@@ -37,8 +37,36 @@ Winutil includes a built-in **Win11 Creator** tool that lets you take an officia
 
 ---
 
+### Step 3 — Run the Modification
 
-### Step 3 — Export Your Result
+Click **Run Windows ISO Modification and Creator** to start the customization process. Winutil will:
+
+**ISO Build Actions:**
+- **Copy and prepare ISO contents** in a temporary working directory
+- **Mount your selected edition** from `install.wim`/`install.esd`
+- **Inject `autounattend.xml`** into the ISO root for setup automation
+- **Bypass hardware checks** — TPM, Secure Boot, CPU, RAM, and storage requirement checks are bypassed during setup
+- **Enable local account setup** — skips Microsoft account requirement during OOBE
+- **Strip unused editions** — keeps only your selected edition, saving 1-2 GB per removed edition
+- **Clean the component store** — runs DISM cleanup (`/StartComponentCleanup /ResetBase`) to reduce image size
+- **Remove ISO support files** — deletes the ISO `support` folder
+
+**Post-OOBE Configuration (First Logon):**
+- **Run Winutil automation script at first logon** during setup finalization
+- **Apply Winutil advance preset after install** instead of baking most tweaks directly into offline `install.wim`
+- **Complete setup with an automatic reboot** into a preconfigured desktop
+
+**Optional: Driver Injection**
+- If enabled, it injects drivers from your current system into `install.wim` — useful for offline installations on machines with missing drivers. This is an optional checkbox in Step 3.
+
+>[!NOTE]
+> To view exactly what advance preset does, see:
+https://github.com/ChrisTitusTech/winutil/blob/main/config/preset.json
+
+---
+
+
+### Step 4 — Export Your Result
 
 Once the modification is complete, choose how to save your image:
 
@@ -68,7 +96,7 @@ Once the modification is complete, choose how to save your image:
 
 ---
 
-### Step 4 — Clean Up (Optional)
+### Step 5 — Clean Up (Optional)
 
 Click **Clean & Reset** to delete the temporary working directory (~10–15 GB) and return the tool to its initial state, ready for a new ISO. You will be asked to confirm before anything is deleted.
 


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://winutil.christitus.com/contributing/ -->
<!--Documentation is auto-generated from configs - no manual documentation updates needed -->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [x] Documentation update
- [ ] UI/UX improvement

<!-- This automatically adds labels to your PR based on the selections above. -->

## Description
<!--[What does this PR do? Provide Screenshots when possible.]-->
https://github.com/ChrisTitusTech/winutil/pull/4553 accept gabi pr before u accept this one


This pull request updates the user guide documentation for the Win11 Creator tool in Winutil, focusing on clarifying instructions, restructuring feature descriptions, and streamlining troubleshooting information. The changes improve readability, separate important notes for clarity, and update the explanation of the ISO modification process to better reflect current functionality.

**Documentation improvements and restructuring:**

* Moved the note about unsupported custom or modified ISOs into a highlighted callout for better visibility and removed the file size requirement from the step-by-step instructions.
* Restructured the description of the ISO modification process to clearly separate "ISO Build Actions" from "Post-OOBE Configuration," emphasizing the use of the Winutil automation script and advance preset after installation, and updated the list of actions for accuracy and clarity.
* Removed a redundant note about `oscdimg.exe` installation in the export step, likely because this information is now covered elsewhere or deemed unnecessary.

**Troubleshooting and feature list simplification:**

* Removed the troubleshooting section and some feature details from the end of the guide, streamlining the documentation and focusing on the main workflow.

## Issue related to PR
<!--[List any ISSUES this is related to as it AUTO-CLOSES Them!]-->
- Resolves #
