### PR TITLE
Add option to disable lock screen in tweaks.json

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -1693,6 +1693,23 @@
     ],
     "link": "https://winutil.christitus.com/dev/tweaks/customize-preferences/loginblur"
   },
+  "WPFTweaksDisableLockscreen": {
+    "Content": "Lock Screen - Disable",
+    "Description": "Skips the lock screen entirely and goes directly to the sign-in screen on boot and wake.",
+    "category": "Customize Preferences",
+    "panel": "2",
+    "Type": "Toggle",
+    "registry": [
+      {
+        "Path": "HKLM:\\SOFTWARE\\Policies\\Microsoft\\Windows\\Personalization",
+        "Name": "NoLockScreen",
+        "Value": "1",
+        "Type": "DWord",
+        "OriginalValue": "<RemoveEntry>"
+      }
+    ],
+    "link": "https://winutil.christitus.com/dev/tweaks/customize-preferences/disablelockscreen"
+  },
   "WPFToggleStartMenuRecommendations": {
     "Content": "Start Menu Recommendations",
     "Description": "Toggles the recommendations section in the Start Menu. WARNING: This will also disable Windows Spotlight on your Lock Screen as a side effect.",


### PR DESCRIPTION
## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactor
- [ ] UI/UX improvement

## Description

Added a new **"Lock Screen - Disable"** tweak under **Customize Preferences** that skips the Windows lock screen entirely and goes directly to the sign-in (password) screen on boot and wake from sleep.

**Registry change:**
- Path: `HKLM:\SOFTWARE\Policies\Microsoft\Windows\Personalization`
- Key: `NoLockScreen`
- Value: `1` (enabled) / removed on undo (`<RemoveEntry>`)

**Note:** This is different from the existing **Logon Screen Acrylic Blur** tweak that keeps the lock screen but removes the blur. This skips the lock screen entirely.

**Tested on:** Windows 11 - 25H2 (OS Build 26200.8655)

Screenshots:
<!-- Drag your screenshot here showing the tweak in GUI with tooltip visible -->
<img width="1431" height="745" alt="image" src="https://github.com/user-attachments/assets/8282ac33-780b-4077-abe7-e3edea3efbcd" />