### PR TITLE
fix(apps): Remove Lightshot for violating safety checks

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -719,15 +719,6 @@
         "winget": "XBMCFoundation.Kodi",
         "foss": true
     },
-    "lightshot": {
-        "category": "Multimedia Tools",
-        "choco": "lightshot",
-        "content": "Lightshot",
-        "description": "The fastest way to take a customizable screenshot.",
-        "link": "https://app.prntscr.com/",
-        "winget": "Skillbrains.Lightshot",
-        "foss": false
-    },
     "lazygit": {
         "category": "Development",
         "choco": "lazygit",


### PR DESCRIPTION
## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactor
- [ ] UI/UX improvement

<!-- This automatically adds labels to your PR based on the selections above. -->

## Description
<!--[What does this PR do? Provide Screenshots when possible.]-->

This app violates much enough things to be considered as good screenshot app:
- own servers to store images
- very short links that allow parse data without any safety checks (which can lead in finding someone's private data)
- there are better alternatives(FFS ShareX exists, or use Flameshot. OR JUST USE BUILT-IN SCISSORS, they're not THAT bad)
- a bit of red flag - devs are russian, which empowers first 2 red flags