### PR TITLE
Resolve PR 4658 Copilot conflict

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -913,6 +913,7 @@
       New-Item \"HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Appx\\AppxAllUserStore\\EndOfLife\\$Sid\\$Appx\" -Force
 
       Get-AppxPackage -AllUsers \"*Copilot*\" | Remove-AppxPackage -AllUsers
+      winget uninstall -e --name \"Copilot\" --silent --force --accept-source-agreements 2>$null
       Get-AppxPackage -AllUsers Microsoft.MicrosoftOfficeHub | Remove-AppxPackage -AllUsers
 
       if ($Appx) {


### PR DESCRIPTION
## What changed

Adds the Copilot `winget uninstall` command from PR #4658 on top of current `main` without the merge conflicts on that fork branch.

## Why

PR #4658 is still marked conflicted because its source branch is protected in the contributor fork. Maintainer updates and force-pushes were rejected by repository rules, so this branch carries the same resolved one-line change from a branch in `ChrisTitusTech/winutil`.

## Validation

```powershell
.\Compile.ps1
Import-Module Pester -RequiredVersion 5.8.0 -Force
Invoke-Pester -Path @('pester/configs.Tests.ps1','pester/tweaks.Tests.ps1') -Output Detailed
```

Result: 26 Pester tests passed, 0 failed.