### PR TITLE
fix: add registry tracking to WPFTweaksRightClickMenu for drift detection

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -1088,6 +1088,15 @@
     "Description": "Restores the classic context menu when right-clicking in File Explorer, replacing the simplified Windows 11 version.",
     "category": "z__Advanced Tweaks - CAUTION",
     "panel": "1",
+    "registry": [
+      {
+        "Path": "HKCU:\\Software\\Classes\\CLSID\\{86ca1aa0-34aa-4e8b-a509-50c905bae2a2}\\InprocServer32",
+        "Name": "(default)",
+        "Value": "",
+        "Type": "String",
+        "OriginalValue": "<RemoveEntry>"
+      }
+    ],
     "InvokeScript": [
       "
       New-Item -Path \"HKCU:\\Software\\Classes\\CLSID\\{86ca1aa0-34aa-4e8b-a509-50c905bae2a2}\" -Name \"InprocServer32\" -force -value \"\"

--- a/functions/public/Invoke-WPFtweaksbutton.ps1
+++ b/functions/public/Invoke-WPFtweaksbutton.ps1
@@ -83,10 +83,6 @@ function Invoke-WPFtweaksbutton {
     Write-Host "--     Tweaks are Finished    ---"
     Write-Host "================================="
     $syncableTweaks = @($tweaks | Where-Object { $sync.configs.tweaks.$_.registry -or $sync.configs.tweaks.$_.service })
-    if ($syncableTweaks.Count -gt 0) {
-        $syncableTweaks | ConvertTo-Json | Out-File "$env:LocalAppData\winutil\lastrun.json" -Force
-    } else {
-        Remove-Item "$env:LocalAppData\winutil\lastrun.json" -Force -ErrorAction SilentlyContinue
-    }
+    $syncableTweaks | ConvertTo-Json | Out-File "$env:LocalAppData\winutil\lastrun.json" -Force
   }
 }

--- a/functions/public/Invoke-WPFtweaksbutton.ps1
+++ b/functions/public/Invoke-WPFtweaksbutton.ps1
@@ -82,6 +82,11 @@ function Invoke-WPFtweaksbutton {
     Write-Host "================================="
     Write-Host "--     Tweaks are Finished    ---"
     Write-Host "================================="
-    @($tweaks | Where-Object { $sync.configs.tweaks.$_.registry -or $sync.configs.tweaks.$_.service }) | ConvertTo-Json | Out-File "$env:LocalAppData\winutil\lastrun.json" -Force
+    $syncableTweaks = @($tweaks | Where-Object { $sync.configs.tweaks.$_.registry -or $sync.configs.tweaks.$_.service })
+    if ($syncableTweaks.Count -gt 0) {
+        $syncableTweaks | ConvertTo-Json | Out-File "$env:LocalAppData\winutil\lastrun.json" -Force
+    } else {
+        Remove-Item "$env:LocalAppData\winutil\lastrun.json" -Force -ErrorAction SilentlyContinue
+    }
   }
 }

--- a/functions/public/Invoke-WPFtweaksbutton.ps1
+++ b/functions/public/Invoke-WPFtweaksbutton.ps1
@@ -82,6 +82,6 @@ function Invoke-WPFtweaksbutton {
     Write-Host "================================="
     Write-Host "--     Tweaks are Finished    ---"
     Write-Host "================================="
-    @($tweaks | Where-Object { $sync.configs.tweaks.$_.registry -or $sync.configs.tweaks.$_.service }) | ConvertTo-Json | Out-File "...lastrun.json" -Force
+    @($tweaks | Where-Object { $sync.configs.tweaks.$_.registry -or $sync.configs.tweaks.$_.service }) | ConvertTo-Json | Out-File "$env:LocalAppData\winutil\lastrun.json" -Force
   }
 }

--- a/functions/public/Invoke-WPFtweaksbutton.ps1
+++ b/functions/public/Invoke-WPFtweaksbutton.ps1
@@ -82,7 +82,6 @@ function Invoke-WPFtweaksbutton {
     Write-Host "================================="
     Write-Host "--     Tweaks are Finished    ---"
     Write-Host "================================="
-    $syncableTweaks = @($tweaks | Where-Object { $sync.configs.tweaks.$_.registry -or $sync.configs.tweaks.$_.service })
-    $syncableTweaks | ConvertTo-Json | Out-File "$env:LocalAppData\winutil\lastrun.json" -Force
+    @($tweaks | Where-Object { $sync.configs.tweaks.$_.registry -or $sync.configs.tweaks.$_.service }) | ConvertTo-Json | Out-File "...lastrun.json" -Force
   }
 }


### PR DESCRIPTION
## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] UI/UX improvement

## Description

Adds registry tracking metadata to `WPFTweaksRightClickMenu` so the classic right-click menu tweak can be correctly monitored for drift on startup.

Also worth mentioning — [#4658](https://github.com/ChrisTitusTech/winutil/pull/4658) by [@gepardjaro](https://github.com/gepardjaro) is a great catch on the winget fallback for Copilot removal, and it gave me an idea to extend drift detection to cover AppxPackage state as a follow-up to this PR.

## Verification & Testing

Ran 5 tweaks, reverted them externally, relaunched WinUtil. Exactly 5 flagged, auto-selected, no false warnings on subsequent runs.

## Issue related to PR

- Resolves #