### PR TITLE
Add new application entries and support msstore Winget installs

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -161,6 +161,15 @@
         "winget": "Cemu.Cemu",
         "foss": true
     },
+    "chatgpt": {
+        "category": "Development",
+        "choco": "na",
+        "content": "ChatGPT Desktop",
+        "description": "The official ChatGPT desktop app for Windows, distributed through the Microsoft Store.",
+        "link": "https://apps.microsoft.com/detail/9nt1r1c2hh7j",
+        "winget": "msstore:9NT1R1C2HH7J",
+        "foss": false
+    },
     "chatterino": {
         "category": "Communications",
         "choco": "chatterino",
@@ -188,6 +197,33 @@
         "winget": "Hibbiki.Chromium",
         "foss": true
     },
+    "cinebenchr23": {
+        "category": "Pro Tools",
+        "choco": "na",
+        "content": "Cinebench R23",
+        "description": "Cinebench R23 is a benchmark tool for comparing CPU rendering performance across systems.",
+        "link": "https://www.maxon.net/en/cinebench",
+        "winget": "Maxon.CinebenchR23",
+        "foss": false
+    },
+    "claude": {
+        "category": "Development",
+        "choco": "claude",
+        "content": "Claude Desktop",
+        "description": "Anthropic's Claude desktop application for focused AI-assisted work and chat.",
+        "link": "https://claude.ai/download",
+        "winget": "Anthropic.Claude",
+        "foss": false
+    },
+    "claude-code": {
+        "category": "Development",
+        "choco": "claude-code",
+        "content": "Claude Code",
+        "description": "Anthropic's agentic coding tool for terminal and IDE development workflows.",
+        "link": "https://code.claude.com/",
+        "winget": "Anthropic.ClaudeCode",
+        "foss": false
+    },
     "cmake": {
         "category": "Development",
         "choco": "cmake",
@@ -195,6 +231,15 @@
         "description": "CMake is an open-source, cross-platform family of tools designed to build, test and package software.",
         "link": "https://cmake.org/",
         "winget": "Kitware.CMake",
+        "foss": true
+    },
+    "codex": {
+        "category": "Development",
+        "choco": "codex",
+        "content": "Codex",
+        "description": "Codex CLI is an OpenAI coding agent that runs locally in your terminal.",
+        "link": "https://developers.openai.com/codex/cli",
+        "winget": "OpenAI.Codex",
         "foss": true
     },
     "cpuz": {
@@ -313,6 +358,15 @@
         "link": "https://dotnet.microsoft.com/download/dotnet/10.0",
         "winget": "Microsoft.DotNet.DesktopRuntime.10",
         "foss": true
+    },
+    "dropbox": {
+        "category": "Utilities",
+        "choco": "dropbox",
+        "content": "Dropbox",
+        "description": "Dropbox is a cloud storage client for syncing files, sharing content, and keeping documents available across devices.",
+        "link": "https://www.dropbox.com/desktop",
+        "winget": "Dropbox.Dropbox",
+        "foss": false
     },
     "eaapp": {
         "category": "Games",
@@ -538,6 +592,15 @@
         "link": "https://imageglass.org/",
         "winget": "DuongDieuPhap.ImageGlass",
         "foss": true
+    },
+    "internetdownloadmanager": {
+        "category": "Utilities",
+        "choco": "internet-download-manager",
+        "content": "Internet Download Manager",
+        "description": "Internet Download Manager is a download manager for accelerating, resuming, and scheduling file downloads.",
+        "link": "https://www.internetdownloadmanager.com/",
+        "winget": "Tonec.InternetDownloadManager",
+        "foss": false
     },
     "irfanview": {
         "category": "Multimedia Tools",
@@ -1285,6 +1348,15 @@
         "winget": "SlackTechnologies.Slack",
         "foss": false
     },
