### PR TITLE
Fix image paths in GitHub

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -68,7 +68,7 @@ graph TD
 ### Fork the Repo
 * Fork the WinUtil Repository [here](https://github.com/ChrisTitusTech/winutil) to create a copy that will be available in your repository list.
 
-![Fork Image](../docs/src/assets/contributing/Fork-Button-Dark.png)
+![Fork Image](/docs/src/assets/contributing/Fork-Button-Dark.png)
 
 ### Clone the Fork
 > [!TIP]
@@ -91,7 +91,7 @@ graph TD
 * Run the following command to compile and run WinUtil:
 * `.\Compile.ps1 -run`
 
-![Compile](../docs/src/assets/contributing/Complie.png)
+![Compile](/docs/src/assets/contributing/Complie.png)
 
 
 Open PowerShell as Administrator.
@@ -102,15 +102,15 @@ Open PowerShell as Administrator.
 ### Committing the changes
 * Before committing your changes, please discard changes made to the `winutil.ps1` file, like the following:
 
-![Push Commit Image](../docs/src/assets/contributing/Discard-GHD.png)
+![Push Commit Image](/docs/src/assets/contributing/Discard-GHD.png)
 
 * Now, commit your changes once you are happy with the result.
 
-![Commit Image](../docs/src/assets/contributing/Commit-GHD.png)
+![Commit Image](/docs/src/assets/contributing/Commit-GHD.png)
 
 * Push the changes to upload them to your fork on GitHub.
 
-![Push Commit Image](../docs/src/assets/contributing/Push-Commit.png)
+![Push Commit Image](/docs/src/assets/contributing/Push-Commit.png)
 
 ### Making a PR
 * To make a PR on your repo under a new branch linking to the main branch, a button will show and say Preview and Create pull request. Click that button and fill in all the information that is provided on the template. Once all the information is filled in correctly, check your PR to make sure there is no WinUtil.ps1 file attached to the PR. Once everything is good, make the PR and wait for Chris (the maintainer) to accept or deny your PR. Once it is accepted by Chris, you will be able to see your changes in the "/windev" build.

--- a/.github/READMEITALIAN.md
+++ b/.github/READMEITALIAN.md
@@ -7,7 +7,7 @@
 
 Questa utility è una raccolta di attività Windows che eseguo personalmente su ogni sistema che utilizzo. È progettata per snellire le *installazioni*, rimuovere i componenti superflui tramite *ottimizzazioni*, risolvere problemi tramite la *configurazione*, e riparare *aggiornamenti* di Windows. Sono estremamente selettivo riguardo ai contributi per mantenere questo progetto pulito ed efficiente.
 
-![screen-install](../docs/src/assets/branding/title-screen.png)
+![screen-install](/docs/src/assets/branding/title-screen.png)
 
 ## 💡 Come usarlo
 


### PR DESCRIPTION
Update image links in `.github/CONTRIBUTING.md` and `.github/READMEITALIAN.md` from `../docs/...` to `/docs/...` so screenshots resolve correctly when viewed from the `.github` directory context on GitHub.

<!--Before you make this PR have you followed the docs here? - https://winutil.christitus.com/contributing/ -->
<!--Documentation is auto-generated from configs - no manual documentation updates needed -->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [x] Documentation update
- [ ] Refactor
- [ ] UI/UX improvement

<!-- This automatically adds labels to your PR based on the selections above. -->

## Description
<!--[What does this PR do? Provide Screenshots when possible.]-->
This pull request updates image paths in the documentation to use absolute paths instead of relative ones. This ensures that images display correctly regardless of where the documentation is viewed.

Documentation updates:

* Updated image paths in `.github/CONTRIBUTING.md` to use absolute paths (starting with `/docs/`) for all screenshots and diagrams, improving image rendering reliability. [[1]](diffhunk://#diff-98e64bc1cd2db9333c6effe87bbe0d6dfe8714aba4c6bde45aa037fe0796e44cL71-R71) [[2]](diffhunk://#diff-98e64bc1cd2db9333c6effe87bbe0d6dfe8714aba4c6bde45aa037fe0796e44cL94-R94) [[3]](diffhunk://#diff-98e64bc1cd2db9333c6effe87bbe0d6dfe8714aba4c6bde45aa037fe0796e44cL105-R113)
* Updated the image path in `.github/READMEITALIAN.md` to use an absolute path for the branding screenshot.

## Issue related to PR
<!--[List any ISSUES this is related to as it AUTO-CLOSES Them!]-->
- Resolves #
