### PR TITLE
New functionality/bug fix: Add support to apply Tweaks for currently logged user, if other Admin elevates winutil + #4600 and #4607

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -71,7 +71,7 @@
       Get-AppxPackage Microsoft.WidgetsPlatformRuntime -AllUsers | Remove-AppxPackage -AllUsers
       Get-AppxPackage MicrosoftWindows.Client.WebExperience -AllUsers | Remove-AppxPackage -AllUsers
 
-      Invoke-WinUtilExplorerUpdate -action \"restart\"
+      Invoke-WinUtilExplorerUpdate -action restart
       Write-Host \"Removed widgets\"
       "
     ],
@@ -567,7 +567,7 @@
       # Disable PowerShell 7 telemetry
       [Environment]::SetEnvironmentVariable('POWERSHELL_TELEMETRY_OPTOUT', '1', 'Machine')
 
-      Remove-ItemProperty -Path \"HKCU:\\Software\\Microsoft\\Siuf\\Rules\" -Name PeriodInNanoSeconds
+      Remove-ItemProperty -Path (Get-WinUtilHKCURedirectPath \"HKCU:\\Software\\Microsoft\\Siuf\\Rules\") -Name PeriodInNanoSeconds
       "
     ],
     "UndoScript": [
@@ -807,10 +807,10 @@
       }
     ],
     "InvokeScript": [
-      "Set-ItemProperty -Path \"HKCU:\\Control Panel\\Desktop\" -Name \"UserPreferencesMask\" -Type Binary -Value ([byte[]](144,18,3,128,16,0,0,0))"
+      "Set-ItemProperty -Path (Get-WinUtilHKCURedirectPath \"HKCU:\\Control Panel\\Desktop\") -Name \"UserPreferencesMask\" -Type Binary -Value ([byte[]](144,18,3,128,16,0,0,0))"
     ],
     "UndoScript": [
-      "Remove-ItemProperty -Path \"HKCU:\\Control Panel\\Desktop\" -Name \"UserPreferencesMask\""
+      "Remove-ItemProperty -Path (Get-WinUtilHKCURedirectPath \"HKCU:\\Control Panel\\Desktop\") -Name \"UserPreferencesMask\""
     ],
     "link": "https://winutil.christitus.com/dev/tweaks/z--advanced-tweaks---caution/display"
   },
