### PR TITLE
Detect reverted tweaks on launch

### DIFF
--- a/functions/public/Invoke-WPFtweaksbutton.ps1
+++ b/functions/public/Invoke-WPFtweaksbutton.ps1
@@ -82,5 +82,6 @@ function Invoke-WPFtweaksbutton {
     Write-Host "================================="
     Write-Host "--     Tweaks are Finished    ---"
     Write-Host "================================="
+    @($tweaks | Where-Object { $sync.configs.tweaks.$_.registry -or $sync.configs.tweaks.$_.service }) | ConvertTo-Json | Out-File "$env:LocalAppData\winutil\lastrun.json" -Force
   }
 }

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -382,6 +382,17 @@ $sync["Form"].Add_ContentRendered({
         Invoke-WPFTab "WPFTab1BT"  # Default to install tab
     }
 
+    if (-not $PARAM_CONFIG -and (Test-Path "$winutildir\lastrun.json")) {
+        try {
+            $drifted = @(Get-Content "$winutildir\lastrun.json" | ConvertFrom-Json | Where-Object { $_ -notin (Invoke-WinUtilCurrentSystem -CheckBox "tweaks") })
+            if ($drifted.Count -gt 0 -and [System.Windows.MessageBox]::Show("$($drifted.Count) tweak(s) were reverted since last run. Re-select them?", "Winutil", "YesNo", "Question") -eq "Yes") {
+                Update-WinUtilSelections -flatJson $drifted
+                Reset-WPFCheckBoxes -doToggles $false
+                Invoke-WPFTab "WPFTab2BT"
+            }
+        } catch {}
+    }
+
     $sync["Form"].Focus()
 
    if ($PARAM_CONFIG -and -not [string]::IsNullOrWhiteSpace($PARAM_CONFIG)) {


### PR DESCRIPTION
## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] UI/UX improvement

## Description
Detects when applied tweaks get reverted (e.g. by Windows Update) and prompts to re-select them on launch.

- **Minimalist:** Exactly 12 lines added across two files. No new files, functions, or comments.
- **Save State:** Filter-saves applied registry/service tweak IDs to `$env:LocalAppData\winutil\lastrun.json` after running tweaks.
- **Drift Check:** On launch, compares lastrun tweaks with current system state. If changes are detected, it prompts to re-select them on the Tweaks tab.

### Testing / Verification
1. Ran Standard preset to generate a fresh `lastrun.json` save state.
2. Simulated a Windows Update by manually reverting registry keys for multiple active tweaks (e.g., `End Task With Right Click`, `Location Tracking`, and `Telemetry`).
3. Launched utility. It successfully detected all 3 drifted tweaks, displayed the prompt, and automatically checked them on relaunch:

<img width="464" height="211" alt="media__1780004280210" src="https://github.com/user-attachments/assets/ca6c68e1-305e-4871-9c0f-67eba3bd9132" />
<img width="350" height="183" alt="media__1780004297830" src="https://github.com/user-attachments/assets/ba7e3574-e71f-486f-ae89-5b43f6cdf29c" />
