### PR TITLE
refactor: style and align Install tab filter chips

### DIFF
--- a/xaml/inputXML.xaml
+++ b/xaml/inputXML.xaml
@@ -965,15 +965,10 @@
             </Setter>
         </Style>
         <!-- Filter Chip Style — used by the Install tab category filter buttons -->
-        <Style x:Key="FilterChipStyle" TargetType="Button">
+        <Style x:Key="FilterChipStyle" TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
             <Setter Property="Margin" Value="2"/>
             <Setter Property="Padding" Value="12,0,12,0"/>
             <Setter Property="Width" Value="Auto"/>
-            <Setter Property="Height" Value="{DynamicResource ButtonHeight}"/>
-            <Setter Property="Foreground" Value="{DynamicResource ButtonForegroundColor}"/>
-            <Setter Property="Background" Value="{DynamicResource ButtonBackgroundColor}"/>
-            <Setter Property="FontSize" Value="{DynamicResource ButtonFontSize}"/>
-            <Setter Property="FontFamily" Value="{DynamicResource FontFamily}"/>
             <Setter Property="Cursor" Value="Hand"/>
             <Setter Property="Template">
                 <Setter.Value>

--- a/xaml/inputXML.xaml
+++ b/xaml/inputXML.xaml
@@ -964,6 +964,44 @@
                 </Setter.Value>
             </Setter>
         </Style>
+        <!-- Filter Chip Style — used by the Install tab category filter buttons -->
+        <Style x:Key="FilterChipStyle" TargetType="Button">
+            <Setter Property="Margin" Value="2"/>
+            <Setter Property="Padding" Value="12,0,12,0"/>
+            <Setter Property="Width" Value="Auto"/>
+            <Setter Property="Height" Value="{DynamicResource ButtonHeight}"/>
+            <Setter Property="Foreground" Value="{DynamicResource ButtonForegroundColor}"/>
+            <Setter Property="Background" Value="{DynamicResource ButtonBackgroundColor}"/>
+            <Setter Property="FontSize" Value="{DynamicResource ButtonFontSize}"/>
+            <Setter Property="FontFamily" Value="{DynamicResource FontFamily}"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border Name="ChipBorder"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{DynamicResource ButtonBorderThickness}"
+                                CornerRadius="{DynamicResource ButtonCornerRadius}"
+                                Padding="{TemplateBinding Padding}">
+                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsPressed" Value="True">
+                                <Setter TargetName="ChipBorder" Property="Background" Value="{DynamicResource ButtonBackgroundPressedColor}"/>
+                            </Trigger>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="ChipBorder" Property="Background" Value="{DynamicResource ButtonBackgroundMouseoverColor}"/>
+                            </Trigger>
+                            <Trigger Property="IsEnabled" Value="False">
+                                <Setter TargetName="ChipBorder" Property="Background" Value="{DynamicResource ButtonBackgroundSelectedColor}"/>
+                                <Setter Property="Foreground" Value="DimGray"/>
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
     </Window.Resources>
     <Grid Background="{DynamicResource MainBackgroundColor}" ShowGridLines="False" Name="WPFMainGrid" Width="Auto" Height="Auto" HorizontalAlignment="Stretch">
         <Grid.RowDefinitions>
@@ -1282,16 +1320,23 @@
 
                     <!-- Quick Category Search Chips -->
                     <WrapPanel Grid.Row="0" Orientation="Horizontal" Margin="5,5,5,5" Name="WPFSearchChips">