@@ -1090,17 +1090,13 @@
     "panel": "1",
     "InvokeScript": [
       "
-      New-Item -Path \"HKCU:\\Software\\Classes\\CLSID\\{86ca1aa0-34aa-4e8b-a509-50c905bae2a2}\" -Name \"InprocServer32\" -force -value \"\"
-      Write-Host Restarting explorer.exe ...
-      Stop-Process -Name \"explorer\" -Force
+      New-Item -Path (Get-WinUtilHKCURedirectPath \"HKCU:\\Software\\Classes\\CLSID\\{86ca1aa0-34aa-4e8b-a509-50c905bae2a2}\\InprocServer32\") -Value '' -Force
+      Invoke-WinUtilExplorerUpdate -action restart
       "
     ],
     "UndoScript": [
       "
-      Remove-Item -Path \"HKCU:\\Software\\Classes\\CLSID\\{86ca1aa0-34aa-4e8b-a509-50c905bae2a2}\" -Recurse -Confirm:$false -Force
-      # Restarting Explorer in the Undo Script might not be necessary, as the Registry change without restarting Explorer does work, but just to make sure.
-      Write-Host Restarting explorer.exe ...
-      Stop-Process -Name \"explorer\" -Force
+      Remove-Item -Path (Get-WinUtilHKCURedirectPath \"HKCU:\\Software\\Classes\\CLSID\\{86ca1aa0-34aa-4e8b-a509-50c905bae2a2}\") -Recurse
       "
     ],
     "link": "https://winutil.christitus.com/dev/tweaks/z--advanced-tweaks---caution/rightclickmenu"
@@ -1231,10 +1227,10 @@
     "InvokeScript": [
       "
       # Previously detected folders
-      $bags = \"HKCU:\\Software\\Classes\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\Bags\"
+      $bags = (Get-WinUtilHKCURedirectPath \"HKCU:\\Software\\Classes\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\Bags\")
 
       # Folder types lookup table
-      $bagMRU = \"HKCU:\\Software\\Classes\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\BagMRU\"
+      $bagMRU = (Get-WinUtilHKCURedirectPath \"HKCU:\\Software\\Classes\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\BagMRU\")
 
       # Flush Explorer view database
       Remove-Item -Path $bags -Recurse -Force
@@ -1244,7 +1240,7 @@
       Write-Host \"Removed $bagMRU\"
 
       # Every folder
-      $allFolders = \"HKCU:\\Software\\Classes\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\Bags\\AllFolders\\Shell\"
+      $allFolders = (Get-WinUtilHKCURedirectPath \"HKCU:\\Software\\Classes\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\Bags\\AllFolders\\Shell\")
 
       if (!(Test-Path $allFolders)) {
         New-Item -Path $allFolders -Force
@@ -1261,10 +1257,10 @@
     "UndoScript": [
       "
       # Previously detected folders
-      $bags = \"HKCU:\\Software\\Classes\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\Bags\"
+      $bags = (Get-WinUtilHKCURedirectPath \"HKCU:\\Software\\Classes\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\Bags\")
 
       # Folder types lookup table
-      $bagMRU = \"HKCU:\\Software\\Classes\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\BagMRU\"
+      $bagMRU = (Get-WinUtilHKCURedirectPath \"HKCU:\\Software\\Classes\\Local Settings\\Software\\Microsoft\\Windows\\Shell\\BagMRU\")
 
       # Flush Explorer view database
       Remove-Item -Path $bags -Recurse -Force
@@ -1381,14 +1377,10 @@
       }
     ],
     "InvokeScript": [
-      "
-      Invoke-WinUtilExplorerUpdate -action \"restart\"
-      "
+      "Invoke-WinUtilExplorerUpdate"
     ],
     "UndoScript": [
-      "
-      Invoke-WinUtilExplorerUpdate -action \"restart\"
-      "
+      "Invoke-WinUtilExplorerUpdate"
     ],
     "link": "https://winutil.christitus.com/dev/tweaks/customize-preferences/showext"
   },
@@ -1409,14 +1401,10 @@
       }
     ],
     "InvokeScript": [
-      "
-      Invoke-WinUtilExplorerUpdate -action \"restart\"
-      "
+      "Invoke-WinUtilExplorerUpdate"
     ],
     "UndoScript": [
-      "
-      Invoke-WinUtilExplorerUpdate -action \"restart\"
-      "
+      "Invoke-WinUtilExplorerUpdate"
     ],
     "link": "https://winutil.christitus.com/dev/tweaks/customize-preferences/hiddenfiles"
   },
@@ -1708,14 +1696,10 @@
       }
     ],
     "InvokeScript": [
-      "
-      Invoke-WinUtilExplorerUpdate -action \"restart\"
-      "
+      "Invoke-WinUtilExplorerUpdate -action restart"
     ],
     "UndoScript": [
-      "
-      Invoke-WinUtilExplorerUpdate -action \"restart\"
-      "
+      "Invoke-WinUtilExplorerUpdate -action restart"
     ],
     "link": "https://winutil.christitus.com/dev/tweaks/customize-preferences/startmenurecommendations"
   },
@@ -1754,14 +1738,10 @@
       }
     ],
     "InvokeScript": [
-      "
-      Invoke-WinUtilExplorerUpdate -action \"restart\"
-      "
+      "Invoke-WinUtilExplorerUpdate"
     ],
     "UndoScript": [
-      "
-      Invoke-WinUtilExplorerUpdate -action \"restart\"
-      "
+      "Invoke-WinUtilExplorerUpdate"
     ],
     "link": "https://winutil.christitus.com/dev/tweaks/customize-preferences/taskbaralignment"
   },

