### PR TITLE
Fix names in applications.json

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -1198,7 +1198,7 @@
     "processmonitor": {
         "category": "Microsoft Tools",
         "choco": "procexp",
-        "content": "SysInternals Process Monitor",
+        "content": "Process Monitor",
         "description": "SysInternals Process Monitor is an advanced monitoring tool that shows real-time file system, registry, and process/thread activity.",
         "link": "https://docs.microsoft.com/en-us/sysinternals/downloads/procmon",
         "winget": "Microsoft.Sysinternals.ProcessMonitor",
@@ -1387,7 +1387,7 @@
     "tcpview": {
         "category": "Microsoft Tools",
         "choco": "tcpview",
-        "content": "SysInternals TCPView",
+        "content": "TCPView",
         "description": "SysInternals TCPView is a network monitoring tool that displays a detailed list of all TCP and UDP endpoints on your system.",
         "link": "https://docs.microsoft.com/en-us/sysinternals/downloads/tcpview",
         "winget": "Microsoft.Sysinternals.TCPView",
@@ -1504,7 +1504,7 @@
     "ungoogled": {
         "category": "Browsers",
         "choco": "ungoogled-chromium",
-        "content": "Ungoogled",
+        "content": "Ungoogled Chromium",
         "description": "Ungoogled Chromium is a version of Chromium without Google's integration for enhanced privacy and control.",
         "link": "https://github.com/Eloston/ungoogled-chromium",
         "winget": "eloston.ungoogled-chromium",


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://winutil.christitus.com/contributing/ -->
<!--Documentation is auto-generated from configs - no manual documentation updates needed -->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactor
- [x] UI/UX improvement

<!-- This automatically adds labels to your PR based on the selections above. -->

## Description
<!--[What does this PR do? Provide Screenshots when possible.]-->
Just a quick UI/UX cleanup to make the installs list look more professional and alphabetized correctly. 

Changes made based on official vendor names:
- `SysInternals Process Monitor` ➔ `Process Monitor`
- `SysInternals TCPView` ➔ `TCPView`
- `Ungoogled` ➔ `Ungoogled Chromium` (Matches the official repo name)

Kept it strictly to objective vendor names. Tested locally!

## Issue related to PR
<!--[List any ISSUES this is related to as it AUTO-CLOSES Them!]-->
N/A
