### PR TITLE
Add window-level progress indicator for Run Tweaks and Undo

### DIFF
--- a/config/themes.json
+++ b/config/themes.json
@@ -100,7 +100,7 @@
     "ScrollBarBackgroundColor": "#2E3135",
     "ScrollBarHoverColor": "#3B4252",
     "ScrollBarDraggingColor": "#5E81AC",
-    "ProgressBarForegroundColor": "#222222",
+    "ProgressBarForegroundColor": "#6EFF72",
     "ProgressBarBackgroundColor": "Transparent",
     "ProgressBarTextColor": "#232629",
     "ButtonInstallBackgroundColor": "#222222",

--- a/functions/private/Set-WinUtilTweaksProgressIndicator.ps1
+++ b/functions/private/Set-WinUtilTweaksProgressIndicator.ps1
@@ -1,0 +1,35 @@
+function Set-WinUtilTweaksProgressIndicator {
+    <#
+    .SYNOPSIS
+        Shows, updates, or hides the window-level progress indicator used by the
+        Tweaks and Undo workflows. It lives outside the TabControl, so unlike the
+        Install tab's progress bar it stays visible no matter which tab is active.
+    .PARAMETER Visible
+        Whether the indicator should be shown or hidden.
+    .PARAMETER Label
+        The text to display above the progress bar.
+    .PARAMETER Percent
+        The percentage of the progress bar that should be filled (0-100).
+    #>
+    param(
+        [bool]$Visible,
+        [string]$Label,
+        [ValidateRange(0,100)]
+        [int]$Percent
+    )
+
+    $indicatorVisible = if ($Visible) { [Windows.Visibility]::Visible } else { [Windows.Visibility]::Collapsed }
+    $indicatorLabel = $Label
+    $hasLabel = $PSBoundParameters.ContainsKey('Label')
+    $hasPercent = $PSBoundParameters.ContainsKey('Percent')
+
+    Invoke-WPFUIThread -ScriptBlock {
+        $sync.WPFTweaksProgressBar.Visibility = $indicatorVisible
+        if ($hasLabel) {
+            $sync.WPFTweaksProgressLabel.Text = $indicatorLabel
+        }
+        if ($hasPercent) {
+            $sync.WPFTweaksProgressValue.Value = $Percent
+        }
+    }
+}