--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -1738,10 +1738,10 @@
       }
     ],
     "InvokeScript": [
-      "Invoke-WinUtilExplorerUpdate"
+      "Invoke-WinUtilExplorerUpdate -action restart"
     ],
     "UndoScript": [
-      "Invoke-WinUtilExplorerUpdate"
+      "Invoke-WinUtilExplorerUpdate -action restart"
     ],
     "link": "https://winutil.christitus.com/dev/tweaks/customize-preferences/taskbaralignment"
   },

--- a/functions/private/Get-WinUtilExplorerOwner.ps1
+++ b/functions/private/Get-WinUtilExplorerOwner.ps1
@@ -1,0 +1,32 @@
+function Get-WinUtilExplorerOwner {
+    <#
+
+    .SYNOPSIS
+        Lists each running explorer.exe process paired with the SID of its owning user.
+
+    .DESCRIPTION
+        Enumerates explorer.exe via CIM and resolves each process owner to a SID, emitting one
+        object ({ ProcessId, Sid }) per process whose owner resolves. Used to identify the interactive
+        user's shell (Get-WinUtilInteractiveUserSid) and to restart only that user's Explorer
+        (Restart-WinUtilExplorer). A CIM enumeration failure is allowed to propagate so callers can
+        fall back; processes whose owner cannot be resolved are skipped.
+
+    #>
+
+    $explorers = Get-CimInstance -ClassName Win32_Process -Filter "Name = 'explorer.exe'" -ErrorAction Stop
+    foreach ($proc in $explorers) {
+        $owner = Invoke-CimMethod -InputObject $proc -MethodName GetOwner -ErrorAction SilentlyContinue
+        if ($owner -and $owner.ReturnValue -eq 0 -and $owner.User) {
+            $account = if ($owner.Domain) { "$($owner.Domain)\$($owner.User)" } else { $owner.User }
+            try {
+                $sid = ([System.Security.Principal.NTAccount]$account).Translate([System.Security.Principal.SecurityIdentifier]).Value
+            } catch {
+                continue
+            }
+            [PSCustomObject]@{
+                ProcessId = $proc.ProcessId
+                Sid       = $sid
+            }
+        }
+    }
+}

--- a/functions/private/Get-WinUtilHKCURedirectPath.ps1
+++ b/functions/private/Get-WinUtilHKCURedirectPath.ps1
@@ -1,0 +1,52 @@
+function Get-WinUtilHKCURedirectPath {
+    <#
+
+    .SYNOPSIS
+        Redirects a HKCU registry path to the interactive user's hive when WinUtil is elevated as a different account.
+
+    .DESCRIPTION
+        Returns the path unchanged unless all of the following hold: the path targets HKCU, the interactive user's
+        SID is known and differs from the elevated process user, and that user's hive is loaded under HKEY_USERS.
+        In that case the path is rewritten to the interactive user's hive so the tweak is applied to the logged-in user.
+        Paths under Software\Classes are mapped to the user's separate classes hive (HKEY_USERS\<SID>_Classes).
+
+    .PARAMETER Path
+        The registry path to evaluate.
+
+    #>
+
+    param (
+        [Parameter(Mandatory)]
+        [string]$Path
+    )
+
+    if ($Path -notmatch '^(HKCU:|HKEY_CURRENT_USER)\\') {
+        return $Path
+    }
+
+    $sid = Get-WinUtilInteractiveUserSid
+    if (-not $sid) {
+        return $Path
+    }
+
+    if (([System.Security.Principal.WindowsIdentity]::GetCurrent()).User.Value -eq $sid) {
+        return $Path
+    }
+
+    $subPath = $Path -replace '^(HKCU:|HKEY_CURRENT_USER)\\', ''
+
+    if ($subPath -match '^Software\\Classes\\(.*)$') {
+        $classesHive = "Registry::HKEY_USERS\${sid}_Classes"
+        if (Test-Path $classesHive) {
+            return "$classesHive\$($matches[1])"
+        }
+        return $Path
+    }
+
+    $userHive = "Registry::HKEY_USERS\$sid"
+    if (-not (Test-Path $userHive)) {
+        return $Path
+    }
+
+    return "$userHive\$subPath"
+}

