### PR TITLE
Add DNS flush to network reset

### DIFF
--- a/functions/public/Invoke-WPFFixesNetwork.ps1
+++ b/functions/public/Invoke-WPFFixesNetwork.ps1
@@ -1,7 +1,6 @@
 function Invoke-WPFFixesNetwork {
     netsh winsock reset
     netsh int ip reset
-    # Flush DNS cache
     ipconfig /flushdns
     Write-Host "Network Configuration has been Reset Please restart your computer."
 }

--- a/functions/public/Invoke-WPFFixesNetwork.ps1
+++ b/functions/public/Invoke-WPFFixesNetwork.ps1
@@ -1,5 +1,7 @@
 function Invoke-WPFFixesNetwork {
     netsh winsock reset
     netsh int ip reset
+    # Flush DNS cache
+    ipconfig /flushdns
     Write-Host "Network Configuration has been Reset Please restart your computer."
 }


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://winutil.christitus.com/contributing/ -->
<!--Documentation is auto-generated from configs - no manual documentation updates needed -->

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] UI/UX improvement

<!-- This automatically adds labels to your PR based on the selections above. -->

## Description
Appends `ipconfig /flushdns` to the end of the `Invoke-WPFFixesNetwork` function to ensure that the DNS resolver cache is cleared as part of the Network Reset utility.

## Issue related to PR
<!--[List any ISSUES this is related to as it AUTO-CLOSES Them!]-->
