### PR TITLE
fix: warn on suspicious TrustedInstaller path

### DIFF
--- a/functions/private/Test-WinUtilTrustedInstallerPath.ps1
+++ b/functions/private/Test-WinUtilTrustedInstallerPath.ps1
@@ -1,0 +1,53 @@
+function Test-WinUtilTrustedInstallerPath {
+    <#
+    .SYNOPSIS
+        Checks whether the TrustedInstaller service ImagePath looks safe.
+
+    .DESCRIPTION
+        Windows Update depends on the Windows Modules Installer service. If that
+        service's ImagePath is hijacked to launch a shell, PowerShell, script host,
+        or temp/AppData payload, Windows Update repair steps can fail or trigger
+        antivirus blocks. This function is intentionally read-only; protected
+        TrustedInstaller service registry values should not be rewritten here.
+
+    .OUTPUTS
+        Boolean. True when the path is expected or could not be inspected; false
+        when a suspicious ImagePath is detected.
+    #>
+
+    $expectedPath = "$env:SystemRoot\servicing\TrustedInstaller.exe"
+    $expectedRegistryPath = "%SystemRoot%\servicing\TrustedInstaller.exe"
+    $suspiciousPattern = "(?i)(encodedcommand|powershell(\.exe)?|cmd\.exe|wscript(\.exe)?|cscript(\.exe)?|mshta(\.exe)?|\bAppData\b|\bTemp\b)"
+
+    try {
+        $trustedInstaller = Get-CimInstance -ClassName Win32_Service -Filter "Name='TrustedInstaller'" -ErrorAction Stop
+    } catch {
+        Write-Warning "Unable to inspect TrustedInstaller service path: $($_.Exception.Message)"
+        Write-WinUtilLog -Level "WARN" -Component "Updates" -Message "Unable to inspect TrustedInstaller service path: $($_.Exception.Message)"
+        return $true
+    }
+
+    if ($null -eq $trustedInstaller) {
+        Write-Warning "TrustedInstaller service was not found. Windows Update repair may not complete successfully."
+        Write-WinUtilLog -Level "WARN" -Component "Updates" -Message "TrustedInstaller service was not found during Windows Update repair preflight."
+        return $true
+    }
+
+    $pathName = [string]$trustedInstaller.PathName
+    $expandedPath = [Environment]::ExpandEnvironmentVariables($pathName).Trim('"')
+    $normalizedExpectedPath = [Environment]::ExpandEnvironmentVariables($expectedRegistryPath)
+
+    if ($expandedPath -ieq $expectedPath -or $expandedPath -ieq $normalizedExpectedPath) {
+        return $true
+    }
+
+    if ($pathName -match $suspiciousPattern) {
+        $message = "TrustedInstaller service ImagePath looks suspicious: '$pathName'. Expected '$expectedRegistryPath'. Windows Update repair may not succeed until this is repaired offline."
+        Write-Warning $message
+        Write-WinUtilLog -Level "WARN" -Component "Updates" -Message $message
+        return $false
+    }
+
+    Write-WinUtilLog -Level "WARN" -Component "Updates" -Message "TrustedInstaller service ImagePath differs from expected value: '$pathName'. Expected '$expectedRegistryPath'."
+    return $true
+}

