### PR TITLE
prevent-automatic-download-of-applications-associated-with-device-metadata

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -958,7 +958,7 @@
         "OriginalValue": "<RemoveEntry>"
       }
     ],
-    "link": ""
+    "link": "https://winutil.christitus.com/dev/tweaks/essential-tweaks/preventdevicemetadatafromnetwork"
   },
   "WPFTweaksRazerBlock": {
     "Content": "Razer Software Auto-Install - Disable",

--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -944,6 +944,22 @@
     ],
     "link": "https://winutil.christitus.com/dev/tweaks/essential-tweaks/wpbt"
   },
+  "WPFTweaksPreventDeviceMetadataFromNetwork": {
+    "Content": "Prevent Device Companion Apps",
+    "Description": "Prevents additional software from being installed when plugging in devices (e.g. Ads when plugging in a monitor). Poses potential security risk.",
+    "category": "Essential Tweaks",
+    "panel": "1",
+    "registry": [
+      {
+        "Path": "HKLM:\\SOFTWARE\\Policies\\Microsoft\\Windows\\Device Metadata",
+        "Name": "PreventDeviceMetadataFromNetwork",
+        "Value": "1",
+        "Type": "DWord",
+        "OriginalValue": "<RemoveEntry>"
+      }
+    ],
+    "link": ""
+  },
   "WPFTweaksRazerBlock": {
     "Content": "Razer Software Auto-Install - Disable",
     "Description": "Blocks ALL Razer Software installations. The hardware works fine without any software.",

--- a/docs/content/dev/tweaks/Essential-Tweaks/PreventDeviceMetadataFromNetwork.md
+++ b/docs/content/dev/tweaks/Essential-Tweaks/PreventDeviceMetadataFromNetwork.md
@@ -28,4 +28,4 @@ You can find information about the registry on [Wikipedia](https://en.wikipedia.
 
 ## References
 1. [Microsoft Documentation - PreventDeviceMetadataFromNetwork](https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-deviceinstallation#preventdevicemetadatafromnetwork)
-2. [CyberSecurityNews - Windows Update Silently Installs LG Monitor App That Pushes McAfee Ads](https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-deviceinstallation#preventdevicemetadatafromnetwork)
+2. [CyberSecurityNews - Windows Update Silently Installs LG Monitor App That Pushes McAfee Ads](https://cybersecuritynews.com/windows-update-installs-lg-monitor-app-pushes-mcafee-ads/)

--- a/docs/content/dev/tweaks/Essential-Tweaks/PreventDeviceMetadataFromNetwork.md
+++ b/docs/content/dev/tweaks/Essential-Tweaks/PreventDeviceMetadataFromNetwork.md
@@ -1,0 +1,31 @@
+---
+title: "Prevent Device Companion Apps"
+description: ""
+---
+
+```json {filename="config/tweaks.json",linenos=inline,linenostart=947}
+  "WPFTweaksPreventDeviceMetadataFromNetwork": {
+    "Content": "Prevent Device Companion Apps",
+    "Description": "Prevents additional software from being installed when plugging in devices (e.g. Ads when plugging in a monitor). Poses potential security risk.",
+    "category": "Essential Tweaks",
+    "panel": "1",
+    "registry": [
+      {
+        "Path": "HKLM:\\SOFTWARE\\Policies\\Microsoft\\Windows\\Device Metadata",
+        "Name": "PreventDeviceMetadataFromNetwork",
+        "Value": "1",
+        "Type": "DWord",
+        "OriginalValue": "<RemoveEntry>"
+      }
+    ],
+```
+
+## Registry Changes
+
+Applications and System Components store and retrieve configuration data to modify Windows settings, so we can use the registry to change many settings in one place.
+
+You can find information about the registry on [Wikipedia](https://en.wikipedia.org/wiki/Windows_Registry) and [Microsoft's Website](https://learn.microsoft.com/en-us/windows/win32/sysinfo/registry).
+
+## References
+1. [Microsoft Documentation - PreventDeviceMetadataFromNetwork](https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-deviceinstallation#preventdevicemetadatafromnetwork)
+2. [CyberSecurityNews - Windows Update Silently Installs LG Monitor App That Pushes McAfee Ads](https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-deviceinstallation#preventdevicemetadatafromnetwork)


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://winutil.christitus.com/contributing/ -->
<!--Documentation is auto-generated from configs - no manual documentation updates needed -->

## Type of Change
- [X] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactor
- [ ] UI/UX improvement

<!-- This automatically adds labels to your PR based on the selections above. -->

## Description
<!--[What does this PR do? Provide Screenshots when possible.]-->
Prevents additional software from being installed when plugging in devices (e.g. Ads when plugging in a monitor). Poses potential security risk.

References:

1. https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-deviceinstallation#preventdevicemetadatafromnetwork
2. https://cybersecuritynews.com/windows-update-installs-lg-monitor-app-pushes-mcafee-ads/


## Issue related to PR
<!--[List any ISSUES this is related to as it AUTO-CLOSES Them!]-->
- Resolves #
