### PR TITLE
bugfix: ensure maximize behavior works as expected

### DIFF
--- a/xaml/inputXML.xaml
+++ b/xaml/inputXML.xaml
@@ -6,7 +6,7 @@
         xmlns:local="clr-namespace:WinUtility"
         WindowStartupLocation="CenterScreen"
         UseLayoutRounding="True"
-        WindowStyle="None"
+        WindowStyle="SingleBorderWindow"
         Width="Auto"
         Height="Auto"
         MinWidth="800"


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://winutil.christitus.com/contributing/ -->
<!--Documentation is auto-generated from configs - no manual documentation updates needed -->

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactor
- [ ] UI/UX improvement

<!-- This automatically adds labels to your PR based on the selections above. -->

## Description
This PR restores the WindowStyle to SingleBorderWindow for proper window framing and maximize behavior. This makes it respect the actual working area of a screen (not the screen bounds).

<img width="2559" height="1599" alt="image" src="https://github.com/user-attachments/assets/38d1e945-54b0-4c70-9c14-ed2da85606cf" />


## Issue related to PR
<!--[List any ISSUES this is related to as it AUTO-CLOSES Them!]-->
- Resolves #4865 
