### PR TITLE
Fix WinGet sources after UAC elevation (for normal users)

### DIFF
--- a/functions/private/Ensure-WinUtilWingetSources.ps1
+++ b/functions/private/Ensure-WinUtilWingetSources.ps1
@@ -1,0 +1,35 @@
+function Ensure-WinUtilWingetSources {
+    try {
+        Write-WinUtilLog -Component "Package" -Message "Resetting WinGet sources..."
+
+        $resetOutput = & winget source reset --force 2>&1
+        $resetExitCode = $LASTEXITCODE
+        @($resetOutput) | ForEach-Object { Write-WinUtilLog -Component "Package" -Message "winget source reset: $_" }
+        if ($resetExitCode -ne 0) {
+            throw "winget source reset failed with exit code $resetExitCode."
+        }
+
+        $updateOutput = & winget source update 2>&1
+        $updateExitCode = $LASTEXITCODE
+        @($updateOutput) | ForEach-Object { Write-WinUtilLog -Component "Package" -Message "winget source update: $_" }
+        if ($updateExitCode -ne 0) {
+            throw "winget source update failed with exit code $updateExitCode."
+        }
+
+        # winGet can report a successful source update in a background session
+        # without registering the source MSIX for the current user.
+        if (-not (Get-AppxPackage -Name "Microsoft.Winget.Source" -ErrorAction SilentlyContinue)) {
+            $sourcePackagePath = Join-Path $env:TEMP "Microsoft.Winget.Source.msix"
+            try {
+                Write-WinUtilLog -Component "Package" -Message "Registering the WinGet source package for the current user..."
+                Invoke-WebRequest -Uri "https://cdn.winget.microsoft.com/cache/source2.msix" -OutFile $sourcePackagePath -UseBasicParsing
+                Add-AppxPackage -Path $sourcePackagePath -ForceApplicationShutdown -ErrorAction Stop
+            } finally {
+                Remove-Item -Path $sourcePackagePath -Force -ErrorAction SilentlyContinue
+            }
+        }
+    } catch {
+        Write-WinUtilLog -Component "Package" -Message "Ensure-WinUtilWingetSources failed: $_"
+        throw
+    }
+}

