### PR TITLE
Fix null-reference errors in app entry rendering ($Apps.$appKey -> $app)

### DIFF
--- a/functions/private/Initialize-InstallAppEntry.ps1
+++ b/functions/private/Initialize-InstallAppEntry.ps1
@@ -69,16 +69,16 @@ function Initialize-InstallAppEntry {
         $icon.SetResourceReference([Windows.FrameworkElement]::HeightProperty, "AppEntryIconSize")
         $icon.Margin = New-Object Windows.Thickness(0, 0, 8, 0)
         $fallback = New-Object Windows.Controls.TextBlock
-        $fallback.Text = $Apps.$appKey.content.TrimStart(".").Substring(0, 1).ToUpper()
+        $fallback.Text = $app.content.TrimStart(".").Substring(0, 1).ToUpper()
         $fallback.FontWeight = "Bold"; $fallback.HorizontalAlignment = "Center"; $fallback.VerticalAlignment = "Center"
-        if ($Apps.$appKey.link) { $fallback.Visibility = "Collapsed" }
+        if ($app.link) { $fallback.Visibility = "Collapsed" }
         $fallback.SetResourceReference([Windows.Controls.TextBlock]::FontSizeProperty, "AppEntryFontSize")
         $fallback.SetResourceReference([Windows.Controls.TextBlock]::ForegroundProperty, "ToggleButtonOnColor")
         [void]$icon.Children.Add($fallback)
-        if ($Apps.$appKey.link) {
+        if ($app.link) {
             $logo = New-Object Windows.Controls.Image
             $logo.Stretch = [Windows.Media.Stretch]::Uniform
-            $logo.Source = "https://www.google.com/s2/favicons?sz=64&domain_url=$([uri]::EscapeDataString($Apps.$appKey.link))"
+            $logo.Source = "https://www.google.com/s2/favicons?sz=64&domain_url=$([uri]::EscapeDataString($app.link))"
             $logo.Add_ImageFailed({ $this.Visibility = "Collapsed"; $this.Parent.Children[0].Visibility = "Visible" })
             [void]$icon.Children.Add($logo)
         }


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://winutil.christitus.com/contributing/ -->
<!--Documentation is auto-generated from configs - no manual documentation updates needed -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] UI/UX improvement

## Description

`Initialize-InstallAppEntry.ps1` computes the correctly-scoped `$app = $sync.configs.applicationsHashtable.$appKey` early in the function (and already uses `$app` at lines 22, 90, 93, 104, 105), but 4 later references still used the undefined `$Apps.$appKey` (capital A) instead - throwing `InvalidOperation: You cannot call a method on a null-valued expression` for every single app card rendered on the Install tab.

Beyond the console spam, this silently broke the app-icon logic: since `$Apps.$appKey.link` always threw/evaluated as falsy, every app card fell back to showing just a letter instead of its real favicon.

Fix: replace the 4 stale `$Apps.$appKey` references with `$app`, matching the rest of the function.

## Verification

- `.\Compile.ps1` succeeds.
- Full Pester suite: 398/398 passing - the repo's own pre-existing test for this exact bug (`pester/install-rendering.Tests.ps1` -> "keeps app-entry metadata lookup independent from the old caller scope") now passes; it was failing on `main` before this fix.
- Ran the app: no more errors in the console, and app icons now load correctly instead of falling back to letters.

## Issue related to PR
- Resolves #4833
