### PR TITLE
Fix font scaling slider not working on touchscreens

### DIFF
--- a/functions/private/Set-WinUtilSliderFromTouch.ps1
+++ b/functions/private/Set-WinUtilSliderFromTouch.ps1
@@ -1,0 +1,22 @@
+function Set-WinUtilSliderFromTouch {
+    <#
+    .SYNOPSIS
+        Moves a Slider's value to a horizontal touch position. WPF Sliders ignore touch drag on touch-only devices, so this is wired up to the touch events manually.
+    #>
+    param (
+        [Parameter(Mandatory)] $Slider,
+        [Parameter(Mandatory)] [double]$PositionX
+    )
+
+    if ($Slider.ActualWidth -le 0) { return }
+
+    $ratio = [math]::Min(1, [math]::Max(0, $PositionX / $Slider.ActualWidth))
+    $value = $Slider.Minimum + ($ratio * ($Slider.Maximum - $Slider.Minimum))
+
+    if ($Slider.TickFrequency -gt 0) {
+        $steps = [math]::Round(($value - $Slider.Minimum) / $Slider.TickFrequency)
+        $value = $Slider.Minimum + ($steps * $Slider.TickFrequency)
+    }
+
+    $Slider.Value = $value
+}

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -525,6 +525,28 @@ $sync["FontScalingSlider"].Add_ValueChanged({
     $sync.FontScalingValue.Text = "$percentage%"
 })
 
+# WPF sliders don't respond to touch drag, so drive the value from touch events
+$sync["FontScalingSlider"].Add_PreviewTouchDown({
+    param($slider, $e)
+    $slider.CaptureTouch($e.TouchDevice) | Out-Null
+    Set-WinUtilSliderFromTouch -Slider $slider -PositionX $e.GetTouchPoint($slider).Position.X
+    $e.Handled = $true
+})
+
+$sync["FontScalingSlider"].Add_PreviewTouchMove({
+    param($slider, $e)
+    if ($slider.AreAnyTouchesCaptured) {
+        Set-WinUtilSliderFromTouch -Slider $slider -PositionX $e.GetTouchPoint($slider).Position.X
+        $e.Handled = $true
+    }
+})
+
+$sync["FontScalingSlider"].Add_PreviewTouchUp({
+    param($slider, $e)
+    $slider.ReleaseTouchCapture($e.TouchDevice) | Out-Null
+    $e.Handled = $true
+})
+
 $sync["FontScalingResetButton"].Add_Click({
     $sync.FontScalingSlider.Value = 1.0
     $sync.FontScalingValue.Text = "100%"

--- a/xaml/inputXML.xaml
+++ b/xaml/inputXML.xaml
@@ -1121,6 +1121,8 @@
                                         TickFrequency="0.25"
                                         TickPlacement="BottomRight"
                                         IsSnapToTickEnabled="True"
+                                        IsMoveToPointEnabled="True"
+                                        Stylus.IsPressAndHoldEnabled="False"
                                         Width="120"
                                         VerticalAlignment="Center"/>
                                 <TextBlock Text="Large"


### PR DESCRIPTION
## What

Makes the Font Scaling slider usable on touchscreen devices.

## Why

WPF `Slider` thumbs only respond to mouse drag. On touch-only devices (handhelds, tablets, 2-in-1s) on my Asus Rog ally x it doesn't  work , touch isn't promoted to the mouse input the thumb relies on, so the slider can't be moved by finger at all.

## How

- Added `Set-WinUtilSliderFromTouch`, which maps a horizontal touch position onto the slider's range and snaps to the nearest tick.
- Wired the slider's `PreviewTouchDown/Move/Up` events to capture the touch and drive the value as the finger moves.
- Set `IsMoveToPointEnabled` and disabled the press-and-hold stylus gesture so tapping the track jumps to that point without a long-press delay.

## Testing

Compiled with `.\Compile.ps1 -Run` and confirmed on a touchscreen handheld: the slider now drags and snaps by touch. Mouse and keyboard behavior is unchanged.