### PR TITLE
Fix Show Installed Apps reliability and selection

### DIFF
--- a/functions/private/Invoke-WinUtilCurrentSystem.ps1
+++ b/functions/private/Invoke-WinUtilCurrentSystem.ps1
@@ -15,32 +15,36 @@ Function Invoke-WinUtilCurrentSystem {
     )
     if ($CheckBox -eq "choco") {
         $apps = (choco list | Select-String -Pattern "^\S+").Matches.Value
-        $filter = Get-WinUtilVariables -Type Checkbox | Where-Object {$psitem -like "WPFInstall*"}
-        $sync.GetEnumerator() | Where-Object {$psitem.Key -in $filter} | ForEach-Object {
-            $dependencies = @($sync.configs.applications.$($psitem.Key).choco -split ";")
-            if ($dependencies -in $apps) {
-                Write-Output $psitem.name
+        $sync.configs.applicationsHashtable.GetEnumerator() | ForEach-Object {
+            $packageId = ($_.Value.choco -split ";")[-1].Trim()
+            if ($packageId -ne "na" -and $packageId -in $apps) {
+                Write-Output $_.Key
             }
         }
     }
 
     if ($checkbox -eq "winget") {
-
         $originalEncoding = [Console]::OutputEncoding
-        [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new()
-        $Sync.InstalledPrograms = @("winget", "msstore") | ForEach-Object {
-            winget list -s $psitem | Select-Object -skip 3 | ConvertFrom-String -PropertyNames "Name", "Id", "Version", "Available" -Delimiter '\s{2,}'
+        try {
+            [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new()
+            $installedProgramOutput = @(winget list --accept-source-agreements --disable-interactivity 2>&1)
+            if ($LASTEXITCODE -ne 0) {
+                throw "winget list failed with exit code $LASTEXITCODE."
+            }
+        } finally {
+            [Console]::OutputEncoding = $originalEncoding
         }
-        [Console]::OutputEncoding = $originalEncoding
+        $installedProgramText = $installedProgramOutput -join "`n"
 
-        $filter = Get-WinUtilVariables -Type Checkbox | Where-Object {$psitem -like "WPFInstall*"}
-        $sync.GetEnumerator() | Where-Object {$psitem.Key -in $filter} | ForEach-Object {
-            $dependencies = @(
-                ($sync.configs.applications.$($psitem.Key).winget -split ";") -replace "^msstore:", ""
-            )
+        $sync.configs.applicationsHashtable.GetEnumerator() | ForEach-Object {
+            $packageId = (($_.Value.winget -split ";")[-1] -replace "^msstore:", "").Trim()
+            if ([string]::IsNullOrWhiteSpace($packageId) -or $packageId -eq "na") {
+                return
+            }
 
-            if ($dependencies[-1] -in $sync.InstalledPrograms.Id) {
-                Write-Output $psitem.name
+            $packagePattern = "(?im)[^\S\r\n]{2,}$([regex]::Escape($packageId))(?=[^\S\r\n]{2,}|$)"
+            if ($installedProgramText -match $packagePattern) {
+                Write-Output $_.Key
             }
         }
     }

--- a/functions/private/Invoke-WinUtilCurrentSystem.ps1
+++ b/functions/private/Invoke-WinUtilCurrentSystem.ps1
@@ -35,9 +35,9 @@ Function Invoke-WinUtilCurrentSystem {
 
         $filter = Get-WinUtilVariables -Type Checkbox | Where-Object {$psitem -like "WPFInstall*"}
         $sync.GetEnumerator() | Where-Object {$psitem.Key -in $filter} | ForEach-Object {
-            $dependencies = @($sync.configs.applications.$($psitem.Key).winget -split ";") | ForEach-Object {
-                $psitem -replace "^msstore:", ""
-            }
+            $dependencies = @(
+                ($sync.configs.applications.$($psitem.Key).winget -split ";") -replace "^msstore:", ""
+            )
 
             if ($dependencies[-1] -in $sync.InstalledPrograms.Id) {
                 Write-Output $psitem.name

--- a/functions/public/Invoke-WPFGetInstalled.ps1
+++ b/functions/public/Invoke-WPFGetInstalled.ps1
@@ -41,8 +41,17 @@ function Invoke-WPFGetInstalled {
         }
 
         $sync.form.Dispatcher.invoke({
-            foreach ($checkbox in $Checkboxes) {
-                $sync.$checkbox.ischecked = $True
+            if ($checkbox -eq "winget") {
+                foreach ($checkboxName in $Checkboxes) {
+                    if (-not $sync.selectedApps.Contains($checkboxName)) {
+                        $sync.selectedApps.Add($checkboxName)
+                    }
+                }
+                Reset-WPFCheckBoxes -checkboxfilterpattern "WPFInstall*"
+            } else {
+                foreach ($checkboxName in $Checkboxes) {
+                    $sync.$checkboxName.ischecked = $True
+                }
             }
         })
 

--- a/functions/public/Invoke-WPFGetInstalled.ps1
+++ b/functions/public/Invoke-WPFGetInstalled.ps1
@@ -18,50 +18,72 @@ function Invoke-WPFGetInstalled {
         return
     }
     $managerPreference = $sync.preferences.packagemanager
-
-    Invoke-WPFRunspace -ParameterList @(("managerPreference", $managerPreference),("checkbox", $checkbox)) -ScriptBlock {
-        param (
-            [string]$checkbox,
-            [string]$managerPreference
+    $operation = [Hashtable]::Synchronized(@{
+        Checkboxes = @()
+        Error = $null
+    })
+    $completeAction = [Action[hashtable, string]]{
+        param(
+            [hashtable]$completedOperation,
+            [string]$completedCheckbox
         )
-        $sync.ProcessRunning = $true
         try {
-            Invoke-WPFUIThread -ScriptBlock { Set-WinUtilTaskbaritem -state "Indeterminate" }
-
-            if ($checkbox -eq "winget") {
-                Write-Host "Getting Installed Programs..."
-                switch ($managerPreference) {
-                    "Choco"{$Checkboxes = Invoke-WinUtilCurrentSystem -CheckBox "choco"; break}
-                    "Winget"{$Checkboxes = Invoke-WinUtilCurrentSystem -CheckBox $checkbox; break}
-                }
-            }
-            elseif ($checkbox -eq "tweaks") {
-                Write-Host "Getting Installed Tweaks..."
-                $Checkboxes = Invoke-WinUtilCurrentSystem -CheckBox $checkbox
+            if ($completedOperation.Error) {
+                Write-WinUtilLog -Level "ERROR" -Component "Install" -Message "Get installed state failed: $($completedOperation.Error)"
+                Write-Warning "Unable to get installed state: $($completedOperation.Error)"
+                return
             }
 
-            Invoke-WPFUIThread -ScriptBlock {
-                if ($checkbox -eq "winget") {
-                    foreach ($checkboxName in $Checkboxes) {
-                        if (-not $sync.selectedApps.Contains($checkboxName)) {
-                            $sync.selectedApps.Add($checkboxName)
-                        }
-                    }
-                    Reset-WPFCheckBoxes -checkboxfilterpattern "WPFInstall*"
-                } else {
-                    foreach ($checkboxName in $Checkboxes) {
-                        $sync.$checkboxName.ischecked = $True
+            if ($completedCheckbox -eq "winget") {
+                foreach ($checkboxName in $completedOperation.Checkboxes) {
+                    if (-not $sync.selectedApps.Contains($checkboxName)) {
+                        $sync.selectedApps.Add($checkboxName)
                     }
                 }
+                Reset-WPFCheckBoxes -checkboxfilterpattern "WPFInstall*"
+            } else {
+                foreach ($checkboxName in $completedOperation.Checkboxes) {
+                    $sync.$checkboxName.ischecked = $True
+                }
             }
-
-            Write-Host "Done..."
-        } catch {
-            Write-WinUtilLog -Level "ERROR" -Component "Install" -Message "Get installed state failed: $($_.Exception.Message)"
-            Write-Warning "Unable to get installed state: $($_.Exception.Message)"
         } finally {
             $sync.ProcessRunning = $false
-            Invoke-WPFUIThread -ScriptBlock { Set-WinUtilTaskbaritem -state "None" }
+            Set-WinUtilTaskbaritem -state "None"
         }
+    }
+
+    $sync.ProcessRunning = $true
+    Set-WinUtilTaskbaritem -state "Indeterminate"
+    try {
+        Invoke-WPFRunspace -ParameterList @(
+            ("managerPreference", $managerPreference),
+            ("checkbox", $checkbox),
+            ("operation", $operation),
+            ("completeAction", $completeAction)
+        ) -ScriptBlock {
+            param (
+                [string]$checkbox,
+                [string]$managerPreference,
+                [hashtable]$operation,
+                [Action[hashtable, string]]$completeAction
+            )
+            try {
+                if ($checkbox -eq "winget") {
+                    switch ($managerPreference) {
+                        "Choco" { $operation.Checkboxes = @(Invoke-WinUtilCurrentSystem -CheckBox "choco"); break }
+                        "Winget" { $operation.Checkboxes = @(Invoke-WinUtilCurrentSystem -CheckBox $checkbox); break }
+                    }
+                } elseif ($checkbox -eq "tweaks") {
+                    $operation.Checkboxes = @(Invoke-WinUtilCurrentSystem -CheckBox $checkbox)
+                }
+            } catch {
+                $operation.Error = $_.Exception.Message
+            } finally {
+                $sync.Form.Dispatcher.BeginInvoke($completeAction, [object[]]@($operation, $checkbox)) | Out-Null
+            }
+        }
+    } catch {
+        $operation.Error = $_.Exception.Message
+        $completeAction.Invoke($operation, $checkbox)
     }
 }

--- a/functions/public/Invoke-WPFGetInstalled.ps1
+++ b/functions/public/Invoke-WPFGetInstalled.ps1
@@ -1,6 +1,5 @@
 function Invoke-WPFGetInstalled {
     <#
-    TODO: Add the Option to use Chocolatey as Engine
     .SYNOPSIS
         Invokes the function that gets the checkboxes to check in a new runspace
 
@@ -26,37 +25,43 @@ function Invoke-WPFGetInstalled {
             [string]$managerPreference
         )
         $sync.ProcessRunning = $true
-        Invoke-WPFUIThread -ScriptBlock { Set-WinUtilTaskbaritem -state "Indeterminate" }
+        try {
+            Invoke-WPFUIThread -ScriptBlock { Set-WinUtilTaskbaritem -state "Indeterminate" }
 
-        if ($checkbox -eq "winget") {
-            Write-Host "Getting Installed Programs..."
-            switch ($managerPreference) {
-                "Choco"{$Checkboxes = Invoke-WinUtilCurrentSystem -CheckBox "choco"; break}
-                "Winget"{$Checkboxes = Invoke-WinUtilCurrentSystem -CheckBox $checkbox; break}
-            }
-        }
-        elseif ($checkbox -eq "tweaks") {
-            Write-Host "Getting Installed Tweaks..."
-            $Checkboxes = Invoke-WinUtilCurrentSystem -CheckBox $checkbox
-        }
-
-        $sync.form.Dispatcher.invoke({
             if ($checkbox -eq "winget") {
-                foreach ($checkboxName in $Checkboxes) {
-                    if (-not $sync.selectedApps.Contains($checkboxName)) {
-                        $sync.selectedApps.Add($checkboxName)
+                Write-Host "Getting Installed Programs..."
+                switch ($managerPreference) {
+                    "Choco"{$Checkboxes = Invoke-WinUtilCurrentSystem -CheckBox "choco"; break}
+                    "Winget"{$Checkboxes = Invoke-WinUtilCurrentSystem -CheckBox $checkbox; break}
+                }
+            }
+            elseif ($checkbox -eq "tweaks") {
+                Write-Host "Getting Installed Tweaks..."
+                $Checkboxes = Invoke-WinUtilCurrentSystem -CheckBox $checkbox
+            }
+
+            Invoke-WPFUIThread -ScriptBlock {
+                if ($checkbox -eq "winget") {
+                    foreach ($checkboxName in $Checkboxes) {
+                        if (-not $sync.selectedApps.Contains($checkboxName)) {
+                            $sync.selectedApps.Add($checkboxName)
+                        }
+                    }
+                    Reset-WPFCheckBoxes -checkboxfilterpattern "WPFInstall*"
+                } else {
+                    foreach ($checkboxName in $Checkboxes) {
+                        $sync.$checkboxName.ischecked = $True
                     }
                 }
-                Reset-WPFCheckBoxes -checkboxfilterpattern "WPFInstall*"
-            } else {
-                foreach ($checkboxName in $Checkboxes) {
-                    $sync.$checkboxName.ischecked = $True
-                }
             }
-        })
 
-        Write-Host "Done..."
-        $sync.ProcessRunning = $false
-        Invoke-WPFUIThread -ScriptBlock { Set-WinUtilTaskbaritem -state "None" }
+            Write-Host "Done..."
+        } catch {
+            Write-WinUtilLog -Level "ERROR" -Component "Install" -Message "Get installed state failed: $($_.Exception.Message)"
+            Write-Warning "Unable to get installed state: $($_.Exception.Message)"
+        } finally {
+            $sync.ProcessRunning = $false
+            Invoke-WPFUIThread -ScriptBlock { Set-WinUtilTaskbaritem -state "None" }
+        }
     }
 }

--- a/functions/public/Invoke-WPFRunspace.ps1
+++ b/functions/public/Invoke-WPFRunspace.ps1
@@ -44,6 +44,8 @@ public sealed class WinUtilRunspaceCleanupState
 
 public static class WinUtilRunspaceCleanup
 {
+    public static readonly System.Threading.WaitOrTimerCallback Callback = Cleanup;
+
     public static void Cleanup(object state, bool timedOut)
     {
         var cleanupState = state as WinUtilRunspaceCleanupState;
@@ -89,8 +91,7 @@ public static class WinUtilRunspaceCleanup
     $cleanupState = [WinUtilRunspaceCleanupState]::new()
     $cleanupState.PowerShell = $powershell
     $cleanupState.Handle = $handle
-    $cleanupCallback = [System.Threading.WaitOrTimerCallback][WinUtilRunspaceCleanup]::Cleanup
-    [System.Threading.ThreadPool]::RegisterWaitForSingleObject($handle.AsyncWaitHandle, $cleanupCallback, $cleanupState, -1, $true) | Out-Null
+    [System.Threading.ThreadPool]::RegisterWaitForSingleObject($handle.AsyncWaitHandle, [WinUtilRunspaceCleanup]::Callback, $cleanupState, -1, $true) | Out-Null
 
     # Return the handle
     return $handle

--- a/functions/public/Invoke-WPFSelectedCheckboxesUpdate.ps1
+++ b/functions/public/Invoke-WPFSelectedCheckboxesUpdate.ps1
@@ -7,11 +7,21 @@ function Invoke-WPFSelectedCheckboxesUpdate ($type, $checkboxName) {
         '^WPFAppx'    { 'selectedAppx' }
     }
 
+    $selectionChanged = $false
     if ($type -eq "Add") {
         if (-not $sync.$listName.Contains($checkboxName)) {
             $sync.$listName.Add($checkboxName)
+            $selectionChanged = $true
         }
     } else {
-        $sync.$listName.Remove($checkboxName)
+        $selectionChanged = $sync.$listName.Remove($checkboxName)
+    }
+
+    if ($listName -eq "selectedApps" -and $selectionChanged) {
+        $sync.WPFselectedAppsButton.Content = "Selected Apps: $($sync.selectedApps.Count)"
+        $sync.selectedAppsstackPanel.Children.Clear()
+        $sync.selectedApps | Sort-Object | ForEach-Object {
+            Add-SelectedAppsMenuItem -name $sync.configs.applicationsHashtable.$_.Content -key $_
+        }
     }
 }

--- a/pester/runspace.Tests.ps1
+++ b/pester/runspace.Tests.ps1
@@ -140,6 +140,10 @@ Describe "Invoke-WPFRunspace behavior" {
         $runspaceScript | Should -Not -Match '\$script:powershell'
         $runspaceScript | Should -Not -Match '\$script:handle'
     }
+
+    It "exposes a strongly typed cleanup callback" {
+        ([WinUtilRunspaceCleanup]::Callback -is [System.Threading.WaitOrTimerCallback]) | Should -BeTrue
+    }
 }
 
 Describe "Public runspace callers" {

--- a/pester/system-helpers.Tests.ps1
+++ b/pester/system-helpers.Tests.ps1
@@ -11,15 +11,10 @@ BeforeAll {
     . (Join-Path $script:repoRoot "functions\private\Set-WinUtilService.ps1")
 
     function winget {
-        param(
-            [Parameter(Position = 0)]
-            $Command,
-            [Alias("s")]
-            $Source
-        )
+        param([Parameter(ValueFromRemainingArguments = $true)]$Arguments)
     }
-    function Get-WinUtilVariables {
-        param($Type)
+    function choco {
+        param([Parameter(ValueFromRemainingArguments = $true)]$Arguments)
     }
     function Write-WinUtilLog { }
 }
@@ -27,42 +22,35 @@ BeforeAll {
 Describe "Invoke-WinUtilCurrentSystem installed apps" {
     BeforeEach {
         $script:sync = [Hashtable]::Synchronized(@{
-            WPFInstallGit = [pscustomobject]@{}
-            WPFInstallChatGPT = [pscustomobject]@{}
-            WPFInstallMissing = [pscustomobject]@{}
             configs = [pscustomobject]@{
-                applications = [pscustomobject]@{
-                    WPFInstallGit = [pscustomobject]@{ winget = "Git.Git" }
-                    WPFInstallChatGPT = [pscustomobject]@{ winget = "msstore:9NT1R1C2HH7J" }
-                    WPFInstallMissing = [pscustomobject]@{ winget = "Missing.Package" }
+                applicationsHashtable = @{
+                    WPFInstallGit = [pscustomobject]@{ winget = "Git.Git"; choco = "git" }
+                    WPFInstallChatGPT = [pscustomobject]@{ winget = "msstore:9NT1R1C2HH7J"; choco = "na" }
+                    WPFInstallMissing = [pscustomobject]@{ winget = "Git"; choco = "missing" }
                 }
             }
         })
 
-        Mock Get-WinUtilVariables {
-            @("WPFInstallGit", "WPFInstallChatGPT", "WPFInstallMissing")
-        }
         Mock winget {
-            if ($Source -eq "winget") {
-                @(
-                    "",
-                    "Name  Id  Version  Available",
-                    "----  --  -------  ---------",
-                    "Git  Git.Git  2.0  "
-                )
-            } else {
-                @(
-                    "",
-                    "Name  Id  Version  Available",
-                    "----  --  -------  ---------",
-                    "ChatGPT  9NT1R1C2HH7J  1.0  "
-                )
-            }
+            $global:LASTEXITCODE = 0
+            $script:wingetArguments = @($Arguments)
+            @(
+                "Name  Id  Version  Source",
+                "--------------------------------",
+                "Git  Git.Git  2.0  winget",
+                "ChatGPT  9NT1R1C2HH7J  1.0  msstore"
+            )
+        }
+        Mock choco {
+            $script:chocoArguments = @($Arguments)
+            @("Chocolatey v2", "git 2.0", "2 packages installed.")
         }
     }
 
     AfterEach {
         Remove-Variable -Name sync -Scope Script -ErrorAction SilentlyContinue
+        Remove-Variable -Name wingetArguments -Scope Script -ErrorAction SilentlyContinue
+        Remove-Variable -Name chocoArguments -Scope Script -ErrorAction SilentlyContinue
     }
 
     It "matches single standard and Microsoft Store package IDs" {
@@ -72,8 +60,25 @@ Describe "Invoke-WinUtilCurrentSystem installed apps" {
         $result | Should -Contain "WPFInstallGit"
         $result | Should -Contain "WPFInstallChatGPT"
         $result | Should -Not -Contain "WPFInstallMissing"
-        Should -Invoke -CommandName winget -Times 1 -Exactly -ParameterFilter { $Source -eq "winget" }
-        Should -Invoke -CommandName winget -Times 1 -Exactly -ParameterFilter { $Source -eq "msstore" }
+        Should -Invoke -CommandName winget -Times 1 -Exactly
+        $script:wingetArguments | Should -Be @("list", "--accept-source-agreements", "--disable-interactivity")
+    }
+
+    It "fails promptly when Winget cannot list applications" {
+        Mock winget {
+            $global:LASTEXITCODE = 1
+            "winget failed"
+        }
+
+        { Invoke-WinUtilCurrentSystem -CheckBox "winget" } | Should -Throw "winget list failed with exit code 1."
+    }
+
+    It "matches the primary Chocolatey package ID in one list call" {
+        $result = @(Invoke-WinUtilCurrentSystem -CheckBox "choco")
+
+        $result | Should -Be @("WPFInstallGit")
+        Should -Invoke -CommandName choco -Times 1 -Exactly
+        $script:chocoArguments | Should -Be @("list")
     }
 }
 

--- a/pester/system-helpers.Tests.ps1
+++ b/pester/system-helpers.Tests.ps1
@@ -6,10 +6,75 @@ $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
 
 BeforeAll {
     $script:repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+    . (Join-Path $script:repoRoot "functions\private\Invoke-WinUtilCurrentSystem.ps1")
     . (Join-Path $script:repoRoot "functions\private\Set-WinUtilRegistry.ps1")
     . (Join-Path $script:repoRoot "functions\private\Set-WinUtilService.ps1")
 
+    function winget {
+        param(
+            [Parameter(Position = 0)]
+            $Command,
+            [Alias("s")]
+            $Source
+        )
+    }
+    function Get-WinUtilVariables {
+        param($Type)
+    }
     function Write-WinUtilLog { }
+}
+
+Describe "Invoke-WinUtilCurrentSystem installed apps" {
+    BeforeEach {
+        $script:sync = [Hashtable]::Synchronized(@{
+            WPFInstallGit = [pscustomobject]@{}
+            WPFInstallChatGPT = [pscustomobject]@{}
+            WPFInstallMissing = [pscustomobject]@{}
+            configs = [pscustomobject]@{
+                applications = [pscustomobject]@{
+                    WPFInstallGit = [pscustomobject]@{ winget = "Git.Git" }
+                    WPFInstallChatGPT = [pscustomobject]@{ winget = "msstore:9NT1R1C2HH7J" }
+                    WPFInstallMissing = [pscustomobject]@{ winget = "Missing.Package" }
+                }
+            }
+        })
+
+        Mock Get-WinUtilVariables {
+            @("WPFInstallGit", "WPFInstallChatGPT", "WPFInstallMissing")
+        }
+        Mock winget {
+            if ($Source -eq "winget") {
+                @(
+                    "",
+                    "Name  Id  Version  Available",
+                    "----  --  -------  ---------",
+                    "Git  Git.Git  2.0  "
+                )
+            } else {
+                @(
+                    "",
+                    "Name  Id  Version  Available",
+                    "----  --  -------  ---------",
+                    "ChatGPT  9NT1R1C2HH7J  1.0  "
+                )
+            }
+        }
+    }
+
+    AfterEach {
+        Remove-Variable -Name sync -Scope Script -ErrorAction SilentlyContinue
+    }
+
+    It "matches single standard and Microsoft Store package IDs" {
+        $result = @(Invoke-WinUtilCurrentSystem -CheckBox "winget")
+
+        $result | Should -HaveCount 2
+        $result | Should -Contain "WPFInstallGit"
+        $result | Should -Contain "WPFInstallChatGPT"
+        $result | Should -Not -Contain "WPFInstallMissing"
+        Should -Invoke -CommandName winget -Times 1 -Exactly -ParameterFilter { $Source -eq "winget" }
+        Should -Invoke -CommandName winget -Times 1 -Exactly -ParameterFilter { $Source -eq "msstore" }
+    }
 }
 
 Describe "Set-WinUtilRegistry" {

--- a/pester/ui-state.Tests.ps1
+++ b/pester/ui-state.Tests.ps1
@@ -61,12 +61,28 @@ namespace System.Windows.Controls
 
     . (Join-Path $script:repoRoot "functions\private\Update-WinUtilSelections.ps1")
     . (Join-Path $script:repoRoot "functions\private\Reset-WPFCheckBoxes.ps1")
+    . (Join-Path $script:repoRoot "functions\public\Invoke-WPFGetInstalled.ps1")
     . (Join-Path $script:repoRoot "functions\public\Invoke-WPFSelectedCheckboxesUpdate.ps1")
     . (Join-Path $script:repoRoot "functions\public\Invoke-WPFButton.ps1")
     . (Join-Path $script:repoRoot "functions\public\Invoke-WPFToggleAllCategories.ps1")
 
     function Set-WinUtilTweaksProgressIndicator {
         param($Visible, $Label, $Percent)
+    }
+    function Invoke-WPFRunspace {
+        param($ArgumentList, $ParameterList, [scriptblock]$ScriptBlock)
+    }
+    function Invoke-WPFUIThread {
+        param([scriptblock]$ScriptBlock)
+    }
+    function Invoke-WinUtilCurrentSystem {
+        param($CheckBox)
+    }
+    function Set-WinUtilTaskbaritem {
+        param($state)
+    }
+    function Test-WinUtilPackageManager {
+        param([switch]$winget)
     }
 
     function script:New-WinUtilFakeCheckBox {
@@ -180,6 +196,9 @@ Describe "Invoke-WPFSelectedCheckboxesUpdate" {
         @($script:sync.selectedToggles) | Should -Be @("WPFToggleDarkMode")
         @($script:sync.selectedFeatures) | Should -Be @("WPFFeatureSandbox")
         @($script:sync.selectedAppx) | Should -Be @("WPFAppxExample")
+        $script:sync.WPFselectedAppsButton.Content | Should -Be "Selected Apps: 1"
+        $script:sync.selectedAppsstackPanel.Children.Count | Should -Be 1
+        $script:sync.selectedAppsstackPanel.Children[0].Key | Should -Be "WPFInstallGit"
     }
 
     It "removes checkbox keys from the matching selected lists" {
@@ -200,6 +219,52 @@ Describe "Invoke-WPFSelectedCheckboxesUpdate" {
         $script:sync.selectedToggles.Count | Should -Be 0
         $script:sync.selectedFeatures.Count | Should -Be 0
         $script:sync.selectedAppx.Count | Should -Be 0
+        $script:sync.WPFselectedAppsButton.Content | Should -Be "Selected Apps: 0"
+        $script:sync.selectedAppsstackPanel.Children.Count | Should -Be 0
+    }
+}
+
+Describe "Invoke-WPFGetInstalled selection state" {
+    BeforeEach {
+        New-WinUtilUiStateTestContext
+
+        $dispatcher = [pscustomobject]@{}
+        $dispatcher | Add-Member -MemberType ScriptMethod -Name Invoke -Value {
+            param([scriptblock]$Action)
+            & $Action
+        }
+
+        $script:sync.ProcessRunning = $false
+        $script:sync.ChocoRadioButton = [pscustomobject]@{ IsChecked = $false }
+        $script:sync.preferences = [pscustomobject]@{ packagemanager = "Winget" }
+        $script:sync.Form = [pscustomobject]@{ Dispatcher = $dispatcher }
+        $script:sync.WPFInstallGit = New-WinUtilFakeCheckBox
+        $script:capturedGetInstalledScriptBlock = $null
+
+        Mock Test-WinUtilPackageManager { "installed" }
+        Mock Invoke-WPFUIThread { }
+        Mock Invoke-WinUtilCurrentSystem { @("WPFInstallGit") }
+        Mock Invoke-WPFRunspace {
+            $script:capturedGetInstalledScriptBlock = $ScriptBlock
+            [pscustomobject]@{ MockHandle = $true }
+        }
+    }
+
+    AfterEach {
+        Remove-Variable -Name sync -Scope Script -ErrorAction SilentlyContinue
+        Remove-Variable -Name sync -Scope Global -ErrorAction SilentlyContinue
+        Remove-Variable -Name capturedGetInstalledScriptBlock -Scope Script -ErrorAction SilentlyContinue
+    }
+
+    It "updates the selected app model, checkbox, count, and popup" {
+        Invoke-WPFGetInstalled -CheckBox "winget"
+        & $script:capturedGetInstalledScriptBlock -checkbox "winget" -managerPreference "Winget"
+
+        @($script:sync.selectedApps) | Should -Be @("WPFInstallGit")
+        $script:sync.WPFInstallGit.IsChecked | Should -BeTrue
+        $script:sync.WPFselectedAppsButton.Content | Should -Be "Selected Apps: 1"
+        $script:sync.selectedAppsstackPanel.Children.Count | Should -Be 1
+        $script:sync.selectedAppsstackPanel.Children[0].Key | Should -Be "WPFInstallGit"
     }
 }
 

--- a/pester/ui-state.Tests.ps1
+++ b/pester/ui-state.Tests.ps1
@@ -235,17 +235,25 @@ Describe "Invoke-WPFGetInstalled selection state" {
         $script:sync.ChocoRadioButton = [pscustomobject]@{ IsChecked = $false }
         $script:sync.preferences = [pscustomobject]@{ packagemanager = "Winget" }
         $script:sync.WPFInstallGit = New-WinUtilFakeCheckBox
+        $dispatcher = [pscustomobject]@{}
+        $dispatcher | Add-Member -MemberType ScriptMethod -Name BeginInvoke -Value {
+            param($Action, [object[]]$Arguments)
+            $Action.DynamicInvoke($Arguments)
+        }
+        $script:sync.Form = [pscustomobject]@{ Dispatcher = $dispatcher }
         $script:capturedGetInstalledScriptBlock = $null
+        $script:capturedGetInstalledParameters = @{}
 
         Mock Test-WinUtilPackageManager { "installed" }
-        Mock Invoke-WPFUIThread { & $ScriptBlock }
         Mock Invoke-WinUtilCurrentSystem { @("WPFInstallGit") }
         Mock Set-WinUtilTaskbaritem { }
         Mock Write-WinUtilLog { }
         Mock Write-Warning { }
         Mock Invoke-WPFRunspace {
             $script:capturedGetInstalledScriptBlock = $ScriptBlock
-            [pscustomobject]@{ MockHandle = $true }
+            foreach ($parameter in $ParameterList) {
+                $script:capturedGetInstalledParameters[$parameter[0]] = $parameter[1]
+            }
         }
     }
 
@@ -253,11 +261,16 @@ Describe "Invoke-WPFGetInstalled selection state" {
         Remove-Variable -Name sync -Scope Script -ErrorAction SilentlyContinue
         Remove-Variable -Name sync -Scope Global -ErrorAction SilentlyContinue
         Remove-Variable -Name capturedGetInstalledScriptBlock -Scope Script -ErrorAction SilentlyContinue
+        Remove-Variable -Name capturedGetInstalledParameters -Scope Script -ErrorAction SilentlyContinue
     }
 
     It "updates the selected app model, checkbox, count, and popup" {
         Invoke-WPFGetInstalled -CheckBox "winget"
-        & $script:capturedGetInstalledScriptBlock -checkbox "winget" -managerPreference "Winget"
+        & $script:capturedGetInstalledScriptBlock `
+            -checkbox "winget" `
+            -managerPreference "Winget" `
+            -operation $script:capturedGetInstalledParameters.operation `
+            -completeAction $script:capturedGetInstalledParameters.completeAction
 
         @($script:sync.selectedApps) | Should -Be @("WPFInstallGit")
         $script:sync.WPFInstallGit.IsChecked | Should -BeTrue
@@ -270,13 +283,31 @@ Describe "Invoke-WPFGetInstalled selection state" {
         Mock Invoke-WinUtilCurrentSystem { throw "detection failed" }
 
         Invoke-WPFGetInstalled -CheckBox "winget"
-        & $script:capturedGetInstalledScriptBlock -checkbox "winget" -managerPreference "Winget"
+        & $script:capturedGetInstalledScriptBlock `
+            -checkbox "winget" `
+            -managerPreference "Winget" `
+            -operation $script:capturedGetInstalledParameters.operation `
+            -completeAction $script:capturedGetInstalledParameters.completeAction
 
         $script:sync.ProcessRunning | Should -BeFalse
         Should -Invoke -CommandName Write-WinUtilLog -Times 1 -Exactly -ParameterFilter {
             $Level -eq "ERROR" -and
                 $Component -eq "Install" -and
                 $Message -eq "Get installed state failed: detection failed"
+        }
+        Should -Invoke -CommandName Set-WinUtilTaskbaritem -Times 1 -Exactly -ParameterFilter { $state -eq "None" }
+    }
+
+    It "clears the running state when the worker cannot be queued" {
+        Mock Invoke-WPFRunspace { throw "queue failed" }
+
+        Invoke-WPFGetInstalled -CheckBox "winget"
+
+        $script:sync.ProcessRunning | Should -BeFalse
+        Should -Invoke -CommandName Write-WinUtilLog -Times 1 -Exactly -ParameterFilter {
+            $Level -eq "ERROR" -and
+                $Component -eq "Install" -and
+                $Message -eq "Get installed state failed: queue failed"
         }
         Should -Invoke -CommandName Set-WinUtilTaskbaritem -Times 1 -Exactly -ParameterFilter { $state -eq "None" }
     }

--- a/pester/ui-state.Tests.ps1
+++ b/pester/ui-state.Tests.ps1
@@ -84,6 +84,9 @@ namespace System.Windows.Controls
     function Test-WinUtilPackageManager {
         param([switch]$winget)
     }
+    function Write-WinUtilLog {
+        param($Message, $Level, $Component)
+    }
 
     function script:New-WinUtilFakeCheckBox {
         param([bool]$IsChecked = $false)
@@ -228,22 +231,18 @@ Describe "Invoke-WPFGetInstalled selection state" {
     BeforeEach {
         New-WinUtilUiStateTestContext
 
-        $dispatcher = [pscustomobject]@{}
-        $dispatcher | Add-Member -MemberType ScriptMethod -Name Invoke -Value {
-            param([scriptblock]$Action)
-            & $Action
-        }
-
         $script:sync.ProcessRunning = $false
         $script:sync.ChocoRadioButton = [pscustomobject]@{ IsChecked = $false }
         $script:sync.preferences = [pscustomobject]@{ packagemanager = "Winget" }
-        $script:sync.Form = [pscustomobject]@{ Dispatcher = $dispatcher }
         $script:sync.WPFInstallGit = New-WinUtilFakeCheckBox
         $script:capturedGetInstalledScriptBlock = $null
 
         Mock Test-WinUtilPackageManager { "installed" }
-        Mock Invoke-WPFUIThread { }
+        Mock Invoke-WPFUIThread { & $ScriptBlock }
         Mock Invoke-WinUtilCurrentSystem { @("WPFInstallGit") }
+        Mock Set-WinUtilTaskbaritem { }
+        Mock Write-WinUtilLog { }
+        Mock Write-Warning { }
         Mock Invoke-WPFRunspace {
             $script:capturedGetInstalledScriptBlock = $ScriptBlock
             [pscustomobject]@{ MockHandle = $true }
@@ -265,6 +264,21 @@ Describe "Invoke-WPFGetInstalled selection state" {
         $script:sync.WPFselectedAppsButton.Content | Should -Be "Selected Apps: 1"
         $script:sync.selectedAppsstackPanel.Children.Count | Should -Be 1
         $script:sync.selectedAppsstackPanel.Children[0].Key | Should -Be "WPFInstallGit"
+    }
+
+    It "clears the running state when detection fails" {
+        Mock Invoke-WinUtilCurrentSystem { throw "detection failed" }
+
+        Invoke-WPFGetInstalled -CheckBox "winget"
+        & $script:capturedGetInstalledScriptBlock -checkbox "winget" -managerPreference "Winget"
+
+        $script:sync.ProcessRunning | Should -BeFalse
+        Should -Invoke -CommandName Write-WinUtilLog -Times 1 -Exactly -ParameterFilter {
+            $Level -eq "ERROR" -and
+                $Component -eq "Install" -and
+                $Message -eq "Get installed state failed: detection failed"
+        }
+        Should -Invoke -CommandName Set-WinUtilTaskbaritem -Times 1 -Exactly -ParameterFilter { $state -eq "None" }
     }
 }
 

--- a/pester/xaml.Tests.ps1
+++ b/pester/xaml.Tests.ps1
@@ -435,7 +435,6 @@ Describe "XAML and sync wiring" {
             "appPopup",
             "appPopupSelectedApp",
             "ItemsControl",
-            "InstalledPrograms",
             "ImportInProgress",
             "ScriptsInstallPrograms",
             "keys",


### PR DESCRIPTION
## Summary

- expose the runspace cleanup handler as a strongly typed `WaitOrTimerCallback`
- query installed Winget packages once with source agreements accepted and interactivity disabled
- match configured Winget and `msstore:` IDs directly from that single result
- scan `applicationsHashtable` instead of rendered WPF controls, including lazy entries
- synchronize detected apps into `selectedApps` and refresh the checkbox, count, and popup UI
- move installed-app completion to a UI-bound delegate with explicit result arguments
- always clear `ProcessRunning` and the taskbar state after success, detection failure, or queue failure
- remove stale installed-program state, duplicate Winget calls, worker-owned UI callbacks, and cosmetic worker host writes

## Root cause

Issue #4849 combined several regressions:

1. Windows PowerShell 5.1 could not cast the reflected static C# cleanup method to `WaitOrTimerCallback`.
2. A single configured dependency ID was collapsed to a scalar string, so indexing it returned its final character instead of its package ID.
3. Show Installed Apps updated rendered controls instead of the selection model, leaving `Selected Apps: 0` unchanged.
4. Installed detection called Winget more than once and could allow source prompts to block the workflow.
5. The background worker synchronously invoked a PowerShell script block on the WPF dispatcher. The worker waited for the UI thread while that delegate retained the worker runspace context, causing the application to stall after detection.

The completion path now passes a delegate created on the UI thread plus a synchronized result object into the worker. Detection stays in the background, and the worker queues the UI-bound delegate with explicit arguments when finished, avoiding cross-thread access and runspace lock inversion.

## User impact

Show Installed Apps now performs one non-interactive package query, detects standard Winget and Microsoft Store packages, selects every detected app, updates the selected-app count and popup, and restores the UI to an idle state without freezing.

## Validation

- elevated end-to-end WinUtil run: 30 apps detected, 30 selected, `ProcessRunning=False`
- Windows PowerShell 5.1 callback and generic UI-delegate smoke tests
- Pester 5.8.0: 463 passed, 0 failed
- `./Compile.ps1`
- PSScriptAnalyzer on the changed runtime function: no diagnostics
- `git diff --check`

Fixes #4849