### PR TITLE
feat(github): Create a discussion template for app suggestion

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/app-suggestion.yaml
+++ b/.github/DISCUSSION_TEMPLATE/app-suggestion.yaml
@@ -17,6 +17,8 @@ body:
           required: true
         - label: "This application should be included on majority of fresh installed systems"
           required: true
+        - label: "This application is present on WinGet (check winstall.app or do 'winget search your-app' in terminal)"
+          required: true
   - type: checkboxes
     attributes:
       label: "Check for denied applications"

--- a/.github/DISCUSSION_TEMPLATE/app_suggest.yaml
+++ b/.github/DISCUSSION_TEMPLATE/app_suggest.yaml
@@ -1,0 +1,27 @@
+title: "[App Suggestion] "
+labels: "Ideas"
+body:
+  - type: input
+    attributes:
+      label: "Application Link"
+      description: "Provide a link where this application can downloaded officially"
+  - type: checkboxes
+    attributes:
+      label: "Rules Checklist"
+      description: "You should agree with next rules"
+      options:
+        - label: "This application is popular enough, so is not considered as niche"
+          required: true
+        - label: "This application is not considered bloatware"
+          required: true
+        - label: "This application is free to access"
+          required: true
+        - label: "This application should be included on majority of fresh installed systems"
+          required: true
+  - type: checkboxes
+    attributes:
+      label: "Check for denied applications"
+      options:
+        - label: "Yes, I checked PRs, issues and discussions for existing suggestions and their result"
+          required: true
+      

--- a/.github/DISCUSSION_TEMPLATE/app_suggest.yaml
+++ b/.github/DISCUSSION_TEMPLATE/app_suggest.yaml
@@ -1,5 +1,4 @@
 title: "[App Suggestion] "
-labels: "Ideas"
 body:
   - type: input
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,3 +3,6 @@ contact_links:
     - name: 💻 Community Discord
       url: https://discord.gg/RUbZUZyByQ
       about: Join our Community Discord server to chat with other users in the WinUtil community.
+    - name: Suggest an application
+      url: https://github.com/ChrisTitusTech/winutil/discussions/new?category=app_suggest
+      about: If you want to suggest an application to be added, create a discussion with given template

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
       url: https://discord.gg/RUbZUZyByQ
       about: Join our Community Discord server to chat with other users in the WinUtil community.
     - name: Suggest an application
-      url: https://github.com/ChrisTitusTech/winutil/discussions/new?category=app_suggest
+      url: https://github.com/ChrisTitusTech/winutil/discussions/new?category=app-suggestion
       about: If you want to suggest an application to be added, create a discussion with given template


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://winutil.christitus.com/contributing/ -->
<!--Documentation is auto-generated from configs - no manual documentation updates needed -->

## Type of Change
- [X] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactor
- [X] UI/UX improvement

<!-- This automatically adds labels to your PR based on the selections above. -->

## Prerequisites

- [x] Go to [categories](https://github.com/ChrisTitusTech/winutil/discussions/categories), press "New Category" and call this EXACTLY "App Suggestion". NO CHANGES

## Description
<!--[What does this PR do? Provide Screenshots when possible.]-->
So PR title is self-explanatory. Reason? THIS
 
<img width="942" height="272" alt="image" src="https://github.com/user-attachments/assets/c955ef8c-a010-4249-91cd-1aec1471329a" />

So it will work next way

https://github.com/user-attachments/assets/11b79389-04b8-48a1-b233-4b67d8eca4ff

## Post-merging optimizations

#1782 can be closed and untouched at all and issues will be left only for issues. Also if app will be needed to be debated, it won't be flooded in one single thread and won't bump every person who ever written in that issue and haven't unsubbed from there  