### PR TITLE
docs: correct Win11 Creator behavior after the ISO workflow refactor

### DIFF
--- a/docs/src/content/docs/code-reference/architecture.mdx
+++ b/docs/src/content/docs/code-reference/architecture.mdx
@@ -253,18 +253,18 @@ The `Invoke-WinUtilISOScript` function stages **50+ registry tweaks** that are a
 
 ### Driver Injection Feature
 
-**Optional Enhancement**: When enabled, exports all drivers from the running system and injects them into both:
-- `install.wim` (main OS image)
-- `boot.wim` index 2 (Windows Setup PE environment)
+**Optional Enhancement**: When enabled, exports all drivers from the running system and:
+- Adds them to the selected `install.wim` index in one mount and commit
+- Stages the storage driver packages in `$WinpeDriver$` at the ISO root, which Windows Setup loads into WinPE. `boot.wim` is not modified.
 
 **Use Case**: Enables offline installation on systems with missing drivers.
 
 ### Disk Space Requirements
 
-- **Temporary working directory**: ~10-15 GB
 - **Original ISO**: 4-6 GB
-- **Modified ISO**: 2.5-3.5 GB
-- **Total needed**: ~25 GB for safe operation
+- **Temporary working directory**: about the size of the source ISO, since the contents are copied as-is
+- **Modified ISO**: about the size of the source ISO
+- **Total needed**: roughly three times the source ISO, plus headroom for the WIM mount when driver injection is enabled
 
 ## Data Flow
 

--- a/docs/src/content/docs/code-reference/architecture.mdx
+++ b/docs/src/content/docs/code-reference/architecture.mdx
@@ -142,11 +142,13 @@ The **Win11 Creator** is a specialized subsystem within Winutil that creates cus
   - `Invoke-WinUtilISOCheckExistingWork`: Recovers incomplete work sessions
   - `Invoke-WinUtilISOCleanAndReset`: Cleans up temp directories and resets UI
 
-- `Invoke-WinUtilISOScript.ps1`: Prepares the copied setup media
-  - Writes autounattend.xml with the post-install AppX removal, registry tweaks, and scheduled task cleanup
-  - Pre-stages the same setup scripts under `sources\$OEM$` as a fallback
-  - Removes `sources\PID.txt` and writes `sources\ei.cfg` for the selected edition
-  - Injects drivers (optional) from the current system into one install.wim index
+- `Invoke-WinUtilISOScript.ps1`: Applies modifications to mounted install.wim
+  - Removes provisioned AppX packages (40+ bloatware apps)
+  - Injects drivers (optional) from the current system
+  - Removes OneDrive setup files
+  - Applies offline registry tweaks (hardware bypass, privacy, telemetry, OOBE)
+  - Deletes telemetry scheduled task definitions
+  - Pre-stages setup scripts from autounattend.xml
 
 ### Win11 Creator Data Flow
 
@@ -167,14 +169,17 @@ User optionally enables the Driver Injection checkbox
 Invoke-WinUtilISOModify (runs in background runspace)
     ├─ Create work directory: ~WinUtil_Win11ISO_[timestamp]
     ├─ Copy ISO contents to disk (~5-6 GB)
+    ├─ Mount install.wim at selected edition/index
     ├─ Invoke-WinUtilISOScript:
-    │   ├─ Write autounattend.xml with the 40+ AppX removals, 50+ registry tweaks,
-    │   │  scheduled task cleanup, and OneDrive uninstall for first logon
-    │   ├─ Pin the selected edition index in autounattend.xml
-    │   ├─ Pre-stage the setup scripts under sources\$OEM$\$$\Setup\Scripts
-    │   ├─ Remove sources\PID.txt and write sources\ei.cfg for the selected edition
-    │   └─ Export and inject drivers (if enabled, one mount and one commit)
-    ├─ Leave install.wim / install.esd untouched unless drivers were injected
+    │   ├─ Remove 40+ bloat AppX packages
+    │   ├─ Export and inject drivers (if enabled)
+    │   ├─ Remove OneDrive setup
+    │   ├─ Load offline registry hives
+    │   ├─ Apply 50+ registry tweaks (hardware bypass, privacy, telemetry, OOBE, etc.)
+    │   ├─ Delete telemetry scheduled task files
+    │   ├─ Pre-stage setup scripts from autounattend.xml to C:\Windows\Setup\Scripts\
+    │   └─ Unload registry hives
+    ├─ Dismount and save the modified install.wim (~10+ minutes, slowest step)
     ├─ Dismount source ISO
     └─ Report completion, enable export options
     ↓
