### PR TITLE
feat: add mpv to Multimedia Tools app list

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -791,6 +791,14 @@
         "winget": "mpc-qt.mpc-qt",
         "foss": true
     },
+    "mpv": {
+        "category": "Multimedia Tools",
+        "content": "mpv",
+        "description": "mpv is a free, open source, and cross-platform media player supporting a wide variety of media formats, codecs, and subtitle types.",
+        "link": "https://mpv.io/",
+        "winget": "shinchiro.mpv",
+        "foss": true
+    },
     "matrix": {
         "category": "Communications",
         "choco": "element-desktop",


### PR DESCRIPTION
## Type of Change
- [x] New feature

## Description
Add `mpv` entry to `config/applications.json` under Multimedia Tools category.

- winget id `shinchiro.mpv` (de facto standard Windows build, mpv has no official Windows installer)
- No choco source: both `mpv` and `mpv.install` choco packages are flagged "Possibly broken" upstream

Test plan:
- [x] Validated `config/applications.json` parses as valid JSON
- [x] Compiled via `.\Compile.ps1 -Run`, confirmed `mpv` checkbox appears under Install tab, Multimedia Tools
- [x] End-to-end install and uninstall via GUI, logs below

<details>
<summary>Install log</summary>

```
[2026-08-07 10:53:41.868] [INFO] [Package] Install winget package: shinchiro.mpv (source: winget)
Found mpv (shinchiro build) [shinchiro.mpv] Version 0.41.0
Downloading https://github.com/0GMou/mpv2winget/releases/download/v0.41.0/mpv_installer_x64.exe
  [progress bar]  36.0 MB / 36.0 MB
Successfully verified installer hash
Starting package install...
Successfully installed
[2026-08-07 10:53:50.323] [INFO] [Package] Install winget package completed: shinchiro.mpv (exit code: 0)
```

</details>

<details>
<summary>Uninstall log</summary>

```
[2026-08-07 10:54:26.401] [INFO] [Uninstall] Uninstall requested for 1 selected package(s) using preference: Winget
[2026-08-07 10:54:27.427] [INFO] [Package] Uninstall winget package: shinchiro.mpv (source: winget)
Found MPV Player [shinchiro.mpv]
Starting package uninstall...
Successfully uninstalled
[2026-08-07 10:54:28.714] [INFO] [Package] Uninstall winget package completed: shinchiro.mpv (exit code: 0)
```

</details>

## Issue related to PR
- Resolves #
