### PR TITLE
Fix devdocs generator mis-placing link / failing on inconsistent indentation + pester update to railguard this

### DIFF
--- a/pester/devdocs-generator.Tests.ps1
+++ b/pester/devdocs-generator.Tests.ps1
@@ -1,0 +1,131 @@
+#===========================================================================
+# Tests - devdocs-generator (Add-LinkAttributeToJson)
+#===========================================================================
+# Regression test for the "link" placement bug (re-fixes #4528 durably): the
+# generator must always update/insert each item's top-level "link" and never
+# place one inside a nested registry block, regardless of indentation or of
+# braces appearing inside string values.
+Describe "devdocs-generator Add-LinkAttributeToJson" {
+    BeforeAll {
+        # Dot-sourcing loads the functions only; the script's run-guard skips the
+        # generation pipeline so this stays a fast, side-effect-free unit test.
+        . "$PSScriptRoot/../tools/devdocs-generator.ps1"
+
+        $script:cut    = 'WPF(WinUtil|Toggle|Features?|Tweaks?|Panel|Fix(es)?)?'
+        $script:prefix = 'https://example/dev/tweaks'
+
+        # Fixture covering the three tricky cases:
+        #  - WPFToggleScrollbars : key indented deeper than its siblings (the real bug),
+        #                          plus an existing top-level link that must be UPDATED.
+        #  - WPFTweakBraces      : has { and } INSIDE a multi-line string value, which must
+        #                          not be mistaken for structural braces.
+        #  - WPFTweakNoLink      : has NO link yet and must get one INSERTED.
+        $script:fixture = @'
+{
+    "WPFToggleScrollbars": {
+    "Content": "Scrollbars",
+    "category": "Customize Preferences",
+    "registry": [
+      {
+        "Path": "HKCU:\\Control Panel",
+        "DefaultState": "false"
+      }
+    ],
+    "link": "https://OLD/x"
+  },
+  "WPFTweakBraces": {
+    "Content": "Braces",
+    "category": "Essential Tweaks",
+    "InvokeScript": [
+      "if ($true) { Write-Host '}' } else { Write-Host '{' }"
+    ],
+    "link": "https://OLD/y"
+  },
+  "WPFTweakNoLink": {
+    "Content": "NoLink",
+    "category": "Essential Tweaks",
+    "registry": [
+      {
+        "Path": "HKLM:\\X",
+        "DefaultState": "true"
+      }
+    ]
+  }
+}
+'@
+    }
+
+    BeforeEach {
+        $script:tmp = Join-Path $TestDrive 'fixture.json'
+        Set-Content -Path $tmp -Value $fixture -Encoding utf8
+        Add-LinkAttributeToJson -JsonFilePath $tmp -UrlPrefix $prefix -ItemNameToCut $cut
+        $script:result = Get-Content -Path $tmp -Raw | ConvertFrom-Json
+    }
+
+    It "produces valid JSON" {
+        { Get-Content -Path $tmp -Raw | ConvertFrom-Json } | Should -Not -Throw
+    }
+
+    It "never places a link inside a registry block" {
+        @($result.PSObject.Properties.Value.registry.link | Where-Object { $_ }).Count | Should -Be 0
+    }
+
+    It "updates an existing top-level link in place, even when the key is mis-indented" {
+        $result.WPFToggleScrollbars.link | Should -Be "$prefix/customize-preferences/scrollbars"
+    }
+
+    It "is not fooled by braces inside string values" {
+        $result.WPFTweakBraces.link | Should -Be "$prefix/essential-tweaks/braces"
+    }
+
+    It "inserts a link when one is missing" {
+        $result.WPFTweakNoLink.link | Should -Be "$prefix/essential-tweaks/nolink"
+    }
+
+    It "is idempotent (a second run changes nothing)" {
+        $before = Get-Content -Path $tmp -Raw
+        Add-LinkAttributeToJson -JsonFilePath $tmp -UrlPrefix $prefix -ItemNameToCut $cut
+        Get-Content -Path $tmp -Raw | Should -Be $before
+    }
+}
+
+Describe "devdocs-generator Get-RawJsonBlock" {
+    BeforeAll {
+        . "$PSScriptRoot/../tools/devdocs-generator.ps1"
+    }
+
+    It "finds the closing brace even when the item key is mis-indented" {
+        $lines = (@'
+{
+    "WPFToggleScrollbars": {
+    "Content": "Scrollbars",
+    "registry": [
+      { "Path": "HKCU:\\Control Panel" }
+    ],
+    "link": "https://OLD"
+  },
+  "WPFNext": { "Content": "n" }
+}
+'@) -split '\r?\n'
+        $block = Get-RawJsonBlock -ItemName 'WPFToggleScrollbars' -JsonLines $lines
+        $block         | Should -Not -BeNullOrEmpty
+        $block.RawText | Should -Match 'Control Panel'
+        $block.RawText | Should -Not -Match '"link"'   # trailing link is stripped
+    }
+
+    It "is not fooled by braces inside string values" {
+        $lines = (@'
+{
+  "WPFTweakBraces": {
+    "InvokeScript": [
+      "if ($true) { Write-Host '}' } else { }"
+    ]
+  },
+  "WPFNext": { "Content": "n" }
+}
+'@) -split '\r?\n'
+        $block = Get-RawJsonBlock -ItemName 'WPFTweakBraces' -JsonLines $lines
+        $block         | Should -Not -BeNullOrEmpty
+        $block.RawText | Should -Match 'InvokeScript'
+    }
+}

--- a/tools/devdocs-generator.ps1
+++ b/tools/devdocs-generator.ps1
@@ -27,12 +27,10 @@ function Get-RawJsonBlock {
 
     $escapedName = [regex]::Escape($ItemName)
     $startIndex  = -1
-    $startIndent = ""
 
     for ($i = 0; $i -lt $JsonLines.Count; $i++) {
-        if ($JsonLines[$i] -match "^(\s*)`"$escapedName`"\s*:\s*\{") {
-            $startIndex  = $i
-            $startIndent = $matches[1]
+        if ($JsonLines[$i] -match "^\s*`"$escapedName`"\s*:\s*\{") {
+            $startIndex = $i
             break
         }
     }
@@ -42,13 +40,29 @@ function Get-RawJsonBlock {
         return $null
     }
 
-    $escapedIndent = [regex]::Escape($startIndent)
-    $endIndex      = -1
-    for ($i = ($startIndex + 1); $i -lt $JsonLines.Count; $i++) {
-        if ($JsonLines[$i] -match "^$escapedIndent\}") {
-            $endIndex = $i
-            break
+    # Find the item's own closing brace by string-aware brace matching from the opening
+    # "{" on the start line: count "{"/"}" but ignore any that appear inside quoted string
+    # values. This is immune to inconsistent indentation and to braces inside multi-line
+    # InvokeScript/UndoScript values.
+    $depth    = 0
+    $inString = $false
+    $escaped  = $false
+    $endIndex = -1
+    for ($i = $startIndex; $i -lt $JsonLines.Count; $i++) {
+        foreach ($ch in $JsonLines[$i].ToCharArray()) {
+            if ($inString) {
+                if     ($escaped)    { $escaped = $false }
+                elseif ($ch -eq '\') { $escaped = $true }
+                elseif ($ch -eq '"') { $inString = $false }
+            }
+            elseif ($ch -eq '"') { $inString = $true }
+            elseif ($ch -eq '{') { $depth++ }
+            elseif ($ch -eq '}') {
+                $depth--
+                if ($depth -eq 0) { $endIndex = $i; break }
+            }
         }
+        if ($endIndex -ne -1) { break }
     }
 
     if ($endIndex -eq -1) {
@@ -104,58 +118,67 @@ function Add-LinkAttributeToJson {
     $jsonData = Get-Content -Path $JsonFilePath -Raw | ConvertFrom-Json
     $lines    = [System.Collections.Generic.List[string]](Get-Content -Path $JsonFilePath)
 
+    # Pre-scan: record the start line of every top-level item by its KNOWN name.
+    # Item names are unique top-level keys, so matching by name never collides with a
+    # brace/key that appears inside a string value (e.g. multi-line InvokeScript/UndoScript).
+    $itemStartIdx = @{}
+    foreach ($item in $jsonData.PSObject.Properties) {
+        $escapedName = [regex]::Escape($item.Name)
+        for ($i = 0; $i -lt $lines.Count; $i++) {
+            if ($lines[$i] -match "^\s*`"$escapedName`"\s*:\s*\{") {
+                $itemStartIdx[$item.Name] = $i
+                break
+            }
+        }
+    }
+    $sortedStarts = @($itemStartIdx.Values | Sort-Object)
+
+    # Root closing brace = the last zero-indent "}" line. Used to bound the final item
+    # so its boundary scan never grabs the root object's brace.
+    $rootCloseIdx = $lines.Count
+    for ($i = $lines.Count - 1; $i -ge 0; $i--) {
+        if ($lines[$i] -match '^\}\s*$') { $rootCloseIdx = $i; break }
+    }
+
     foreach ($item in $jsonData.PSObject.Properties) {
         $itemName    = $item.Name
         $category    = $item.Value.category -replace '[^a-zA-Z0-9]', '-'
         $displayName = $itemName -replace $ItemNameToCut, ''
         $newLink     = "$UrlPrefix/$($category.ToLower())/$($displayName.ToLower())"
-        $escapedName = [regex]::Escape($itemName)
 
-        # Find item start line
-        $startIdx = -1
-        for ($i = 0; $i -lt $lines.Count; $i++) {
-            if ($lines[$i] -match "^\s*`"$escapedName`"\s*:\s*\{") {
-                $startIdx = $i
-                break
-            }
+        if (-not $itemStartIdx.ContainsKey($itemName)) { continue }
+        $startIdx = $itemStartIdx[$itemName]
+
+        # Boundary = the next item's start line, or the root closing brace for the last item.
+        $boundary = $rootCloseIdx
+        foreach ($s in $sortedStarts) {
+            if ($s -gt $startIdx) { $boundary = $s; break }
         }
-        if ($startIdx -eq -1) { continue }
 
-        # Derive indentation: propIndent is one level deeper than the item start.
-        # Used to target only top-level properties and skip nested object braces.
-        $null          = $lines[$startIdx] -match '^(\s*)'
-        $propIndent    = $matches[1] + '  '
-        $propIndentLen = $propIndent.Length
-        $escapedPropIndent = [regex]::Escape($propIndent)
-
-        # Scan forward: update existing "link" or find the closing brace to insert one.
-        # Closing brace is matched by indent <= propIndentLen to handle inconsistent formatting.
-        $linkUpdated   = $false
+        # The item's OWN closing brace = the last "}"/"}," line strictly before the boundary.
+        # We never count braces, so nested objects and braces inside strings are irrelevant.
         $closeBraceIdx = -1
-        for ($j = $startIdx + 1; $j -lt $lines.Count; $j++) {
-            if ($lines[$j] -match "^$escapedPropIndent`"link`"\s*:") {
-                $lines[$j] = $lines[$j] -replace '"link"\s*:\s*"[^"]*"', "`"link`": `"$newLink`""
-                $linkUpdated = $true
-                break
-            }
-            if ($lines[$j] -match '^\s*\}') {
-                $null = $lines[$j] -match '^(\s*)'
-                if ($matches[1].Length -le $propIndentLen) {
-                    $closeBraceIdx = $j
-                    break
-                }
-            }
+        for ($j = $boundary - 1; $j -gt $startIdx; $j--) {
+            if ($lines[$j] -match '^\s*\},?\s*$') { $closeBraceIdx = $j; break }
         }
+        if ($closeBraceIdx -eq -1) { continue }
 
-        if (-not $linkUpdated -and $closeBraceIdx -ne -1) {
-            # Insert "link" before the closing brace
-            $prevPropIdx = $closeBraceIdx - 1
-            while ($prevPropIdx -gt $startIdx -and $lines[$prevPropIdx].Trim() -eq '') { $prevPropIdx-- }
+        # The top-level "link", if any, is the property immediately before that brace
+        # (skipping blank lines). Update it in place; otherwise insert a new one.
+        $prevIdx = $closeBraceIdx - 1
+        while ($prevIdx -gt $startIdx -and $lines[$prevIdx].Trim() -eq '') { $prevIdx-- }
 
-            if ($lines[$prevPropIdx] -notmatch ',\s*$') {
-                $lines[$prevPropIdx] = $lines[$prevPropIdx].TrimEnd() + ','
+        if ($lines[$prevIdx] -match '"link"\s*:') {
+            $lines[$prevIdx] = $lines[$prevIdx] -replace '"link"\s*:\s*"[^"]*"', "`"link`": `"$newLink`""
+        }
+        else {
+            if ($lines[$prevIdx] -notmatch ',\s*$') {
+                $lines[$prevIdx] = $lines[$prevIdx].TrimEnd() + ','
             }
-            $lines.Insert($closeBraceIdx, "$propIndent`"link`": `"$newLink`"")
+            # Indent the new "link" two spaces deeper than its closing brace.
+            $null       = $lines[$closeBraceIdx] -match '^(\s*)'
+            $linkIndent = $matches[1] + '  '
+            $lines.Insert($closeBraceIdx, "$linkIndent`"link`": `"$newLink`"")
         }
     }
 
@@ -165,6 +188,12 @@ function Add-LinkAttributeToJson {
 # ==============================================================================
 # Main
 # ==============================================================================
+
+# When this file is dot-sourced (e.g. by pester/devdocs-generator.Tests.ps1) load the
+# functions above only and skip the generation pipeline below. Running the script
+# directly (./devdocs-generator.ps1, as CI does) leaves InvocationName as the script
+# name, so generation proceeds as normal.
+if ($MyInvocation.InvocationName -eq '.') { return }
 
 $scriptDir = if ($PSScriptRoot) { $PSScriptRoot } else { (Get-Location).Path }
 $repoRoot  = Resolve-Path "$scriptDir/.."


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://winutil.christitus.com/contributing/ -->
<!--Documentation is auto-generated from configs - no manual documentation updates needed -->

## Type of Change
- [ ] New feature
- [X] Bug fix
- [X] Documentation update
- [ ] UI/UX improvement

<!-- This automatically adds labels to your PR based on the selections above. -->

## Description
<!--[What does this PR do? Provide Screenshots when possible.]-->
Last time I made a mistake pasting link in the json file while adding Scrollbars feature in https://github.com/ChrisTitusTech/winutil/pull/4402. Then I raised PR to fix this https://github.com/ChrisTitusTech/winutil/pull/4528. It was fine until doc generator ran and regressed the fix.

As it was taking bunch of time to fix this, I asked my friend Claude to get a solution, I didn't have a time yet to go through all the code yet (spoke with ANGRYxScotsman to raise a PR already so we can both check it), but testing proved it's working now and it's guarded with additional script that checks on that + pester is updated to cover failures like this in the future, when somebody is making a mistake within the JSON structure

**tl;dr:**

The generator located structure by matching indentation, which breaks for any item whose key is indented differently from its siblings (today: WPFToggleScrollbars, indented 4 spaces instead of 2). Because the docs/links are machine-generated, the hand-fix in #4528 was wiped by the next generation (chore re-run in #4619), so the defect keeps returning. Two functions were affected, both hardened here.

Add-LinkAttributeToJson located each item link via propIndent = itemKeyIndent + 2, so a deeper-indented key made propIndent coincide with the nested registry object indent: the updater latched onto a stray link inside the registry block (and inserts targeted the registry brace, leaving a dangling comma). Rewritten to find each item by its unique name and take its own closing brace as the last brace before the next item start (root brace for the last item), then update/insert the top-level link there.

Get-RawJsonBlock found an item closing brace by matching a brace at the same indent as the key, so a mis-indented key produced a 'Could not find closing brace' warning and emitted no JSON doc block. Rewritten to match the closing brace by string-aware brace counting that ignores braces inside quoted values.

Also adds a run-guard so the script loads its functions without running the generation pipeline when dot-sourced, and pester/devdocs-generator.Tests.ps1 with regression tests.

**Detailed changes:**
`tools/devdocs-generator.ps1` located JSON structure by indentation, which breaks for any item whose key is indented differently from its siblings (today: `WPFToggleScrollbars`, indented 4 spaces). Because the docs/links are machine-generated, hand-fixing the JSON (as in #4528) doesn't stick — the next generation (e.g. the chore re-run in #4619) reintroduces the defect. This PR fixes the **generator** so placement is always correct, making the fix permanent. Generator-only change; no behavior change to WinUtil itself.

## Details

Two functions were fooled by the mis-indented key, both hardened here:

- **`Add-LinkAttributeToJson`** placed each item's `"link"` using `propIndent = itemKeyIndent + 2`, so a deeper-indented key made `propIndent` coincide with the nested `registry` object's indent — the updater latched onto a stray link inside the registry block (and inserts targeted the registry brace, leaving a dangling comma). Rewritten to find each item by its **unique name** and take its own closing brace as the last `}` before the **next item's start** (root brace for the last item), then update/insert the top-level `"link"` there.
- **`Get-RawJsonBlock`** found an item's closing brace by matching `}` at the **same indent as the key**, so a mis-indented key produced a `Could not find closing brace` warning and emitted no JSON doc block. Rewritten to match the closing brace by **string-aware brace counting** (ignoring braces inside quoted values).

Both approaches are immune to inconsistent indentation **and** to braces inside multi-line `InvokeScript`/`UndoScript` string values.

Also adds a run-guard so the script loads its functions without running the generation pipeline when dot-sourced, and `pester/devdocs-generator.Tests.ps1` covering: no link inside registry blocks, in-place update of a mis-indented entry, brace-in-string safety, insert-when-missing, idempotency, and `Get-RawJsonBlock` brace finding.

## Verification

- `Invoke-Pester -Path 'pester/*.Tests.ps1'` → 12 passed (4 existing + 6 new + 2 for Get-RawJsonBlock).
- Running the generator directly no longer warns and renders the previously-missing Scrollbars doc block.
- `git diff config/tweaks.json` shows registry blocks untouched (only top-level links may change).

> Note: the one-time cleanup of the already-corrupted `WPFToggleScrollbars` entry in `config/tweaks.json` (stray inner `link` + dangling comma) is handled separately.


## Issue related to PR
<!--[List any ISSUES this is related to as it AUTO-CLOSES Them!]-->
- Resolves #