@@ -190,7 +195,7 @@ Invoke-WinUtilISOExport (user chooses output)
         └─ Output: Bootable USB (minimum 8 GB)
     ↓
 Invoke-WinUtilISOCleanAndReset (optional)
-    └─ Delete temp working directory (~5-6 GB)
+    └─ Delete temp working directory (~10-15 GB)
     └─ Reset UI to initial state
 ```
 
@@ -215,7 +220,7 @@ Invoke-WinUtilISOCleanAndReset (optional)
 
 ### Win11 Creator Registry Tweaks
 
-The `Invoke-WinUtilISOScript` function stages **50+ registry tweaks** that are applied on first logon:
+The `Invoke-WinUtilISOScript` function applies **50+ offline registry tweaks**:
 
 **Hardware Bypass**:
 - TPM 2.0 check bypass
@@ -253,18 +258,18 @@ The `Invoke-WinUtilISOScript` function stages **50+ registry tweaks** that are a
 
 ### Driver Injection Feature
 
-**Optional Enhancement**: When enabled, exports all drivers from the running system and:
-- Adds them to the selected `install.wim` index in one mount and commit
-- Stages the storage driver packages in `$WinpeDriver$` at the ISO root, which Windows Setup loads into WinPE. `boot.wim` is not modified.
+**Optional Enhancement**: When enabled, exports all drivers from the running system and injects them into both:
+- `install.wim` (main OS image)
+- `boot.wim` index 2 (Windows Setup PE environment)
 
 **Use Case**: Enables offline installation on systems with missing drivers.
 
 ### Disk Space Requirements
 
+- **Temporary working directory**: ~10-15 GB
 - **Original ISO**: 4-6 GB
-- **Temporary working directory**: about the size of the source ISO, since the contents are copied as-is
-- **Modified ISO**: about the size of the source ISO
-- **Total needed**: roughly three times the source ISO, plus headroom for the WIM mount when driver injection is enabled
+- **Modified ISO**: close to the source ISO size
+- **Total needed**: ~25 GB for safe operation
 
 ## Data Flow
 

--- a/docs/src/content/docs/code-reference/architecture.mdx
+++ b/docs/src/content/docs/code-reference/architecture.mdx
@@ -142,15 +142,11 @@ The **Win11 Creator** is a specialized subsystem within Winutil that creates cus
   - `Invoke-WinUtilISOCheckExistingWork`: Recovers incomplete work sessions
   - `Invoke-WinUtilISOCleanAndReset`: Cleans up temp directories and resets UI
 
-- `Invoke-WinUtilISOScript.ps1`: Applies modifications to mounted install.wim
-  - Removes provisioned AppX packages (40+ bloatware apps)
-  - Injects drivers (optional) from the current system
-  - Removes OneDrive setup files
-  - Applies offline registry tweaks (hardware bypass, privacy, telemetry, OOBE)
-  - Deletes telemetry scheduled task definitions
-  - Pre-stages setup scripts from autounattend.xml
-  - Removes unused Windows editions
-  - Cleans component store via DISM
+- `Invoke-WinUtilISOScript.ps1`: Prepares the copied setup media
+  - Writes autounattend.xml with the post-install AppX removal, registry tweaks, and scheduled task cleanup
+  - Pre-stages the same setup scripts under `sources\$OEM$` as a fallback
+  - Removes `sources\PID.txt` and writes `sources\ei.cfg` for the selected edition
+  - Injects drivers (optional) from the current system into one install.wim index
 
 ### Win11 Creator Data Flow
 
@@ -171,26 +167,21 @@ User optionally enables the Driver Injection checkbox
 Invoke-WinUtilISOModify (runs in background runspace)
     ├─ Create work directory: ~WinUtil_Win11ISO_[timestamp]
     ├─ Copy ISO contents to disk (~5-6 GB)
-    ├─ Mount install.wim at selected edition/index
     ├─ Invoke-WinUtilISOScript:
-    │   ├─ Remove 40+ bloat AppX packages
-    │   ├─ Export and inject drivers (if enabled)
-    │   ├─ Remove OneDrive setup
-    │   ├─ Load offline registry hives
-    │   ├─ Apply 50+ registry tweaks (hardware bypass, privacy, telemetry, OOBE, etc.)
-    │   ├─ Delete telemetry scheduled task files
-    │   ├─ Pre-stage setup scripts from autounattend.xml to C:\Windows\Setup\Scripts\
-    │   └─ Unload registry hives
-    ├─ DISM /Cleanup-Image /StartComponentCleanup /ResetBase (saves 300-800 MB)
-    ├─ Dismount and save the modified install.wim (~10+ minutes, slowest step)
-    ├─ Export selected edition only (removes all other editions, saves 1-2 GB each)
+    │   ├─ Write autounattend.xml with the 40+ AppX removals, 50+ registry tweaks,
+    │   │  scheduled task cleanup, and OneDrive uninstall for first logon
+    │   ├─ Pin the selected edition index in autounattend.xml
+    │   ├─ Pre-stage the setup scripts under sources\$OEM$\$$\Setup\Scripts
+    │   ├─ Remove sources\PID.txt and write sources\ei.cfg for the selected edition
+    │   └─ Export and inject drivers (if enabled, one mount and one commit)
+    ├─ Leave install.wim / install.esd untouched unless drivers were injected
     ├─ Dismount source ISO
     └─ Report completion, enable export options
     ↓
 Invoke-WinUtilISOExport (user chooses output)
     ├─ Option 1: Save as ISO
     │   ├─ Build bootable ISO via oscdimg.exe (BIOS/UEFI dual-boot)
-    │   └─ Output: Win11_Modified_[date].iso (2.5-3.5 GB)
+    │   └─ Output: Win11_Modified_[date].iso (close to the source ISO size)
     │
     └─ Option 2: Write to USB
         ├─ Format USB as GPT
@@ -199,7 +190,7 @@ Invoke-WinUtilISOExport (user chooses output)
         └─ Output: Bootable USB (minimum 8 GB)
     ↓
 Invoke-WinUtilISOCleanAndReset (optional)
-    └─ Delete temp working directory (~10-15 GB)
+    └─ Delete temp working directory (~5-6 GB)
     └─ Reset UI to initial state
 ```
 
