### PR TITLE
Add pnpm package manager

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -845,6 +845,14 @@
         "winget": "OpenJS.NodeJS.LTS",
         "foss": true
     },
+    "pnpm": {
+    "category": "Development",
+    "content": "pnpm",
+    "description": "pnpm is a fast and disk space efficient package manager for JavaScript and Node.js applications.",
+    "link": "https://pnpm.io/",
+    "winget": "pnpm.pnpm",
+    "foss": true
+    },
     "notepadplus": {
         "category": "Multimedia Tools",
         "choco": "notepadplusplus",


### PR DESCRIPTION
## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactor
- [ ] UI/UX improvement

## Description

Adds pnpm as a Development package using the official WinGet package identifier `pnpm.pnpm`.

### Testing

- Verified the WinGet package identifier with `winget search pnpm`.
- Ran `.\Compile.ps1 -Run`.
- Confirmed WinUtil launches correctly.
- Confirmed pnpm appears in the application list.

## Issue related to PR

N/A
