### PR TITLE
Import YouTubeEmbed in tweaks guide. this will fix the build

### DIFF
--- a/docs/src/content/docs/guides/tweaks.mdx
+++ b/docs/src/content/docs/guides/tweaks.mdx
@@ -5,6 +5,8 @@ sidebar:
   order: 3
 ---
 
+import YouTubeEmbed from '../../../components/YouTubeEmbed.astro';
+
 Use the Tweaks tab to apply recommended Windows changes, review optional presets, and adjust a few supporting settings such as DNS and power plans. Start with a preset unless you already know which individual tweaks you want.
 
 ![Image of Tweaks Tab](../../../assets/screenshots/tweaks-tab-new.png)


### PR DESCRIPTION
Add the `YouTubeEmbed` component import to `docs/src/content/docs/guides/tweaks.mdx` so the guide can use embedded YouTube content without missing-component build issues.

<!--Before you make this PR have you followed the docs here? - https://winutil.christitus.com/contributing/ -->
<!--Documentation is auto-generated from configs - no manual documentation updates needed -->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [x] Documentation update
- [ ] Refactor
- [ ] UI/UX improvement

<!-- This automatically adds labels to your PR based on the selections above. -->

## Description
<!--[What does this PR do? Provide Screenshots when possible.]-->
This pull request makes a minor documentation update, adding an import statement for the `YouTubeEmbed` component to the `tweaks.mdx` guide file. No other content or functional changes are included.

* Documentation update:
  * Added an import for the `YouTubeEmbed` component at the top of the `docs/src/content/docs/guides/tweaks.mdx` file.

## Issue related to PR
<!--[List any ISSUES this is related to as it AUTO-CLOSES Them!]-->
- Resolves #