+    "startallback": {
+        "category": "Utilities",
+        "choco": "StartAllBack",
+        "content": "StartAllBack",
+        "description": "StartAllBack restores and improves Windows taskbar, Start menu, File Explorer, and shell UI behavior.",
+        "link": "https://www.startallback.com/",
+        "winget": "StartIsBack.StartAllBack",
+        "foss": false
+    },
     "steam": {
         "category": "Games",
         "choco": "steam-client",
@@ -1572,6 +1644,15 @@
         "link": "https://www.waterfox.net/",
         "winget": "Waterfox.Waterfox",
         "foss": true
+    },
+    "whatsapp": {
+        "category": "Communications",
+        "choco": "na",
+        "content": "WhatsApp Desktop",
+        "description": "WhatsApp Desktop is the official Windows desktop messaging app from Meta, distributed through the Microsoft Store.",
+        "link": "https://apps.microsoft.com/detail/9nksqgp7f2nh",
+        "winget": "msstore:9NKSQGP7F2NH",
+        "foss": false
     },
     "wingetui": {
         "category": "Utilities",

--- a/functions/private/Install-WinUtilProgramWinget.ps1
+++ b/functions/private/Install-WinUtilProgramWinget.ps1
@@ -8,9 +8,21 @@ Function Install-WinUtilProgramWinget {
         [string[]]$Programs
     )
 
-    if ($Action -eq 'Install') {
-        Start-Process -FilePath winget -ArgumentList "install $Programs --accept-package-agreements --source winget --silent" -NoNewWindow -Wait
-    } else {
-        Start-Process -FilePath winget -ArgumentList "uninstall $Programs --source winget --silent" -NoNewWindow -Wait
+    foreach ($program in $Programs) {
+        if ([string]::IsNullOrWhiteSpace($program) -or $program -eq "na") {
+            continue
+        }
+
+        $source = "winget"
+        if ($program.StartsWith("msstore:", [System.StringComparison]::OrdinalIgnoreCase)) {
+            $source = "msstore"
+            $program = $program.Substring("msstore:".Length)
+        }
+
+        if ($Action -eq 'Install') {
+            Start-Process -FilePath winget -ArgumentList @("install", "--id", $program, "--accept-package-agreements", "--accept-source-agreements", "--source", $source, "--silent") -NoNewWindow -Wait
+        } else {
+            Start-Process -FilePath winget -ArgumentList @("uninstall", "--id", $program, "--source", $source, "--silent") -NoNewWindow -Wait
+        }
     }
 }

--- a/functions/private/Invoke-WinUtilCurrentSystem.ps1
+++ b/functions/private/Invoke-WinUtilCurrentSystem.ps1
@@ -28,12 +28,16 @@ Function Invoke-WinUtilCurrentSystem {
 
         $originalEncoding = [Console]::OutputEncoding
         [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new()
-        $Sync.InstalledPrograms = winget list -s winget | Select-Object -skip 3 | ConvertFrom-String -PropertyNames "Name", "Id", "Version", "Available" -Delimiter '\s{2,}'
+        $Sync.InstalledPrograms = @("winget", "msstore") | ForEach-Object {
+            winget list -s $psitem | Select-Object -skip 3 | ConvertFrom-String -PropertyNames "Name", "Id", "Version", "Available" -Delimiter '\s{2,}'
+        }
         [Console]::OutputEncoding = $originalEncoding
 
         $filter = Get-WinUtilVariables -Type Checkbox | Where-Object {$psitem -like "WPFInstall*"}
         $sync.GetEnumerator() | Where-Object {$psitem.Key -in $filter} | ForEach-Object {
-            $dependencies = @($sync.configs.applications.$($psitem.Key).winget -split ";")
+            $dependencies = @($sync.configs.applications.$($psitem.Key).winget -split ";") | ForEach-Object {
+                $psitem -replace "^msstore:", ""
+            }
 
             if ($dependencies[-1] -in $sync.InstalledPrograms.Id) {
                 Write-Output $psitem.name


### PR DESCRIPTION
## Summary
- Added several new application definitions to `config/applications.json`, including ChatGPT, Claude, Codex, Dropbox, WhatsApp, and other requested tools.
- Updated Winget installation handling to support both standard `winget` IDs and `msstore:` package sources.
- Expanded installed-program detection to include Microsoft Store entries so app state reflects Store-backed packages correctly.

## Testing
- Not run (not requested)
- Changes were reviewed for consistency with the existing application/config schema and Winget invocation flow