--- a/functions/private/Get-WinUtilInteractiveUserSid.ps1
+++ b/functions/private/Get-WinUtilInteractiveUserSid.ps1
@@ -1,0 +1,48 @@
+function Get-WinUtilInteractiveUserSid {
+    <#
+
+    .SYNOPSIS
+        Returns the SID of the currently logged-in interactive (console) user.
+
+    .DESCRIPTION
+        When WinUtil is elevated with a different account than the logged-in user (over-the-shoulder UAC),
+        this resolves the SID of the interactive user so HKCU tweaks can target the correct hive.
+        Prefers the console user reported by Win32_ComputerSystem; falls back to the owner of explorer.exe
+        only when a single interactive shell is present, to avoid guessing on multi-session hosts.
+        Returns $null when no interactive user can be unambiguously determined. The result is cached only
+        once a real SID is found, so a transient detection failure is retried on the next call.
+
+    #>
+
+    if ($script:WinUtilInteractiveUserSidResolved) {
+        return $script:WinUtilInteractiveUserSid
+    }
+
+    $sid = $null
+
+    try {
+        $userName = (Get-CimInstance -ClassName Win32_ComputerSystem -ErrorAction Stop).UserName
+        if ($userName) {
+            $sid = ([System.Security.Principal.NTAccount]$userName).Translate([System.Security.Principal.SecurityIdentifier]).Value
+        }
+    } catch {
+        $sid = $null
+    }
+
+    if (-not $sid) {
+        try {
+            $distinct = @(Get-WinUtilExplorerOwner | Select-Object -ExpandProperty Sid -Unique)
+            if ($distinct.Count -eq 1) {
+                $sid = $distinct[0]
+            }
+        } catch {
+            $sid = $null
+        }
+    }
+
+    if ($sid) {
+        $script:WinUtilInteractiveUserSid = $sid
+        $script:WinUtilInteractiveUserSidResolved = $true
+    }
+    return $sid
+}

