### PR TITLE
Add Fan Control to applications.json.

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -413,6 +413,15 @@
         "winget": "EpicGames.EpicGamesLauncher",
         "foss": false
     },
+    "fancontrol": {
+        "category": "Pro Tools", 
+        "choco": "na",
+        "content": "Fan Control",
+        "description": "A deeply customizable and lightweight fan controlling software for Windows.",
+        "link": "https://getfancontrol.com/",
+        "winget": "Rem0o.FanControl",
+        "foss": false
+    },
     "files": {
         "category": "Utilities",
         "choco": "files",


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://winutil.christitus.com/contributing/ -->
<!--Documentation is auto-generated from configs - no manual documentation updates needed -->

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactor
- [ ] UI/UX improvement

<!-- This automatically adds labels to your PR based on the selections above. -->

## Description
<!--[What does this PR do? Provide Screenshots when possible.]-->
Adding FanControl to the `applications.json` list.

- **Added to Pro Tools:** Placed it alongside HWiNFO and HWMonitor since it's an advanced hardware control tool.
- **Why:** It's widely considered the best lightweight, highly customizable fan controlling software for Windows, replacing the need for bloated motherboard vendor software and can control fans that MSI Afterburner cannot.

Tested locally via `Compile.ps1` and it renders perfectly.

## Issue related to PR
<!--[List any ISSUES this is related to as it AUTO-CLOSES Them!]-->
N/A
