### PR TITLE
Add MiniTool Partition Wizard and fix Everything sorting

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -719,6 +719,15 @@
         "winget": "Element.Element",
         "foss": true
     },
+    "minitoolpartitionwizard": {
+        "category": "Utilities",
+        "choco": "minitoolpartitionwizard",
+        "content": "MiniTool Partition Wizard",
+        "description": "Comprehensive free partition manager that performs advanced operations Windows natively cannot, such as merging partitions, converting file systems, and organizing disk capacity.",
+        "link": "https://www.partitionwizard.com/",
+        "winget": "MiniTool.PartitionWizard.Free",
+        "foss": false
+    },
     "modrinth": {
         "category": "Games",
         "choco": "modrinth-app",
@@ -1450,7 +1459,7 @@
     "everything": {
         "category": "Utilities",
         "choco": "everything",
-        "content": "VoidTools Everything",
+        "content": "Everything",
         "description": "Everything is a search engine that locates files and folders by filename instantly for Windows. Unlike Windows search Everything initially displays every file and folder on your computer (hence the name Everything). You type in a search filter to limit what files and folders are displayed.",
         "link": "https://www.voidtools.com/",
         "winget": "voidtools.Everything",


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://winutil.christitus.com/contributing/ -->
<!--Documentation is auto-generated from configs - no manual documentation updates needed -->

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactor
- [x] UI/UX improvement

<!-- This automatically adds labels to your PR based on the selections above. -->

## Description
This PR introduces two small, focused updates to the `applications.json` file:

1. **Addition of MiniTool Partition Wizard (new feature):** Added to the "Utilities" category. It is a reliable and highly requested disk management tool capable of performing advanced operations that Windows does not offer natively (such as merging partitions and converting file systems).
2. **Fix for Everything sorting (UI/UX improvement):** The field `"content": "VoidTools Everything"` was renamed to `"content": "Everything"`. This fixes the alphabetical sorting issue in the interface, making it much easier for users to find the application under the letter 'E'—something I personally couldn't do before.

Tested locally via `Compile.ps1` and both changes worked perfectly in the UI and the installation.

## Issue related to PR
<!--[List any ISSUES this is related to as it AUTO-CLOSES Them!]-->
N/A
