### PR TITLE
bugfix(tweaks): fix OneDrive uninstall path

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -650,7 +650,7 @@
       icacls $Env:OneDrive /deny \"Administrators:(D,DC)\"
 
       Write-Host \"Uninstalling OneDrive...\"
-      Start-Process 'C:\\Windows\\System32\\OneDriveSetup.exe' -ArgumentList '/uninstall' -Wait
+      Start-Process -FilePath (Join-Path $Env:SystemRoot \"System32\\OneDriveSetup.exe\") -ArgumentList '/uninstall' -Wait
 
       # Some of OneDrive files use explorer, and OneDrive uses FileCoAuth
       Write-Host \"Removing leftover OneDrive Files...\"

--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -650,7 +650,7 @@
       icacls $Env:OneDrive /deny \"Administrators:(D,DC)\"
 
       Write-Host \"Uninstalling OneDrive...\"
-      Start-Process '$Env:SystemRoot\\System32\\OneDriveSetup.exe' -ArgumentList '/uninstall' -Wait
+      Start-Process 'C:\\Windows\\System32\\OneDriveSetup.exe' -ArgumentList '/uninstall' -Wait
 
       # Some of OneDrive files use explorer, and OneDrive uses FileCoAuth
       Write-Host \"Removing leftover OneDrive Files...\"


### PR DESCRIPTION
## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactor
- [ ] UI/UX improvement

## Description
Uses `Join-Path $Env:SystemRoot` to locate OneDriveSetup.exe so `$Env:SystemRoot` is evaluated safely. The uninstall implementation and flow are unchanged.

## Validation
- `./Compile.ps1`
- Uninstalled OneDrive locally to verify the tweak works end-to-end