--- a/functions/private/Get-WinUtilToggleStatus.ps1
+++ b/functions/private/Get-WinUtilToggleStatus.ps1
@@ -8,11 +8,9 @@ Function Get-WinUtilToggleStatus ($ToggleSwitch) {
 
     foreach ($regentry in $ToggleSwitchReg) {
 
-        if (-not (Test-Path $regentry.Path)) {
-            New-Item -Path $regentry.Path -Force | Out-Null
-        }
+        $regPath = Get-WinUtilHKCURedirectPath -Path $regentry.Path
 
-        $regstate = (Get-ItemProperty -Path $regentry.Path).$($regentry.Name)
+        $regstate = (Get-ItemProperty -Path $regPath -ErrorAction SilentlyContinue).$($regentry.Name)
 
         if ($null -eq $regstate) {
             switch ($regentry.DefaultState) {

--- a/functions/private/Invoke-WinUtilCurrentSystem.ps1
+++ b/functions/private/Invoke-WinUtilCurrentSystem.ps1
@@ -70,9 +70,10 @@ Function Invoke-WinUtilCurrentSystem {
                         Foreach ($tweak in $tweaks) {
                             $registryTotal++
                             $regstate = $null
+                            $tweakPath = Get-WinUtilHKCURedirectPath -Path $tweak.Path
 
-                            if (Test-Path $tweak.Path) {
-                                $regstate = Get-ItemProperty -Name $tweak.Name -Path $tweak.Path -ErrorAction SilentlyContinue | Select-Object -ExpandProperty $($tweak.Name)
+                            if (Test-Path $tweakPath) {
+                                $regstate = Get-ItemProperty -Name $tweak.Name -Path $tweakPath -ErrorAction SilentlyContinue | Select-Object -ExpandProperty $($tweak.Name)
                             }
 
                             if ($null -eq $regstate) {

--- a/functions/private/Invoke-WinUtilExplorerUpdate.ps1
+++ b/functions/private/Invoke-WinUtilExplorerUpdate.ps1
@@ -27,12 +27,18 @@ public class Win32 {
             $WM_SETTINGCHANGE = 0x1A
             $SMTO_ABORTIFHUNG = 0x2
 
+            # Send a Broadcast Message to tell the Explorer that the Theme has changed
             [Win32]::SendMessageTimeout($HWND_BROADCAST, $WM_SETTINGCHANGE,
                 [IntPtr]::Zero, "ImmersiveColorSet", $SMTO_ABORTIFHUNG, 100,
                 [ref]([IntPtr]::Zero))
+
+            # Refresh the configuration for all open Explorer instances
+            $shell = New-Object -ComObject Shell.Application
+            foreach ($window in $shell.Windows()) {
+                $window.Refresh()
+            }
         }
     } elseif ($action -eq "restart") {
-        taskkill.exe /F /IM "explorer.exe"
-        Start-Process "explorer.exe"
+        Restart-WinUtilExplorer
     }
 }

--- a/functions/private/Restart-WinUtilExplorer.ps1
+++ b/functions/private/Restart-WinUtilExplorer.ps1
@@ -1,0 +1,31 @@
+function Restart-WinUtilExplorer {
+    <#
+
+    .SYNOPSIS
+        Restarts Windows Explorer so shell changes apply without a re-login.
+
+    .DESCRIPTION
+        When WinUtil is elevated as a different account than the interactive (console) user, only that user's
+        explorer.exe is stopped so Winlogon respawns the shell in their session; starting explorer from the
+        elevated context would not produce a working shell. Otherwise the shell is restarted the usual way for
+        the current session.
+
+    #>
+
+    $sid = Get-WinUtilInteractiveUserSid
+    $currentSid = ([System.Security.Principal.WindowsIdentity]::GetCurrent()).User.Value
+
+    if ($sid -and $sid -ne $currentSid) {
+        try {
+            Get-WinUtilExplorerOwner | Where-Object { $_.Sid -eq $sid } | ForEach-Object {
+                Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue
+            }
+        } catch {
+            taskkill.exe /F /IM "explorer.exe"
+            Start-Process "explorer.exe"
+        }
+    } else {
+        taskkill.exe /F /IM "explorer.exe"
+        Start-Process "explorer.exe"
+    }
+}

--- a/functions/private/Set-WinUtilRegistry.ps1
+++ b/functions/private/Set-WinUtilRegistry.ps1
@@ -1,54 +1,23 @@
-function Set-WinUtilRegistry {
-    <#
+function Set-WinUtilRegistry ($Name, $Path, $Type, $Value) {
+    if (-not (Get-PSDrive -Name HKU)) {
+        New-PSDrive -PSProvider Registry -Name HKU -Root HKEY_USERS | Out-Null
+    }
 
-    .SYNOPSIS
-        Modifies the registry based on the given inputs
+    $Path = Get-WinUtilHKCURedirectPath -Path $Path
 
-    .PARAMETER Name
-        The name of the key to modify
-
-    .PARAMETER Path
-        The path to the key
-
-    .PARAMETER Type
-        The type of value to set the key to
-
-    .PARAMETER Value
-        The value to set the key to
-
-    .EXAMPLE
-        Set-WinUtilRegistry -Name "PublishUserActivities" -Path "HKLM:\SOFTWARE\Policies\Microsoft\Windows\System" -Type "DWord" -Value "0"
-
-    #>
-    param (
-        $Name,
-        $Path,
-        $Type,
-        $Value
-    )
+    if (-not (Test-Path $Path)) {
+        Write-Host "$Path was not found. Creating..."
+        New-Item -Path $Path -Force -ErrorAction Stop | Out-Null
+    }
 
     try {
-        if(!(Test-Path 'HKU:\')) {New-PSDrive -PSProvider Registry -Name HKU -Root HKEY_USERS}
-
-        If (!(Test-Path $Path)) {
-            Write-Host "$Path was not found. Creating..."
-            New-Item -Path $Path -Force -ErrorAction Stop | Out-Null
-        }
-
         if ($Value -ne "<RemoveEntry>") {
             Write-Host "Set $Path\$Name to $Value"
             Set-ItemProperty -Path $Path -Name $Name -Type $Type -Value $Value -Force -ErrorAction Stop | Out-Null
-        }
-        else{
+        } else {
             Write-Host "Remove $Path\$Name"
             Remove-ItemProperty -Path $Path -Name $Name -Force -ErrorAction Stop | Out-Null
         }
-    } catch [System.Security.SecurityException] {
-        Write-Warning "Unable to set $Path\$Name to $Value due to a Security Exception."
-    } catch [System.Management.Automation.ItemNotFoundException] {
-        Write-Warning $psitem.Exception.ErrorRecord
-    } catch [System.UnauthorizedAccessException] {
-       Write-Warning $psitem.Exception.Message
     } catch {
         Write-Warning "Unable to set $Name due to unhandled exception."
         Write-Warning $psitem.Exception.StackTrace

--- a/functions/private/Set-WinUtilRegistry.ps1
+++ b/functions/private/Set-WinUtilRegistry.ps1
@@ -1,5 +1,5 @@
 function Set-WinUtilRegistry ($Name, $Path, $Type, $Value) {
-    if (-not (Get-PSDrive -Name HKU)) {
+    if (-not (Get-PSDrive -Name HKU -ErrorAction SilentlyContinue)) {
         New-PSDrive -PSProvider Registry -Name HKU -Root HKEY_USERS | Out-Null
     }
 


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://winutil.christitus.com/contributing/ -->
<!--Documentation is auto-generated from configs - no manual documentation updates needed -->

## Type of Change
- [X] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] UI/UX improvement

<!-- This automatically adds labels to your PR based on the selections above. -->

## Description
<!--[What does this PR do? Provide Screenshots when possible.]-->
Added new functionality to support winutil Tweaks tab, when other elevated User opened WinUtil as Admin (typical corpo scenario for non-admin users or people that don't want to have local admin on the same account). Also it fixes the issue: Non-admin accounts don't get the same tweaks from admin account https://github.com/ChrisTitusTech/winutil/issues/4637
it was caused by writing to HKCU of the elevated admin account, not logged in user

- I also added-forward the changes from below opened PRs as they would break my PR, when merged (and I believe they will): 
https://github.com/ChrisTitusTech/winutil/pull/4600
https://github.com/ChrisTitusTech/winutil/pull/4607 
- Also fixed-forward https://github.com/ChrisTitusTech/winutil/pull/4600 Gabi's missing -EA SilentlyContinue
- Also fixed-forward https://github.com/ChrisTitusTech/winutil/pull/4607 2 typos and bring back restart for Tweak Taskbar Centered Icons as it's needed

**New helpers:**
- Get-WinUtilInteractiveUserSid.ps1 -  resolves the interactive (console) user's SID; caches on success only
- Get-WinUtilHKCURedirectPath.ps1 -  rewrites HKCU to HKU and Software\Classes to <SID>_Classes when elevated as a different user, returns path unchanged otherwise
- Get-WinUtilExplorerOwner.ps1 - enumerates explorer.exe processes and brings ProcessId, Sid per resolved owner
- Restart-WinUtilExplorer.ps1 -  stops only the interactive user's Explorer. falls back to taskkill for the same-user/failure

**Changed:**
- Set-WinUtilRegistry.ps1 - routes apply + undo paths through the HKCU redirect
- Get-WinUtilToggleStatus.ps1 - redirects path. reads via Get-ItemProperty -ErrorAction SilentlyContinue
- Invoke-WinUtilCurrentSystem.ps1 - redirects path for startup "already applied?" detection
- Invoke-WinUtilExplorerUpdate.ps1 -  "restart" branch now delegates to Restart-WinUtilExplorer
- config/tweaks.json - wraps inline HKCU writes in `Get-WinUtilHKCURedirectPath` (Telemetry, Display, RightClickMenu, DisableExplorerAutoDiscovery).

I tested it and works fine

## Issue related to PR
<!--[List any ISSUES this is related to as it AUTO-CLOSES Them!]-->
- Resolves #4637
