### PR TITLE
ci: read the PR body from env instead of interpolating it into the shell

### DIFF
--- a/.github/workflows/close-discussion-on-pr.yaml
+++ b/.github/workflows/close-discussion-on-pr.yaml
@@ -18,10 +18,11 @@ jobs:
       - name: Extract Discussion Number & Close If any Were Found
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_BODY: ${{ github.event.pull_request.body }}
         if: github.event.pull_request.merged == true
         id: extract-discussion
         run: |
-          pr_body="${{ github.event.pull_request.body }}"
+          pr_body="$PR_BODY"
           discussion_ids=$(echo "$pr_body" | grep -oP '(?i)(resolve|fix|close)[s|d]? #\K[0-9]+')
 
           if [ -z "$discussion_ids" ]; then


### PR DESCRIPTION
Hi, and thanks for winutil.

In `.github/workflows/close-discussion-on-pr.yaml`, the PR description is read into the shell by interpolation:

```yaml
run: |
  pr_body="${{ github.event.pull_request.body }}"
  discussion_ids=$(echo "$pr_body" | grep -oP '(?i)(resolve|fix|close)[s|d]? #\K[0-9]+')
```

Actions expands `${{ ... }}` into the script text before bash runs, so the description becomes part of the script rather than a string assigned to `pr_body`. A PR description is free text, and `$(...)` and backticks still execute inside double quotes — so a body containing `$(...)` would run on the runner rather than being searched for `resolve #123` style references.

Some context that keeps this modest, which I would rather state than leave you to infer: the step is guarded by `if: github.event.pull_request.merged == true`, so a maintainer has to merge the PR first, and the token in scope is the default `GITHUB_TOKEN`. The realistic risk is a description that does something unintended once merged, not an open door.

The step already passes `GITHUB_TOKEN` through `env:`; this change does the same for the body:

```yaml
env:
  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
  PR_BODY: ${{ github.event.pull_request.body }}
run: |
  pr_body="$PR_BODY"
```

The `grep -oP` extraction and everything downstream is untouched, so discussion numbers are found exactly as they are today. One line added, one changed.

Disclosure: I used AI assistance to help spot this and prepare the change, and I read the workflow and its merge guard myself.
