### PR TITLE
Fix Multiplane Overlay toggle

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -1512,9 +1512,9 @@
       {
         "Path": "HKLM:\\SYSTEM\\CurrentControlSet\\Control\\GraphicsDrivers",
         "Name": "DisableOverlays",
-        "Value": "1",
+        "Value": "0",
         "Type": "DWord",
-        "OriginalValue": "0",
+        "OriginalValue": "1",
         "DefaultState": "false"
       }
     ],

--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -1515,7 +1515,7 @@
         "Value": "0",
         "Type": "DWord",
         "OriginalValue": "1",
-        "DefaultState": "false"
+        "DefaultState": "true"
       }
     ],
     "link": "https://winutil.christitus.com/dev/tweaks/customize-preferences/multiplaneoverlay"


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://winutil.christitus.com/contributing/ -->
<!--Documentation is auto-generated from configs - no manual documentation updates needed -->

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactor
- [ ] UI/UX improvement

<!-- This automatically adds labels to your PR based on the selections above. -->

## Description
<!--[What does this PR do? Provide Screenshots when possible.]-->
HKLM:\SYSTEM\CurrentControlSet\Control\GraphicsDrivers\DisableOverlays should be 0 when enabling MPO
<img width="1115" height="628" alt="image" src="https://github.com/user-attachments/assets/6bfadb69-08cd-4bf3-919b-5f07d2662a6e" />


## Issue related to PR
<!--[List any ISSUES this is related to as it AUTO-CLOSES Them!]-->
- Resolves #4755
