### PR TITLE
bugfix: wrap Tweaks header buttons to prevent layout clipping

### DIFF
--- a/xaml/inputXML.xaml
+++ b/xaml/inputXML.xaml
@@ -1326,14 +1326,14 @@
 
                             <StackPanel Background="{DynamicResource MainBackgroundColor}" Orientation="Vertical" Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" Margin="5">
                                 <Label Content="Recommended Selections:" FontSize="{DynamicResource FontSize}" VerticalAlignment="Center" Margin="2"/>
-                                <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" Margin="0,2,0,0">
+                                <WrapPanel Orientation="Horizontal" HorizontalAlignment="Left" Margin="0,2,0,0">
                                     <Button Name="WPFstandard" Content=" Standard " Margin="2" Width="{DynamicResource ButtonWidth}" Height="{DynamicResource ButtonHeight}"/>
                                     <Button Name="WPFminimal" Content=" Minimal " Margin="2" Width="{DynamicResource ButtonWidth}" Height="{DynamicResource ButtonHeight}"/>
                                     <Button Name="WPFAdvanced" Content=" Advanced " Margin="2" Width="{DynamicResource ButtonWidth}" Height="{DynamicResource ButtonHeight}"/>
                                     <Button Name="WPFClearTweaksSelection" Content=" Clear " Margin="2" Width="{DynamicResource ButtonWidth}" Height="{DynamicResource ButtonHeight}"/>
                                     <Button Name="WPFGetInstalledTweaks" Content=" Get Installed Tweaks " Margin="2" Width="{DynamicResource ButtonWidth}" Height="{DynamicResource ButtonHeight}"/>
                                     <Button Name="WPFAppxRemoval" Content=" AppX Removal " Margin="2" Width="{DynamicResource ButtonWidth}" Height="{DynamicResource ButtonHeight}"/>
-                                </StackPanel>
+                                </WrapPanel>
                             </StackPanel>
 
                             <Grid Name="tweakspanel" Grid.Row="1">


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://winutil.christitus.com/contributing/ -->
<!--Documentation is auto-generated from configs - no manual documentation updates needed -->

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactor
- [x] UI/UX improvement

<!-- This automatically adds labels to your PR based on the selections above. -->

## Description
The recommended selections button row on the Tweaks tab was using a StackPanel. If the window was resized below ~1200px or forced smaller by tiling window managers like GlazeWM, the buttons at the end (like "AppX Removal") would clip off-screen and become hidden.

I swapped the container to a WrapPanel so that the buttons wrap to a new line when horizontal space runs out.

### Screenshots
* **Before:** <img width="738" height="303" alt="image" src="https://github.com/user-attachments/assets/c973d022-02e6-49df-9b44-bdcf06988e39" />
* **After:** <img width="1707" height="1103" alt="image" src="https://github.com/user-attachments/assets/0f103768-a829-489d-bb1a-9969073ca892" />

### Verification
- [x] Ran Pester tests locally; all 456 known tests passed.
- [x] Tested window resizing to confirm buttons wrap instead of clipping.

## Issue related to PR
- Resolves: No pre-existing issue was created. This layout bug was reported and discussed in the Discord Server.