### PR TITLE
Add other Discord client variants and Legcord

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -262,7 +262,7 @@
     },
     "discord-canary": {
         "category": "Communications",
-        "choco": "discord-canary",
+        "choco": "na",
         "content": "Discord Canary",
         "description": "Discord is a popular communication platform with voice, video, and text chat, designed for gamers but used by a wide range of communities. (Canary Version)",
         "link": "https://discord.com/",

--- a/config/applications.json
+++ b/config/applications.json
@@ -251,6 +251,33 @@
         "winget": "Discord.Discord",
         "foss": false
     },
+    "discord-ptb": {
+        "category": "Communications",
+        "choco": "na",
+        "content": "Discord PTB",
+        "description": "Discord is a popular communication platform with voice, video, and text chat, designed for gamers but used by a wide range of communities. (Public Test Build)",
+        "link": "https://discord.com/",
+        "winget": "Discord.Discord.PTB",
+        "foss": false
+    },
+    "discord-canary": {
+        "category": "Communications",
+        "choco": "discord-canary",
+        "content": "Discord Canary",
+        "description": "Discord is a popular communication platform with voice, video, and text chat, designed for gamers but used by a wide range of communities. (Canary Version)",
+        "link": "https://discord.com/",
+        "winget": "Discord.Discord.Canary",
+        "foss": false
+    },
+    "discord-development": {
+        "category": "Communications",
+        "choco": "na",
+        "content": "Discord Development Edition",
+        "description": "Discord is a popular communication platform with voice, video, and text chat, designed for gamers but used by a wide range of communities. (Development Edition)",
+        "link": "https://discord.com/",
+        "winget": "Discord.Discord.Development",
+        "foss": false
+    },
     "dismtools": {
         "category": "Microsoft Tools",
         "choco": "dismtools",
@@ -672,6 +699,15 @@
         "description": "Simple terminal UI for git commands.",
         "link": "https://github.com/jesseduffield/lazygit/",
         "winget": "JesseDuffield.lazygit",
+        "foss": true
+    },
+    "legcord": {
+        "category": "Communications",
+        "choco": "na",
+        "content": "Legcord",
+        "description": "Legcord is a custom client designed to enhance your Discord experience while keeping everything lightweight. ",
+        "link": "https://legcord.app/",
+        "winget": "smartfrigde.Legcord",
         "foss": true
     },
     "libreoffice": {


### PR DESCRIPTION
## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactor
- [ ] UI/UX improvement

<!-- This automatically adds labels to your PR based on the selections above. -->

## Description
<!--[What does this PR do? Provide Screenshots when possible.]-->
This PR adds the other variants of the Discord desktop client as well as the Legcord client  
The other variants in question are as follows:
- Discord PTB
- Discord Canary
- Discord Development Edition

<img width="1566" height="81" alt="added discord variants marked" src="https://github.com/user-attachments/assets/b21ef3e4-49c9-461c-bf04-5fca841ab78c" />
  
All variants are installed through winget, as PTB and Development are not on Chocolatey and Canary was having issues, though if it gets fixed, the choco package name for Canary is `discord-canary`
