### PR TITLE
feat(apps): add gsudo

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -530,6 +530,15 @@
         "winget": "TechPowerUp.GPU-Z",
         "foss": false
     },
+    "gsudo": {
+        "category": "Pro Tools",
+        "choco": "gsudo",
+        "content": "gsudo",
+        "description": "gsudo is a sudo equivalent for Windows. It allows you to run commands with elevated administrative privileges directly within the current console window.",
+        "link": "https://github.com/gerardog/gsudo",
+        "winget": "gerardog.gsudo",
+        "foss": true
+    },
     "helium": {
         "category": "Browsers",
         "choco": "helium",


### PR DESCRIPTION
## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactor
- [ ] UI/UX improvement

## Description
Added gsudo to the Pro Tools category in `config/applications.json`. Includes both winget (`gerardog.gsudo`) and choco (`gsudo`) install options.