### PR TITLE
Streamline WPF application grid generation

### DIFF
--- a/functions/public/Invoke-WPFUIElements.ps1
+++ b/functions/public/Invoke-WPFUIElements.ps1
@@ -53,25 +53,19 @@ function Invoke-WPFUIElements {
         $targetGrid.ColumnDefinitions.Add($colDef) | Out-Null
     }
 
-    # Convert PSCustomObject to Hashtable
-    $configHashtable = @{}
-    $configVariable.PSObject.Properties.Name | ForEach-Object {
-        $configHashtable[$_] = $configVariable.$_
-    }
-
     $radioButtonGroups = @{}
-
     $organizedData = @{}
-    # Iterate through JSON data and organize by panel and category
-    foreach ($entry in $configHashtable.Keys) {
-        $entryInfo = $configHashtable[$entry]
 
-        # Create an object for the application
+    foreach ($prop in $configVariable.PSObject.Properties) {
+        $entryInfo = $prop.Value
+        $panel = if ($entryInfo.Panel) { $entryInfo.Panel } else { "0" }
+        $category = $entryInfo.Category
+
         $entryObject = [PSCustomObject]@{
-            Name        = $entry
-            Category    = $entryInfo.Category
+            Name        = $prop.Name
+            Category    = $category
             Content     = $entryInfo.Content
-            Panel       = if ($entryInfo.Panel) { $entryInfo.Panel } else { "0" }
+            Panel       = $panel
             Link        = $entryInfo.link
             Description = $entryInfo.description
             Type        = $entryInfo.type
@@ -81,17 +75,13 @@ function Invoke-WPFUIElements {
             GroupName   = $entryInfo.GroupName  # Added for RadioButton groupings
         }
 
-        if (-not $organizedData.ContainsKey($entryObject.Panel)) {
-            $organizedData[$entryObject.Panel] = @{}
+        if (-not $organizedData.ContainsKey($panel)) {
+            $organizedData[$panel] = @{}
         }
-
-        if (-not $organizedData[$entryObject.Panel].ContainsKey($entryObject.Category)) {
-            $organizedData[$entryObject.Panel][$entryObject.Category] = @()
+        if (-not $organizedData[$panel].ContainsKey($category)) {
+            $organizedData[$panel][$category] = [System.Collections.Generic.List[object]]::new()
         }
-
-        # Store application data in an array under the category
-        $organizedData[$entryObject.Panel][$entryObject.Category] += $entryObject
-
+        $organizedData[$panel][$category].Add($entryObject) | Out-Null
     }
 
     # Initialize panel count


### PR DESCRIPTION
## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [x] Refactor
- [ ] UI/UX improvement

## Description
Improves UI element processing performance in `Invoke-WPFUIElements.ps1` by:
- Eliminating redundant property-copying loops during PSCustomObject evaluation.
- Replaced O(N²) array concatenation (`+=`) with direct collection insertions (`List[object].Add()`) when organizing panel category entries.

## Issue related to PR
- Resolves #
