### PR TITLE
fix: Import now fills all tabs

### DIFF
--- a/functions/private/Initialize-WinUtilTabContent.ps1
+++ b/functions/private/Initialize-WinUtilTabContent.ps1
@@ -36,4 +36,7 @@ function Initialize-WinUtilTabContent {
     }
 
     $sync.InitializedTabs[$TabName] = $true
+
+    # Sync freshly built controls to any selections already in $sync.selected* (import/preset).
+    Reset-WPFCheckBoxes -doToggles $true
 }

--- a/pester/lazy-tabs.Tests.ps1
+++ b/pester/lazy-tabs.Tests.ps1
@@ -12,6 +12,7 @@ BeforeAll {
         param([string]$TargetGridName)
     }
     function Invoke-WinUtilISOCheckExistingWork { }
+    function Reset-WPFCheckBoxes { param([bool]$doToggles) }
 
     . (Join-Path $script:repoRoot "functions\private\Initialize-WinUtilTabContent.ps1")
 }
@@ -29,6 +30,7 @@ Describe "Initialize-WinUtilTabContent" {
 
         Mock Invoke-WPFUIElements { }
         Mock Initialize-WPFUI { }
+        Mock Reset-WPFCheckBoxes { }
     }
 
     AfterEach {
@@ -49,6 +51,21 @@ Describe "Initialize-WinUtilTabContent" {
             $TargetGridName -eq "appspanel"
         }
         $script:sync.InitializedTabs["Install"] | Should -BeTrue
+    }
+
+    It "re-applies checkbox selections after building a tab's controls" {
+        Initialize-WinUtilTabContent -TabName "Tweaks"
+
+        Should -Invoke -CommandName Reset-WPFCheckBoxes -Times 1 -Exactly -ParameterFilter {
+            $doToggles -eq $true
+        }
+    }
+
+    It "does not re-apply checkbox selections on a tab that's already built" {
+        Initialize-WinUtilTabContent -TabName "Tweaks"
+        Initialize-WinUtilTabContent -TabName "Tweaks"
+
+        Should -Invoke -CommandName Reset-WPFCheckBoxes -Times 1 -Exactly
     }
 
     It "initializes deferred config-backed tabs once" {


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://winutil.christitus.com/contributing/ -->
<!--Documentation is auto-generated from configs - no manual documentation updates needed -->

## Type of Change
- [x] Bug fix

## Description
Importing a JSON config only checked the boxes on whichever tab was currently open, forcing users to re-import once per tab. Tabs other than Install build their checkboxes lazily on first visit, and the import's `Reset-WPFCheckBoxes` call only touches checkboxes that already exist - so any tab not yet visited later builds its controls with the default unchecked state and never picks up the import.

Fix: re-run `Reset-WPFCheckBoxes` right after a tab's controls are built, so freshly-created checkboxes and toggles sync to whatever is already recorded (import or preset), regardless of visit order.

Added Pester coverage asserting this happens once per tab build. Verified manually by compiling and running the GUI, importing a config, then switching tabs.

## Issue related to PR
- Resolves #