--- a/functions/public/Invoke-WPFButton.ps1
+++ b/functions/public/Invoke-WPFButton.ps1
@@ -16,6 +16,7 @@ function Invoke-WPFButton {
     #[System.Windows.MessageBox]::Show("$Button","Chris Titus Tech's Windows Utility","OK","Info")
     if (-not $sync.ProcessRunning) {
         Set-WinUtilProgressBar  -label "" -percent 0
+        Set-WinUtilTweaksProgressIndicator -Visible $false
     }
 
     # Check if button is defined in feature config with function or InvokeScript

--- a/functions/public/Invoke-WPFtweaksbutton.ps1
+++ b/functions/public/Invoke-WPFtweaksbutton.ps1
@@ -40,12 +40,14 @@ function Invoke-WPFtweaksbutton {
     }
 
     Set-WinUtilProgressBar -Label "Creating restore point" -Percent 0
+    Set-WinUtilTweaksProgressIndicator -Visible $true -Label "Creating restore point" -Percent 0
     Write-WinUtilLog -Component "Tweaks" -Message "Creating restore point before applying selected tweaks."
     Invoke-WinUtilTweaks $restorePointTweak
     $completedSteps = 1
 
     if ($tweaksToRun.Count -eq 0 -and $dnsProvider -eq "Default") {
       Set-WinUtilProgressBar -Label "Tweaks finished" -Percent 100
+      Set-WinUtilTweaksProgressIndicator -Visible $true -Label "Tweaks finished" -Percent 100
       $sync.ProcessRunning = $false
       Invoke-WPFUIThread -ScriptBlock { Set-WinUtilTaskbaritem -state "None" -overlay "checkmark" }
       Write-Host "================================="
@@ -76,12 +78,14 @@ function Invoke-WPFtweaksbutton {
 
     for ($i = 0; $i -lt $tweaks.Count; $i++) {
       Set-WinUtilProgressBar -Label "Applying $($tweaks[$i])" -Percent ($completedSteps / $totalSteps * 100)
+      Set-WinUtilTweaksProgressIndicator -Visible $true -Label "Applying $($tweaks[$i]) ($($completedSteps + 1)/$totalSteps)" -Percent ($completedSteps / $totalSteps * 100)
       Invoke-WinUtilTweaks $tweaks[$i]
       $completedSteps++
       $progress = $completedSteps / $totalSteps
       Invoke-WPFUIThread -ScriptBlock { Set-WinUtilTaskbaritem -value $progress }
     }
     Set-WinUtilProgressBar -Label "Tweaks finished" -Percent 100
+    Set-WinUtilTweaksProgressIndicator -Visible $true -Label "Tweaks finished" -Percent 100
     $sync.ProcessRunning = $false
     Invoke-WPFUIThread -ScriptBlock { Set-WinUtilTaskbaritem -state "None" -overlay "checkmark" }
     Write-Host "================================="

--- a/functions/public/Invoke-WPFundoall.ps1
+++ b/functions/public/Invoke-WPFundoall.ps1
@@ -34,11 +34,13 @@ function Invoke-WPFundoall {
 
         for ($i = 0; $i -lt $tweaks.Count; $i++) {
             Set-WinUtilProgressBar -Label "Undoing $($tweaks[$i])" -Percent ($i / $tweaks.Count * 100)
+            Set-WinUtilTweaksProgressIndicator -Visible $true -Label "Undoing $($tweaks[$i]) ($($i + 1)/$($tweaks.Count))" -Percent ($i / $tweaks.Count * 100)
             Invoke-WinUtiltweaks $tweaks[$i] -undo $true
             Invoke-WPFUIThread -ScriptBlock { Set-WinUtilTaskbaritem -value ($i/$tweaks.Count) }
         }
 
         Set-WinUtilProgressBar -Label "Undo Tweaks Finished" -Percent 100
+        Set-WinUtilTweaksProgressIndicator -Visible $true -Label "Undo Tweaks Finished" -Percent 100
         $sync.ProcessRunning = $false
         Invoke-WPFUIThread -ScriptBlock { Set-WinUtilTaskbaritem -state "None" -overlay "checkmark" }
         Write-Host "=================================="

--- a/pester/tweaks.Tests.ps1
+++ b/pester/tweaks.Tests.ps1
@@ -34,6 +34,9 @@ BeforeAll {
     function Set-WinUtilProgressBar {
         param($Label, $Percent)
     }
+    function Set-WinUtilTweaksProgressIndicator {
+        param($Visible, $Label, $Percent)
+    }
     function Write-WinUtilLog {
         param($Message, $Level, $Component)
     }

--- a/pester/ui-state.Tests.ps1
+++ b/pester/ui-state.Tests.ps1
@@ -44,7 +44,16 @@ namespace System.Windows.Controls
     . (Join-Path $script:repoRoot "functions\private\Update-WinUtilSelections.ps1")
     . (Join-Path $script:repoRoot "functions\private\Reset-WPFCheckBoxes.ps1")
     . (Join-Path $script:repoRoot "functions\public\Invoke-WPFSelectedCheckboxesUpdate.ps1")
+    . (Join-Path $script:repoRoot "functions\public\Invoke-WPFButton.ps1")
     . (Join-Path $script:repoRoot "functions\public\Invoke-WPFToggleAllCategories.ps1")
+
+    function Set-WinUtilProgressBar {
+        param($Label, $Percent)
+    }
+
+    function Set-WinUtilTweaksProgressIndicator {
+        param($Visible, $Label, $Percent)
+    }
 
     function script:New-WinUtilFakeCheckBox {
         param([bool]$IsChecked = $false)
@@ -270,5 +279,40 @@ Describe "Invoke-WPFToggleAllCategories" {
         Should -Invoke -CommandName Write-Warning -Times 1 -Exactly -ParameterFilter {
             $Message -eq "ItemsControl not initialized"
         }
+    }
+}
+
+Describe "Invoke-WPFButton progress cleanup" {
+    BeforeEach {
+        New-WinUtilUiStateTestContext
+        Mock Set-WinUtilProgressBar { }
+        Mock Set-WinUtilTweaksProgressIndicator { }
+    }
+
+    AfterEach {
+        Remove-Variable -Name sync -Scope Script -ErrorAction SilentlyContinue
+        Remove-Variable -Name sync -Scope Global -ErrorAction SilentlyContinue
+    }
+
+    It "clears completed progress on the next idle button click" {
+        $script:sync.ProcessRunning = $false
+
+        Invoke-WPFButton -Button "WPFNoOp"
+
+        Should -Invoke Set-WinUtilProgressBar -Times 1 -Exactly -ParameterFilter {
+            $Label -eq "" -and $Percent -eq 0
+        }
+        Should -Invoke Set-WinUtilTweaksProgressIndicator -Times 1 -Exactly -ParameterFilter {
+            $Visible -eq $false
+        }
+    }
+
+    It "leaves progress visible while a process is running" {
+        $script:sync.ProcessRunning = $true
+
+        Invoke-WPFButton -Button "WPFNoOp"
+
+        Should -Not -Invoke Set-WinUtilProgressBar
+        Should -Not -Invoke Set-WinUtilTweaksProgressIndicator
     }
 }

--- a/xaml/inputXML.xaml
+++ b/xaml/inputXML.xaml
@@ -918,12 +918,27 @@
                 </MultiDataTrigger>
             </Style.Triggers>
         </Style>
+        <Style x:Key="RoundedProgressBarStyle" TargetType="ProgressBar">
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="ProgressBar">
+                        <Border CornerRadius="4" Background="{DynamicResource MainBackgroundColor}" BorderBrush="{DynamicResource MainForegroundColor}" BorderThickness="1">
+                            <Grid ClipToBounds="True">
+                                <Border Name="PART_Track" CornerRadius="4" Background="Transparent"/>
+                                <Border Name="PART_Indicator" CornerRadius="4" Background="{DynamicResource ProgressBarForegroundColor}" HorizontalAlignment="Left"/>
+                            </Grid>
+                        </Border>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
     </Window.Resources>
     <Grid Background="{DynamicResource MainBackgroundColor}" ShowGridLines="False" Name="WPFMainGrid" Width="Auto" Height="Auto" HorizontalAlignment="Stretch">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*"/>
@@ -1717,5 +1732,13 @@
                 </Grid>
             </TabItem>
         </TabControl>
+
+        <!-- Tweaks/Undo progress indicator - visible regardless of active tab -->
+        <Border Name="WPFTweaksProgressBar" Grid.Row="3" Background="{DynamicResource MainBackgroundColor}" Visibility="Collapsed" Padding="10,6">
+            <StackPanel Orientation="Vertical">
+                <TextBlock Name="WPFTweaksProgressLabel" Text="" Foreground="{DynamicResource MainForegroundColor}" FontSize="13" Background="Transparent" Margin="0,0,0,4"/>
+                <ProgressBar Name="WPFTweaksProgressValue" Height="6" Minimum="0" Maximum="100" Value="0" Style="{StaticResource RoundedProgressBarStyle}"/>
+            </StackPanel>
+        </Border>
     </Grid>
 </Window>


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://winutil.christitus.com/contributing/ -->
<!--Documentation is auto-generated from configs - no manual documentation updates needed -->

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactor
- [x] UI/UX improvement

## Description

Running Run Tweaks / Undo Selected Tweaks gives no visible feedback in the window itself - only the taskbar icon overlay updates, so there's no way to tell what's currently running, how far along it is, or whether it's hung, without alt-tabbing to check the taskbar.

This adds a slim status bar at the bottom of the window (visible regardless of which tab is active, since it lives outside the TabControl) showing the current tweak being applied/undone and a progress bar, using the exact same progress data (`Set-WinUtilProgressBar`) already computed by `Invoke-WPFtweaksbutton.ps1`/`Invoke-WPFundoall.ps1` - it's an additive display, not a rework of the existing Install-tab progress bar (that one stays untouched, it's used deliberately for the Install/Uninstall flow).

New: `functions/private/Set-WinUtilTweaksProgressIndicator.ps1`, following the same pattern as `Set-WinUtilProgressbar.ps1`.

The completed status remains visible until the user's next idle button or tab interaction, then the indicator is hidden so stale tweak status does not persist across unrelated workflows.

## Verification

- `.\Compile.ps1` succeeds.
- Full Pester suite: 411/411 passing.
- Manually run end-to-end (Run Tweaks and Undo, light and dark theme) to confirm the indicator shows/updates/looks correct.

## Issue related to PR
- Resolves #1151