-                        <Button Name="WPFSearchChipAll"             Content="All"               Width="Auto" Height="Auto" Margin="2"/>
-                        <Button Name="WPFSearchChipBrowsers"        Content="Browsers"          Width="Auto" Height="Auto" Margin="2"/>
-                        <Button Name="WPFSearchChipCommunications"  Content="Communications"    Width="Auto" Height="Auto" Margin="2"/>
-                        <Button Name="WPFSearchChipDevelopment"     Content="Development"       Width="Auto" Height="Auto" Margin="2"/>
-                        <Button Name="WPFSearchChipGames"           Content="Games"             Width="Auto" Height="Auto" Margin="2"/>
-                        <Button Name="WPFSearchChipMicrosoftTools"  Content="Microsoft Tools"   Width="Auto" Height="Auto" Margin="2"/>
-                        <Button Name="WPFSearchChipMultimediaTools" Content="Multimedia Tools"  Width="Auto" Height="Auto" Margin="2"/>
-                        <Button Name="WPFSearchChipProTools"        Content="Pro Tools"         Width="Auto" Height="Auto" Margin="2"/>
-                        <Button Name="WPFSearchChipSelfhostedTools" Content="Selfhosted Tools"  Width="Auto" Height="Auto" Margin="2"/>
-                        <Button Name="WPFSearchChipUtilities"       Content="Utilities"         Width="Auto" Height="Auto" Margin="2"/>
+                        <TextBlock Text="Filters"
+                                   FontSize="{DynamicResource HeaderFontSize}"
+                                   FontFamily="{DynamicResource HeaderFontFamily}"
+                                   Foreground="{DynamicResource LabelboxForegroundColor}"
+                                   Background="Transparent"
+                                   VerticalAlignment="Center"
+                                   Margin="15,0,8,0"/>
+                        <Button Name="WPFSearchChipAll"             Content="All"               Style="{StaticResource FilterChipStyle}"/>
+                        <Button Name="WPFSearchChipBrowsers"        Content="Browsers"          Style="{StaticResource FilterChipStyle}"/>
+                        <Button Name="WPFSearchChipCommunications"  Content="Communications"    Style="{StaticResource FilterChipStyle}"/>
+                        <Button Name="WPFSearchChipDevelopment"     Content="Development"       Style="{StaticResource FilterChipStyle}"/>
+                        <Button Name="WPFSearchChipGames"           Content="Games"             Style="{StaticResource FilterChipStyle}"/>
+                        <Button Name="WPFSearchChipMicrosoftTools"  Content="Microsoft Tools"   Style="{StaticResource FilterChipStyle}"/>
+                        <Button Name="WPFSearchChipMultimediaTools" Content="Multimedia Tools"  Style="{StaticResource FilterChipStyle}"/>
+                        <Button Name="WPFSearchChipProTools"        Content="Pro Tools"         Style="{StaticResource FilterChipStyle}"/>
+                        <Button Name="WPFSearchChipSelfhostedTools" Content="Selfhosted Tools"  Style="{StaticResource FilterChipStyle}"/>
+                        <Button Name="WPFSearchChipUtilities"       Content="Utilities"         Style="{StaticResource FilterChipStyle}"/>
                     </WrapPanel>
 
                     <Grid Grid.Row="1" Margin="{DynamicResource TabContentMargin}">


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://winutil.christitus.com/contributing/ -->
<!--Documentation is auto-generated from configs - no manual documentation updates needed -->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [x] Refactor
- [x] UI/UX improvement

<!-- This automatically adds labels to your PR based on the selections above. -->

## Description
Refactored the top category filter buttons on the Install tab to clean up their layout and make them match the rest of the application:

* **Centralized Style:** Created a `FilterChipStyle` in Window.Resources. This replaces the inline overrides with standard height/paddings and keeps the corners rectangular to match other buttons in the app.
* **Added Section Label:** Added a "Filters" header label in the same cyan style as other section headers to make their purpose clear.
* **Alignment Fix:** Aligned the new label and buttons with the left sidebar ("Actions", "Package Manager", etc.) at a 20px indent so they line up cleanly.

### Screenshots
* **Before:** 
<img width="1719" height="1115" alt="image" src="https://github.com/user-attachments/assets/deca9f14-222d-492b-ad8f-807d20f10a33" />

* **After:** <img width="1918" height="1104" alt="image" src="https://github.com/user-attachments/assets/301e8748-82d9-4271-977f-12c475c5db95" />

### Verification
- [x] Ran Pester tests locally; all 456 known tests passed.
- [x] Verified the design works nicely in both light and dark themes.

## Issue related to PR
- Resolves: N/A