--- a/functions/private/Install-WinUtilProgramWinget.ps1
+++ b/functions/private/Install-WinUtilProgramWinget.ps1
@@ -1,4 +1,4 @@
-Function Install-WinUtilProgramWinget {
+function Install-WinUtilProgramWinget {
     param (
         [Parameter(Mandatory=$true)]
         [ValidateSet("Install", "Uninstall")]
@@ -7,6 +7,9 @@ Function Install-WinUtilProgramWinget {
         [Parameter(Mandatory=$true)]
         [string[]]$Programs
     )
+
+    # signed process exit codes for 0x8A15000F and 0x8A15000E.
+    $sourceErrorExitCodes = @(-1978335217, -1978335218)
 
     foreach ($program in $Programs) {
         if ([string]::IsNullOrWhiteSpace($program) -or $program -eq "na") {
@@ -27,6 +30,16 @@ Function Install-WinUtilProgramWinget {
 
         Write-WinUtilLog -Component "Package" -Message "$Action winget package: $program (source: $source)"
         $process = Start-Process -FilePath winget -ArgumentList $arguments -NoNewWindow -Wait -PassThru
+
+        if ($Action -eq 'Install' -and $source -eq 'winget' -and $process.ExitCode -in $sourceErrorExitCodes) {
+            Write-WinUtilLog -Component "Package" -Message "WinGet source failure detected for $program. Repairing sources and retrying..."
+            Ensure-WinUtilWingetSources
+            $process = Start-Process -FilePath winget -ArgumentList $arguments -NoNewWindow -Wait -PassThru
+            if ($process.ExitCode -in $sourceErrorExitCodes) {
+                throw "WinGet source repair did not resolve the source failure for $program."
+            }
+        }
+
         Write-WinUtilLog -Component "Package" -Message "$Action winget package completed: $program (exit code: $($process.ExitCode))"
     }
 }

--- a/pester/package.Tests.ps1
+++ b/pester/package.Tests.ps1
@@ -7,6 +7,7 @@ BeforeAll {
 
     . (Join-Path $script:repoRoot "functions\private\Get-WinUtilSelectedPackages.ps1")
     . (Join-Path $script:repoRoot "functions\private\Test-WinUtilPackageManager.ps1")
+    . (Join-Path $script:repoRoot "functions\private\Ensure-WinUtilWingetSources.ps1")
     . (Join-Path $script:repoRoot "functions\private\Install-WinUtilProgramWinget.ps1")
     . (Join-Path $script:repoRoot "functions\private\Install-WinUtilProgramChoco.ps1")
 
@@ -112,12 +113,14 @@ Describe "Test-WinUtilPackageManager" {
 Describe "Install-WinUtilProgramWinget" {
     BeforeEach {
         Mock Write-WinUtilLog { }
+        Mock Ensure-WinUtilWingetSources { }
         Mock Start-Process { [pscustomobject]@{ ExitCode = 0 } }
     }
 
     It "starts winget with install arguments" {
         Install-WinUtilProgramWinget -Action Install -Programs @("Git.Git")
 
+        Should -Invoke -CommandName Ensure-WinUtilWingetSources -Times 0 -Exactly
         Should -Invoke -CommandName Start-Process -Times 1 -Exactly -ParameterFilter {
             $FilePath -eq "winget" -and
                 (@($ArgumentList) -join "|") -eq "install|--id|Git.Git|--accept-package-agreements|--accept-source-agreements|--source|winget|--silent" -and
@@ -127,9 +130,44 @@ Describe "Install-WinUtilProgramWinget" {
         }
     }
 
+    It "repairs sources and retries a source failure once" {
+        $script:wingetCallCount = 0
+        Mock Start-Process {
+            $script:wingetCallCount++
+            if ($script:wingetCallCount -eq 1) {
+                return [pscustomobject]@{ ExitCode = -1978335217 }
+            }
+            return [pscustomobject]@{ ExitCode = 0 }
+        }
+
+        Install-WinUtilProgramWinget -Action Install -Programs @("Git.Git")
+
+        Should -Invoke -CommandName Ensure-WinUtilWingetSources -Times 1 -Exactly
+        Should -Invoke -CommandName Start-Process -Times 2 -Exactly
+    }
+
+    It "throws when source repair does not resolve the failure" {
+        Mock Start-Process { [pscustomobject]@{ ExitCode = -1978335217 } }
+
+        { Install-WinUtilProgramWinget -Action Install -Programs @("Git.Git") } | Should -Throw
+
+        Should -Invoke -CommandName Ensure-WinUtilWingetSources -Times 1 -Exactly
+        Should -Invoke -CommandName Start-Process -Times 2 -Exactly
+    }
+
+    It "does not repair sources for unrelated failures" {
+        Mock Start-Process { [pscustomobject]@{ ExitCode = 1 } }
+
+        Install-WinUtilProgramWinget -Action Install -Programs @("Git.Git")
+
+        Should -Invoke -CommandName Ensure-WinUtilWingetSources -Times 0 -Exactly
+        Should -Invoke -CommandName Start-Process -Times 1 -Exactly
+    }
+
     It "starts winget with uninstall arguments and msstore source when requested" {
         Install-WinUtilProgramWinget -Action Uninstall -Programs @("msstore:9NBLGGH4NNS1")
 
+        Should -Invoke -CommandName Ensure-WinUtilWingetSources -Times 0 -Exactly
         Should -Invoke -CommandName Start-Process -Times 1 -Exactly -ParameterFilter {
             $FilePath -eq "winget" -and
                 (@($ArgumentList) -join "|") -eq "uninstall|--id|9NBLGGH4NNS1|--source|msstore|--silent"


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://winutil.christitus.com/contributing/ -->
<!--Documentation is auto-generated from configs - no manual documentation updates needed -->

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactor
- [ ] UI/UX improvement

<!-- This automatically adds labels to your PR based on the selections above. -->

## Description

Fixes a niche issue with winget installs failing after UAC elevation with `0x8A15000F` even after sources are reset and updated. Winget may report success without registering the `Microsoft.Winget.Source` package for the current user.

This only happened to me when trying to use WinUtil's installer through an normal user account if, it went through a admin account which never used winget before. Niche issue but it has bothered me for a while.

When this error occurs, repair the WinGet sources, register the source package missing from the elevated user context, and retry the failed installation once.