### PR TITLE
feat: add advanced tweak to disable reserved storage

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -878,6 +878,19 @@
     ],
     "link": "https://winutil.christitus.com/dev/tweaks/essential-tweaks/debloat"
   },
+  "WPFTweaksReservedStorage": {
+    "Content": "Disable Reserved Storage",
+    "Description": "Disables Windows Reserved Storage (7-10 GB held for updates/temp files). Recommended only on small drives. Re-enable before major Windows feature updates to avoid installation failures.",
+    "category": "z__Advanced Tweaks - CAUTION",
+    "panel": "1",
+    "InvokeScript": [
+      "DISM /Online /Set-ReservedStorageState /State:Disabled"
+    ],
+    "UndoScript": [
+      "DISM /Online /Set-ReservedStorageState /State:Enabled"
+    ],
+    "link": "https://winutil.christitus.com/dev/tweaks/z--advanced-tweaks---caution/reservedstorage"
+  },
   "WPFTweaksRestorePoint": {
     "Content": "Restore Point - Create",
     "Description": "Creates a restore point at runtime in case a revert is needed from WinUtil modifications.",


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://winutil.christitus.com/contributing/ -->
<!--Documentation is auto-generated from configs - no manual documentation updates needed -->

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] UI/UX improvement

<!-- This automatically adds labels to your PR based on the selections above. -->

## Description
Adds `WPFTweaksReservedStorage` to `tweaks.json` under Advanced Tweaks - CAUTION. Runs DISM to disable Windows Reserved Storage, reclaiming 7-10 GB on small drives. The UndoScript re-enables it cleanly.

⚠️ Disabling Reserved Storage may cause Windows future update installation failures if the drive is near capacity. Re-enable Reserved Storage before running major Windows upgrades.

## Issue related to PR
<!--[List any ISSUES this is related to as it AUTO-CLOSES Them!]-->
