### PR TITLE
Tweak/WindowsAI added winget uninstall Copilot for machines that Copilot is back after Windows Updates

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -966,9 +966,9 @@
       New-Item \"HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Appx\\AppxAllUserStore\\EndOfLife\\$Sid\\$Appx\" -Force
 
       Get-AppxPackage -AllUsers *Copilot* | Remove-AppxPackage -AllUsers
+      winget uninstall -e --name \"Copilot\" --silent --force --accept-source-agreements 2>$null      
       Get-AppxPackage -AllUsers Microsoft.MicrosoftOfficeHub | Remove-AppxPackage -AllUsers
       Remove-AppxPackage $Appx
-      winget uninstall -e --name \"Copilot\" --silent --force --accept-source-agreements 2>$null
 
       Set-Service -Name WSAIFabricSvc -StartupType Disabled
       Disable-WindowsOptionalFeature -FeatureName Recall -Online

--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -968,6 +968,7 @@
       Get-AppxPackage -AllUsers *Copilot* | Remove-AppxPackage -AllUsers
       Get-AppxPackage -AllUsers Microsoft.MicrosoftOfficeHub | Remove-AppxPackage -AllUsers
       Remove-AppxPackage $Appx
+      winget uninstall -e --name \"Copilot\" --silent --force --accept-source-agreements 2>$null
 
       Set-Service -Name WSAIFabricSvc -StartupType Disabled
       Disable-WindowsOptionalFeature -FeatureName Recall -Online


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://winutil.christitus.com/contributing/ -->
<!--Documentation is auto-generated from configs - no manual documentation updates needed -->

## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] UI/UX improvement

<!-- This automatically adds labels to your PR based on the selections above. -->

## Description
<!--[What does this PR do? Provide Screenshots when possible.]-->
added winget uninstall Copilot as Remove-AppxPackage is not working when Copilot is installed back after Windows Updates and the only option that works is using winget. This happens for 25H2 for sure
I tested it

## Issue related to PR
<!--[List any ISSUES this is related to as it AUTO-CLOSES Them!]-->
- Resolves #
