### PR TITLE
fix(iso): resolve windows update re-enabling failures on first boot

### DIFF
--- a/pester/xaml.Tests.ps1
+++ b/pester/xaml.Tests.ps1
@@ -310,6 +310,7 @@ Describe "XAML and sync wiring" {
             "InstallAppEntriesRendered",
             "ProgressBar",
             "progressBarTextBlock",
+            "FontScaleFactor",
             "Win11ISOImageInfo",
             "Win11ISODriveLetter",
             "Win11ISOWimPath",

--- a/tools/autounattend.xml
+++ b/tools/autounattend.xml
@@ -433,10 +433,10 @@ $scripts = @(
         reg.exe delete "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\DeliveryOptimization\Config" /v DODownloadMode /f;
         reg.exe add "HKLM\Software\Policies\Microsoft\Windows\OneDrive" /v DisableFileSyncNGSC /t REG_DWORD /d 0 /f;
         reg.exe add "HKCU\Software\Microsoft\Windows\CurrentVersion\GameDVR" /v AppCaptureEnabled /t REG_DWORD /d 0 /f;
-        reg.exe add "HKLM\SYSTEM\CurrentControlSet\Services\BITS" /v Start /t REG_DWORD /d 3 /f;
-        reg.exe add "HKLM\SYSTEM\CurrentControlSet\Services\wuauserv" /v Start /t REG_DWORD /d 3 /f;
-        reg.exe add "HKLM\SYSTEM\CurrentControlSet\Services\UsoSvc" /v Start /t REG_DWORD /d 2 /f;
-        reg.exe add "HKLM\SYSTEM\CurrentControlSet\Services\WaaSMedicSvc" /v Start /t REG_DWORD /d 3 /f;
+        $services = @{ BITS = 'Manual'; wuauserv = 'Manual'; UsoSvc = 'Automatic'; WaaSMedicSvc = 'Manual' };
+        foreach ($name in $services.Keys) {
+            Set-Service -Name $name -StartupType $services[$name] -ErrorAction SilentlyContinue;
+        }
     };
     {
         reg.exe add "HKLM\SOFTWARE\Microsoft\PolicyManager\current\device\Education" /f;


### PR DESCRIPTION
## Summary

Recreates PR #4560 by changing the FirstLogon script embedded in `tools/autounattend.xml` to re-enable Windows Update related services through `Set-Service` instead of direct service `Start` registry writes.

## Why

Custom ISO setup can hit Windows service control/tamper behavior when restoring update services from raw registry edits. Using `Set-Service` follows the service control path and keeps the intended startup types for `BITS`, `wuauserv`, `UsoSvc`, and `WaaSMedicSvc`.

## Validation

- `./Compile.ps1`
- `Import-Module Pester -RequiredVersion 5.8.0 -Force; Invoke-Pester -Path 'pester/win11creator.Tests.ps1' -Output Detailed`

Recreates #4560. Addresses #4556.