### PR TITLE
feat(legacy-panels): add Firewall, Security, Programs, and Mouse to L…

### DIFF
--- a/config/feature.json
+++ b/config/feature.json
@@ -179,6 +179,17 @@
     "function": "Invoke-WPFFixesWinget",
     "link": "https://winutil.christitus.com/dev/features/fixes/winget"
   },
+  "WPFPanelComputer": {
+    "Content": "Computer Management",
+    "category": "Legacy Windows Panels",
+    "panel": "2",
+    "Type": "Button",
+    "ButtonWidth": "300",
+    "InvokeScript": [
+      "compmgmt.msc"
+    ],
+    "link": "https://winutil.christitus.com/dev/features/legacy-windows-panels/computer"
+  },
   "WPFPanelControl": {
     "Content": "Control Panel",
     "category": "Legacy Windows Panels",
@@ -190,16 +201,16 @@
     ],
     "link": "https://winutil.christitus.com/dev/features/legacy-windows-panels/control"
   },
-  "WPFPanelComputer": {
-    "Content": "Computer Management",
+  "WPFPanelMouse": {
+    "Content": "Mouse Properties",
     "category": "Legacy Windows Panels",
     "panel": "2",
     "Type": "Button",
     "ButtonWidth": "300",
     "InvokeScript": [
-      "compmgmt.msc"
+      "main.cpl"
     ],
-    "link": "https://winutil.christitus.com/dev/features/legacy-windows-panels/computer"
+    "link": "https://winutil.christitus.com/dev/features/legacy-windows-panels/mouse"
   },
   "WPFPanelNetwork": {
     "Content": "Network Connections",
@@ -234,6 +245,17 @@
     ],
     "link": "https://winutil.christitus.com/dev/features/legacy-windows-panels/printer"
   },
+  "WPFPanelPrograms": {
+    "Content": "Programs and Features",
+    "category": "Legacy Windows Panels",
+    "panel": "2",
+    "Type": "Button",
+    "ButtonWidth": "300",
+    "InvokeScript": [
+      "appwiz.cpl"
+    ],
+    "link": "https://winutil.christitus.com/dev/features/legacy-windows-panels/programs"
+  },
   "WPFPanelRegion": {
     "Content": "Region",
     "category": "Legacy Windows Panels",
@@ -245,16 +267,16 @@
     ],
     "link": "https://winutil.christitus.com/dev/features/legacy-windows-panels/region"
   },
-  "WPFPanelRestore": {
-    "Content": "Windows Restore",
+  "WPFPanelSecurity": {
+    "Content": "Security and Maintenance",
     "category": "Legacy Windows Panels",
     "panel": "2",
     "Type": "Button",
     "ButtonWidth": "300",
     "InvokeScript": [
-      "rstrui.exe"
+      "wscui.cpl"
     ],
-    "link": "https://winutil.christitus.com/dev/features/legacy-windows-panels/restore"
+    "link": "https://winutil.christitus.com/dev/features/legacy-windows-panels/security"
   },
   "WPFPanelSound": {
     "Content": "Sound Settings",
@@ -300,38 +322,16 @@
     ],
     "link": "https://winutil.christitus.com/dev/features/legacy-windows-panels/firewall"
   },
-  "WPFPanelSecurity": {
-    "Content": "Security and Maintenance",
+  "WPFPanelRestore": {
+    "Content": "Windows Restore",
     "category": "Legacy Windows Panels",
     "panel": "2",
     "Type": "Button",
     "ButtonWidth": "300",
     "InvokeScript": [
-      "wscui.cpl"
+      "rstrui.exe"
     ],
-    "link": "https://winutil.christitus.com/dev/features/legacy-windows-panels/security"
-  },
-  "WPFPanelPrograms": {
-    "Content": "Programs and Features",
-    "category": "Legacy Windows Panels",
-    "panel": "2",
-    "Type": "Button",
-    "ButtonWidth": "300",
-    "InvokeScript": [
-      "appwiz.cpl"
-    ],
-    "link": "https://winutil.christitus.com/dev/features/legacy-windows-panels/programs"
-  },
-  "WPFPanelMouse": {
-    "Content": "Mouse Properties",
-    "category": "Legacy Windows Panels",
-    "panel": "2",
-    "Type": "Button",
-    "ButtonWidth": "300",
-    "InvokeScript": [
-      "main.cpl"
-    ],
-    "link": "https://winutil.christitus.com/dev/features/legacy-windows-panels/mouse"
+    "link": "https://winutil.christitus.com/dev/features/legacy-windows-panels/restore"
   },
   "WPFWinUtilInstallPSProfile": {
     "Content": "CTT PowerShell Profile - Install",

--- a/config/feature.json
+++ b/config/feature.json
@@ -289,6 +289,50 @@
     ],
     "link": "https://winutil.christitus.com/dev/features/legacy-windows-panels/timedate"
   },
+  "WPFPanelFirewall": {
+    "Content": "Windows Defender Firewall",
+    "category": "Legacy Windows Panels",
+    "panel": "2",
+    "Type": "Button",
+    "ButtonWidth": "300",
+    "InvokeScript": [
+      "firewall.cpl"
+    ],
+    "link": "https://winutil.christitus.com/dev/features/legacy-windows-panels/firewall"
+  },
+  "WPFPanelSecurity": {
+    "Content": "Security and Maintenance",
+    "category": "Legacy Windows Panels",
+    "panel": "2",
+    "Type": "Button",
+    "ButtonWidth": "300",
+    "InvokeScript": [
+      "wscui.cpl"
+    ],
+    "link": "https://winutil.christitus.com/dev/features/legacy-windows-panels/security"
+  },
+  "WPFPanelPrograms": {
+    "Content": "Programs and Features",
+    "category": "Legacy Windows Panels",
+    "panel": "2",
+    "Type": "Button",
+    "ButtonWidth": "300",
+    "InvokeScript": [
+      "appwiz.cpl"
+    ],
+    "link": "https://winutil.christitus.com/dev/features/legacy-windows-panels/programs"
+  },
+  "WPFPanelMouse": {
+    "Content": "Mouse Properties",
+    "category": "Legacy Windows Panels",
+    "panel": "2",
+    "Type": "Button",
+    "ButtonWidth": "300",
+    "InvokeScript": [
+      "main.cpl"
+    ],
+    "link": "https://winutil.christitus.com/dev/features/legacy-windows-panels/mouse"
+  },
   "WPFWinUtilInstallPSProfile": {
     "Content": "CTT PowerShell Profile - Install",
     "category": "Powershell Profile Powershell 7+ Only",


### PR DESCRIPTION
## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactor
- [ ] UI/UX improvement

## Description
**What changed:** 
Added 4 new buttons to the "Legacy Windows Panels" category in `config/feature.json`:
- Windows Defender Firewall (`firewall.cpl`)
- Security and Maintenance (`wscui.cpl`)
- Programs and Features (`appwiz.cpl`)
- Mouse Properties (`main.cpl`)

**Why it was changed:** 
To provide quick GUI access to these essential legacy control panel applets, saving time compared to navigating through the modern Windows Settings app to find them.