--- a/functions/public/Invoke-WPFFixesUpdate.ps1
+++ b/functions/public/Invoke-WPFFixesUpdate.ps1
@@ -32,6 +32,7 @@ function Invoke-WPFFixesUpdate {
     Write-Progress -Id 0 -Activity "Repairing Windows Update" -PercentComplete 0
     Set-WinUtilTaskbaritem -state "Indeterminate" -overlay "logo"
     Write-Host "Starting Windows Update Repair..."
+    Test-WinUtilTrustedInstallerPath | Out-Null
     # Wait for the first progress bar to show, otherwise the second one won't show
     Start-Sleep -Milliseconds 200
 

--- a/pester/update-repair-helpers.Tests.ps1
+++ b/pester/update-repair-helpers.Tests.ps1
@@ -1,0 +1,72 @@
+#===========================================================================
+# Tests - Windows Update Repair Helpers
+#===========================================================================
+
+BeforeAll {
+    $script:repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+    . (Join-Path $script:repoRoot "functions\private\Test-WinUtilTrustedInstallerPath.ps1")
+
+    function Write-WinUtilLog {
+        param($Message, $Level, $Component)
+        $null = $Message
+        $null = $Level
+        $null = $Component
+    }
+}
+
+Describe "Test-WinUtilTrustedInstallerPath" {
+    BeforeEach {
+        $env:SystemRoot = "C:\Windows"
+        Mock Write-Warning { }
+        Mock Write-WinUtilLog { }
+    }
+
+    It "returns true for the expected TrustedInstaller ImagePath" {
+        Mock Get-CimInstance {
+            [pscustomobject]@{
+                Name = "TrustedInstaller"
+                PathName = "%SystemRoot%\servicing\TrustedInstaller.exe"
+            }
+        } -ParameterFilter {
+            $ClassName -eq "Win32_Service" -and $Filter -eq "Name='TrustedInstaller'"
+        }
+
+        Test-WinUtilTrustedInstallerPath | Should -BeTrue
+
+        Should -Invoke -CommandName Write-Warning -Times 0 -Exactly
+    }
+
+    It "warns and returns false when TrustedInstaller points to an encoded PowerShell command" {
+        Mock Get-CimInstance {
+            [pscustomobject]@{
+                Name = "TrustedInstaller"
+                PathName = "cmd.exe /c PowerShell.exe -encodedcommand badpayload"
+            }
+        } -ParameterFilter {
+            $ClassName -eq "Win32_Service" -and $Filter -eq "Name='TrustedInstaller'"
+        }
+
+        Test-WinUtilTrustedInstallerPath | Should -BeFalse
+
+        Should -Invoke -CommandName Write-Warning -Times 1 -Exactly -ParameterFilter {
+            $Message -like "TrustedInstaller service ImagePath looks suspicious:*"
+        }
+        Should -Invoke -CommandName Write-WinUtilLog -Times 1 -Exactly -ParameterFilter {
+            $Level -eq "WARN" -and $Component -eq "Updates" -and $Message -like "TrustedInstaller service ImagePath looks suspicious:*"
+        }
+    }
+
+    It "does not block repair when TrustedInstaller cannot be inspected" {
+        Mock Get-CimInstance {
+            throw "CIM unavailable"
+        } -ParameterFilter {
+            $ClassName -eq "Win32_Service" -and $Filter -eq "Name='TrustedInstaller'"
+        }
+
+        Test-WinUtilTrustedInstallerPath | Should -BeTrue
+
+        Should -Invoke -CommandName Write-Warning -Times 1 -Exactly -ParameterFilter {
+            $Message -like "Unable to inspect TrustedInstaller service path:*"
+        }
+    }
+}


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] UI/UX improvement

## Description
Adds a read-only Windows Update repair preflight check for the TrustedInstaller service ImagePath.

Windows Update depends on Windows Modules Installer / TrustedInstaller. If the TrustedInstaller ImagePath is hijacked to launch a shell/script payload, Windows Update repair can fail or trigger antivirus blocks. This PR detects suspicious values such as `encodedcommand`, `powershell`, `cmd.exe`, script hosts, `AppData`, or `Temp`, then warns/logs the problem instead of trying to rewrite protected service registry keys.

This is intentionally diagnostic-only. It does not modify TrustedInstaller.

## Issue related to PR
- Related to #4811

## Verification
- `Import-Module Pester -RequiredVersion 5.8.0 -Force; Invoke-Pester -Path 'pester/update-profiles.Tests.ps1','pester/update-repair-helpers.Tests.ps1' -Output Detailed`
  - `Tests Passed: 11, Failed: 0, Skipped: 0, Inconclusive: 0, NotRun: 0`
- `.\Compile.ps1`
  - exit 0
- `Invoke-ScriptAnalyzer` on changed files with `lint/PSScriptAnalyser.ps1`
  - no findings
- `git diff --check`
  - no findings