### PR TITLE
feat: Add native Sudo (Win 11 24H2+) toggle to Essential Tweaks

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -922,6 +922,22 @@
     ],
     "link": "https://winutil.christitus.com/dev/tweaks/essential-tweaks/endtaskontaskbar"
   },
+  "WPFTweaksEnableSudo": {
+    "Content": "Enable Sudo (Win 11 24H2+)",
+    "Description": "Enables native Sudo functionality in Windows (Inline mode). Requires Windows 11 Build 26045 (24H2) or higher.",
+    "category": "Essential Tweaks",
+    "panel": "1",
+    "registry": [
+      {
+        "Path": "HKLM:\\Software\\Microsoft\\Windows\\CurrentVersion\\Sudo",
+        "Name": "Enabled",
+        "Value": "3",
+        "Type": "DWord",
+        "OriginalValue": "<RemoveEntry>"
+      }
+    ],
+    "link": "https://winutil.christitus.com/dev/tweaks/essential-tweaks/enablesudo"
+  },
   "WPFTweaksStorage": {
     "Content": "Storage Sense - Disable",
     "Description": "Storage Sense deletes temp files automatically.",

--- a/docs/content/dev/tweaks/Essential-Tweaks/EnableSudo.md
+++ b/docs/content/dev/tweaks/Essential-Tweaks/EnableSudo.md
@@ -1,0 +1,38 @@
+---
+title: "Enable Sudo (Win 11 24H2+)"
+description: ""
+---
+
+```json {filename="config/tweaks.json"}
+  "WPFTweaksEnableSudo": {
+    "Content": "Enable Sudo (Win 11 24H2+)",
+    "Description": "Enables native Sudo functionality in Windows (Inline mode). Requires Windows 11 Build 26045 (24H2) or higher.",
+    "category": "Essential Tweaks",
+    "panel": "1",
+    "registry": [
+      {
+        "Path": "HKLM:\\Software\\Microsoft\\Windows\\CurrentVersion\\Sudo",
+        "Name": "Enabled",
+        "Value": "3",
+        "Type": "DWord",
+        "OriginalValue": "<RemoveEntry>"
+      }
+    ],
+    "link": "https://winutil.christitus.com/dev/tweaks/essential-tweaks/enablesudo"
+  },
+```
+
+## Registry Changes
+
+Applications and System Components store and retrieve configuration data to modify Windows settings, so we can use the registry to change many settings in one place.
+
+You can find information about the registry on [Wikipedia](https://en.wikipedia.org/wiki/Windows_Registry) and [Microsoft's Website](https://learn.microsoft.com/en-us/windows/win32/sysinfo/registry).
+
+### Sudo Modes
+
+Windows offers three modes for Sudo:
+- **`1`**: In a new window
+- **`2`**: With input disabled
+- **`3`**: Inline (similar to Linux)
+
+This tweak sets the `Value` to `3` to enable **Inline mode**. This provides the most seamless and familiar experience, as it executes the elevated command in the exact same console window, just like `sudo` on Linux.


### PR DESCRIPTION
## Type of Change
- [x] New feature
- [ ] Bug fix
- [x] Documentation update
- [ ] Refactor
- [ ] UI/UX improvement

## Description
**What changed:**
Added a new tweak to the Essential Tweaks section that allows users to enable the native `sudo` command built into Windows 11. 

**Why it was changed:**
Windows 11 introduced native `sudo` functionality (starting with Insider Build 26045 and publicly in 24H2). This PR allows users to easily enable it through WinUtil rather than having to install third-party binaries (like `gsudo`). 

**Implementation Details:**
- Uses the native Windows registry key: `HKLM:\Software\Microsoft\Windows\CurrentVersion\Sudo`
- Set to `Value: 3` so that `sudo` executes in **Inline mode** (resembling the familiar Linux experience in the same console window).
- `OriginalValue` is correctly set to `<RemoveEntry>` so that undoing the tweak fully restores the system to factory defaults (since older Windows 11 builds don't have this registry key).
- The title explicitly mentions `(Win 11 24H2+)` to prevent confusion for users on older Windows 10/11 versions.
- Added corresponding markdown documentation under `docs\content\dev\tweaks\Essential-Tweaks\EnableSudo.md`.