@@ -224,7 +215,7 @@ Invoke-WinUtilISOCleanAndReset (optional)
 
 ### Win11 Creator Registry Tweaks
 
-The `Invoke-WinUtilISOScript` function applies **50+ offline registry tweaks**:
+The `Invoke-WinUtilISOScript` function stages **50+ registry tweaks** that are applied on first logon:
 
 **Hardware Bypass**:
 - TPM 2.0 check bypass

--- a/docs/src/content/docs/guides/win11creator.mdx
+++ b/docs/src/content/docs/guides/win11creator.mdx
@@ -14,7 +14,7 @@ WinUtil includes a built-in **Win11 Creator** tool that lets you take an officia
 ![Win11 Creator tab in WinUtil](../../../assets/screenshots/win11creator-tab-new.png)
 
 :::caution
-You need an **official Windows 11 ISO** from [Microsoft's website](https://www.microsoft.com/en-us/software-download/windows11) before starting. Custom, modified, or non-official ISOs are not supported. The ISO contents are copied to a temporary folder, so allow room for about twice the size of your ISO, plus space for the one you export.
+You need an **official Windows 11 ISO** from [Microsoft's website](https://www.microsoft.com/en-us/software-download/windows11) before starting. Custom, modified, or non-official ISOs are not supported. The process uses ~10–15 GB of temporary disk space, so make sure you have room.
 :::
 
 :::note
@@ -47,16 +47,16 @@ This step takes around 10–30 seconds, depending on your drive speed.
 
 Click **Run Windows ISO Modification and Creator** to start the customization process. WinUtil will:
 
-**App & Component Removal:** (applied on first logon by the staged setup script, not baked into the image)
+**App & Component Removal:**
 - **Remove 40+ bloat apps** — Clipchamp, Teams, Copilot, Dev Home, new Outlook, Bing apps, Solitaire, and more
-- **Uninstall OneDrive**
+- **Delete OneDrive setup** from the image
 
 **System Customization:**
 - **Bypass hardware checks** — removes TPM, Secure Boot, CPU, RAM, and storage requirement enforcement so the ISO installs on unsupported hardware
 - **Enable local account setup** — injects an `autounattend.xml` that skips the Microsoft account screen during OOBE
 - **Disable BitLocker and device encryption** — removes startup overhead
 - **Disable Chat icon** — removes chat taskbar button
-- **Pin the selected edition during setup** — writes `sources\ei.cfg` and setup metadata so OEM firmware keys for a different edition do not force the installer down the wrong product-key path
+- **Pin the selected edition during setup** — writes setup metadata so OEM firmware keys for a different edition do not force the installer down the wrong product-key path
 
 **Privacy & Telemetry Tweaks:**
 - **Disable telemetry** — advertising ID, tailored experiences, input personalization, speech online privacy
@@ -70,9 +70,9 @@ Click **Run Windows ISO Modification and Creator** to start the customization pr
 - **Disable Copilot and search box suggestions**
 
 **Optional: Driver Injection**
-- If enabled, all drivers from your current system are added to the `install.wim` edition you selected, and the storage drivers are also staged in `$WinpeDriver$` so Windows Setup can load them in WinPE. `boot.wim` itself is not modified. Useful for offline installations on machines with missing drivers. This is an optional checkbox in Step 3.
+- If enabled, it injects all drivers from your current system into the install.wim and boot.wim — useful for offline installations on machines with missing drivers. This is an optional checkbox in Step 3.
 
-A live log shows progress as each step completes. Without driver injection this stage is a copy of the ISO contents plus a few small setup files, so it is limited by disk speed. Enabling driver injection adds a single WIM mount and commit, which is by far the slowest part. Do not close WinUtil while it is running.
+A live log shows progress as each step completes. This stage usually takes **10–30 minutes** depending on disk speed. The WIM dismount near the end is the slowest part, so do not close WinUtil while it is running.
 
 :::note
 The resulting ISO is close to the size of the source ISO. WinUtil does not remove the unused editions from `install.wim`; it selects your edition through `sources\ei.cfg` and `autounattend.xml` so Windows Setup installs the right one.
@@ -112,7 +112,7 @@ Double-check you have selected the correct drive before confirming. This operati
 
 ### Step 5 — Clean Up (Optional)
 
-Click **Clean & Reset** to delete the temporary working directory (about the size of your ISO) and return the tool to its initial state, ready for a new ISO. You will be asked to confirm before anything is deleted.
+Click **Clean & Reset** to delete the temporary working directory (~10–15 GB) and return the tool to its initial state, ready for a new ISO. You will be asked to confirm before anything is deleted.
 
 ---
 
@@ -136,7 +136,7 @@ When you install Windows 11 from your modified ISO:
 | "install.wim not found" | Not a valid Windows 11 ISO — download a fresh one from Microsoft |
 | "oscdimg.exe not found" | Run `winget install -e --id Microsoft.OSCDIMG` then retry |
 | USB drive not showing up | Plug it in, wait a few seconds, then click **Refresh** |
-| Modification seems stuck | Without driver injection this stage is a file copy, so check disk activity. With driver injection enabled, the WIM commit is slow — wait at least 10 minutes before assuming it's frozen |
+| Modification seems stuck | The WIM dismount step is slow — wait at least 10 minutes before assuming it's frozen |
 | "Access Denied" error | Make sure WinUtil is running as Administrator |
 | "Setup has failed to validate the product key" | Recreate the ISO with the latest WinUtil. The creator now removes stale `PID.txt`, writes `sources\ei.cfg`, and pins the selected image in `autounattend.xml` so setup does not use an embedded OEM key for a different edition |
 

--- a/docs/src/content/docs/guides/win11creator.mdx
+++ b/docs/src/content/docs/guides/win11creator.mdx
@@ -14,7 +14,7 @@ WinUtil includes a built-in **Win11 Creator** tool that lets you take an officia
 ![Win11 Creator tab in WinUtil](../../../assets/screenshots/win11creator-tab-new.png)
 
 :::caution
-You need an **official Windows 11 ISO** from [Microsoft's website](https://www.microsoft.com/en-us/software-download/windows11) before starting. Custom, modified, or non-official ISOs are not supported. The process uses ~10–15 GB of temporary disk space, so make sure you have room.
+You need an **official Windows 11 ISO** from [Microsoft's website](https://www.microsoft.com/en-us/software-download/windows11) before starting. Custom, modified, or non-official ISOs are not supported. The ISO contents are copied to a temporary folder, so allow room for about twice the size of your ISO, plus space for the one you export.
 :::
 
 :::note
@@ -70,7 +70,7 @@ Click **Run Windows ISO Modification and Creator** to start the customization pr
 - **Disable Copilot and search box suggestions**
 
 **Optional: Driver Injection**
-- If enabled, it injects all drivers from your current system into the install.wim and boot.wim — useful for offline installations on machines with missing drivers. This is an optional checkbox in Step 3.
+- If enabled, all drivers from your current system are added to the `install.wim` edition you selected, and the storage drivers are also staged in `$WinpeDriver$` so Windows Setup can load them in WinPE. `boot.wim` itself is not modified. Useful for offline installations on machines with missing drivers. This is an optional checkbox in Step 3.
 
 A live log shows progress as each step completes. Without driver injection this stage is a copy of the ISO contents plus a few small setup files, so it is limited by disk speed. Enabling driver injection adds a single WIM mount and commit, which is by far the slowest part. Do not close WinUtil while it is running.
 
@@ -112,7 +112,7 @@ Double-check you have selected the correct drive before confirming. This operati
 
 ### Step 5 — Clean Up (Optional)
 
-Click **Clean & Reset** to delete the temporary working directory (~10–15 GB) and return the tool to its initial state, ready for a new ISO. You will be asked to confirm before anything is deleted.
+Click **Clean & Reset** to delete the temporary working directory (about the size of your ISO) and return the tool to its initial state, ready for a new ISO. You will be asked to confirm before anything is deleted.
 
 ---
 
@@ -136,7 +136,7 @@ When you install Windows 11 from your modified ISO:
 | "install.wim not found" | Not a valid Windows 11 ISO — download a fresh one from Microsoft |
 | "oscdimg.exe not found" | Run `winget install -e --id Microsoft.OSCDIMG` then retry |
 | USB drive not showing up | Plug it in, wait a few seconds, then click **Refresh** |
-| Modification seems stuck | The WIM dismount step is slow — wait at least 10 minutes before assuming it's frozen |
+| Modification seems stuck | Without driver injection this stage is a file copy, so check disk activity. With driver injection enabled, the WIM commit is slow — wait at least 10 minutes before assuming it's frozen |
 | "Access Denied" error | Make sure WinUtil is running as Administrator |
 | "Setup has failed to validate the product key" | Recreate the ISO with the latest WinUtil. The creator now removes stale `PID.txt`, writes `sources\ei.cfg`, and pins the selected image in `autounattend.xml` so setup does not use an embedded OEM key for a different edition |
 

--- a/docs/src/content/docs/guides/win11creator.mdx
+++ b/docs/src/content/docs/guides/win11creator.mdx
@@ -47,18 +47,16 @@ This step takes around 10–30 seconds, depending on your drive speed.
 
 Click **Run Windows ISO Modification and Creator** to start the customization process. WinUtil will:
 
-**App & Component Removal:**
+**App & Component Removal:** (applied on first logon by the staged setup script, not baked into the image)
 - **Remove 40+ bloat apps** — Clipchamp, Teams, Copilot, Dev Home, new Outlook, Bing apps, Solitaire, and more
-- **Delete OneDrive setup** from the image
+- **Uninstall OneDrive**
 
 **System Customization:**
 - **Bypass hardware checks** — removes TPM, Secure Boot, CPU, RAM, and storage requirement enforcement so the ISO installs on unsupported hardware
 - **Enable local account setup** — injects an `autounattend.xml` that skips the Microsoft account screen during OOBE
 - **Disable BitLocker and device encryption** — removes startup overhead
 - **Disable Chat icon** — removes chat taskbar button
-- **Strip unused editions** — keeps only your selected edition, saving 1–2 GB per removed edition
-- **Pin the selected edition during setup** — writes setup metadata so OEM firmware keys for a different edition do not force the installer down the wrong product-key path
-- **Clean the component store** — runs DISM cleanup to reclaim another 300–800 MB
+- **Pin the selected edition during setup** — writes `sources\ei.cfg` and setup metadata so OEM firmware keys for a different edition do not force the installer down the wrong product-key path
 
 **Privacy & Telemetry Tweaks:**
 - **Disable telemetry** — advertising ID, tailored experiences, input personalization, speech online privacy
@@ -74,7 +72,11 @@ Click **Run Windows ISO Modification and Creator** to start the customization pr
 **Optional: Driver Injection**
 - If enabled, it injects all drivers from your current system into the install.wim and boot.wim — useful for offline installations on machines with missing drivers. This is an optional checkbox in Step 3.
 
-A live log shows progress as each step completes. This stage usually takes **10–30 minutes** depending on disk speed. The WIM dismount near the end is the slowest part, so do not close WinUtil while it is running.
+A live log shows progress as each step completes. Without driver injection this stage is a copy of the ISO contents plus a few small setup files, so it is limited by disk speed. Enabling driver injection adds a single WIM mount and commit, which is by far the slowest part. Do not close WinUtil while it is running.
+
+:::note
+The resulting ISO is close to the size of the source ISO. WinUtil does not remove the unused editions from `install.wim`; it selects your edition through `sources\ei.cfg` and `autounattend.xml` so Windows Setup installs the right one.
+:::
 
 ---
 


### PR DESCRIPTION
## Type of Change
- [ ] New feature
- [ ] Bug fix
- [x] Documentation update
- [ ] Refactor
- [ ] UI/UX improvement

## Description
#4862 removed the `Export-WindowsImage` step and the component store cleanup, so the creator no longer strips unused editions or shrinks the image. The selected edition is applied through `sources\ei.cfg` and `autounattend.xml` instead, and the output ISO stays close to the size of the source. The docs still promised the old savings, which is what #4918 ran into.

This only touches the claims that promised a size reduction or edition removal:

- the strip-editions and component store bullets in the guide
- the matching two lines in the architecture data flow and function list
- the modified ISO size in the data flow and the disk space block
- a short note in the guide explaining why the output is not smaller

Everything else in the Win11 Creator docs is left as it was. An earlier revision of this PR rewrote more of the section; that has been reverted, since the rest of it needs its own review rather than being carried along here.

Verified with `npm run build` in `docs/` (111 pages, no errors).

## Issue related to PR
- Resolves #4918
