### PR TITLE
Fix UI helper errors during headless -Preset and -Config runs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,6 +163,7 @@ When the user corrects an agent approach, add or tighten one concrete rule here 
 - Import Pester 5.8.0 before running tests so `Invoke-Pester -Output Detailed -CI` does not resolve to Windows' inbox Pester 3.4.0.
 - Keep package install/uninstall process launches simple unless explicitly requested; do not add a separate stdout/stderr process logging helper for winget or Chocolatey.
 - When the active log file is owned by `Start-Transcript`, do not call `Add-Content` against that file; write to host output so the transcript captures the line in the same log file without recording a terminating-error diagnostic.
+- Keep UI helpers such as `Invoke-WPFUIThread` and `Set-WinUtilTweaksProgressIndicator` safe to call without a window; the `-Preset` and `-Config` paths run the workflows before the form is created and before PresentationCore is loaded.
 - Log install/uninstall package names and package-manager IDs before queuing background runspace work; do not rely on runspace host output for the package identity.
 - For Win11 Creator, start each new ISO modification in a fresh `WinUtil_Win11ISO_*` temp directory; existing-work detection is only for resuming/exporting already modified media.
 - For Win11 Creator driver injection, keep offline WIM servicing to one mount, one `/Add-Driver`, and one commit; do not export editions or run unrelated WIM cleanup, and reject damaged metadata before ISO export.

--- a/functions/private/Set-WinUtilRegistry.ps1
+++ b/functions/private/Set-WinUtilRegistry.ps1
@@ -28,7 +28,7 @@ function Set-WinUtilRegistry {
     )
 
     try {
-        if(!(Test-Path 'HKU:\')) {New-PSDrive -PSProvider Registry -Name HKU -Root HKEY_USERS}
+        if(!(Test-Path 'HKU:\')) {New-PSDrive -PSProvider Registry -Name HKU -Root HKEY_USERS | Out-Null}
 
         If (!(Test-Path $Path)) {
             Write-Host "$Path was not found. Creating..."

--- a/functions/private/Set-WinUtilTweaksProgressIndicator.ps1
+++ b/functions/private/Set-WinUtilTweaksProgressIndicator.ps1
@@ -18,6 +18,10 @@ function Set-WinUtilTweaksProgressIndicator {
         [int]$Percent
     )
 
+    if ($null -eq $sync.form -or $null -eq $sync.form.Dispatcher) {
+        return
+    }
+
     $indicatorVisible = if ($Visible) { [Windows.Visibility]::Visible } else { [Windows.Visibility]::Collapsed }
     $indicatorLabel = $Label
     $hasLabel = $PSBoundParameters.ContainsKey('Label')

--- a/functions/public/Invoke-WPFAppxRemoval.ps1
+++ b/functions/public/Invoke-WPFAppxRemoval.ps1
@@ -96,5 +96,5 @@ function Invoke-WPFAppxRemoval {
             $sync.ProcessRunning = $false
         }
 
-    }
+    } | Out-Null
 }

--- a/functions/public/Invoke-WPFFeatureInstall.ps1
+++ b/functions/public/Invoke-WPFFeatureInstall.ps1
@@ -36,5 +36,5 @@ function Invoke-WPFFeatureInstall {
         Write-Host "---   Features are Installed    ---"
         Write-Host "---  A Reboot may be required   ---"
         Write-Host "==================================="
-    }
+    } | Out-Null
 }

--- a/functions/public/Invoke-WPFInstall.ps1
+++ b/functions/public/Invoke-WPFInstall.ps1
@@ -110,5 +110,5 @@ function Invoke-WPFInstall {
             }
             $sync.ProcessRunning = $False
         }
-    }
+    } | Out-Null
 }

--- a/functions/public/Invoke-WPFUIThread.ps1
+++ b/functions/public/Invoke-WPFUIThread.ps1
@@ -1,3 +1,7 @@
 function Invoke-WPFUIThread ($ScriptBlock) {
+    if ($null -eq $sync.form -or $null -eq $sync.form.Dispatcher) {
+        return
+    }
+
     $sync.form.Dispatcher.Invoke([action]$ScriptBlock)
 }

--- a/functions/public/Invoke-WPFtweaksbutton.ps1
+++ b/functions/public/Invoke-WPFtweaksbutton.ps1
@@ -88,5 +88,5 @@ function Invoke-WPFtweaksbutton {
     Write-Host "--     Tweaks are Finished    ---"
     Write-Host "================================="
     Write-WinUtilLog -Component "Tweaks" -Message "Tweaks workflow completed."
-  }
+  } | Out-Null
 }

--- a/pester/headless-ui.Tests.ps1
+++ b/pester/headless-ui.Tests.ps1
@@ -1,0 +1,107 @@
+#===========================================================================
+# Tests - UI Helpers During Headless (-Preset / -Config) Runs
+#===========================================================================
+
+BeforeAll {
+    $script:repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+
+    if (-not ("Windows.Visibility" -as [type])) {
+        Add-Type @"
+namespace Windows
+{
+    public enum Visibility
+    {
+        Visible,
+        Collapsed
+    }
+}
+"@
+    }
+
+    . (Join-Path $script:repoRoot "functions\public\Invoke-WPFUIThread.ps1")
+    . (Join-Path $script:repoRoot "functions\private\Set-WinUtilTweaksProgressIndicator.ps1")
+
+    function script:New-WinUtilFakeForm {
+        $dispatcher = New-Object psobject
+        $dispatcher | Add-Member -MemberType NoteProperty -Name InvokeCount -Value 0
+        $dispatcher | Add-Member -MemberType ScriptMethod -Name Invoke -Value {
+            param($Action)
+
+            $null = $Action
+            $this.InvokeCount++
+        }
+
+        $form = New-Object psobject
+        $form | Add-Member -MemberType NoteProperty -Name Dispatcher -Value $dispatcher
+        return $form
+    }
+
+    function script:New-WinUtilFakeIndicatorControlSet {
+        @{
+            Bar   = [pscustomobject]@{ Visibility = [Windows.Visibility]::Collapsed }
+            Label = [pscustomobject]@{ Text = "" }
+            Value = [pscustomobject]@{ Value = 0 }
+        }
+    }
+}
+
+Describe "Invoke-WPFUIThread without a window" {
+    AfterEach {
+        Remove-Variable -Name sync -Scope Script -ErrorAction SilentlyContinue
+    }
+
+    It "does nothing when the automation paths run before the form is created" {
+        $script:sync = [Hashtable]::Synchronized(@{})
+        $script:blockRan = $false
+
+        { Invoke-WPFUIThread -ScriptBlock { $script:blockRan = $true } } | Should -Not -Throw
+        $script:blockRan | Should -BeFalse
+    }
+
+    It "does nothing when the form exists but has no dispatcher" {
+        $script:sync = [Hashtable]::Synchronized(@{ Form = [pscustomobject]@{ Dispatcher = $null } })
+        $script:blockRan = $false
+
+        { Invoke-WPFUIThread -ScriptBlock { $script:blockRan = $true } } | Should -Not -Throw
+        $script:blockRan | Should -BeFalse
+    }
+
+    It "still marshals onto the dispatcher when a window exists" {
+        $form = New-WinUtilFakeForm
+        $script:sync = [Hashtable]::Synchronized(@{ Form = $form })
+
+        Invoke-WPFUIThread -ScriptBlock { }
+
+        $form.Dispatcher.InvokeCount | Should -Be 1
+    }
+}
+
+Describe "Set-WinUtilTweaksProgressIndicator without a window" {
+    AfterEach {
+        Remove-Variable -Name sync -Scope Script -ErrorAction SilentlyContinue
+    }
+
+    It "returns before resolving WPF types when the form is missing" {
+        $script:sync = [Hashtable]::Synchronized(@{})
+
+        { Set-WinUtilTweaksProgressIndicator -Visible $true -Label "Creating restore point" -Percent 0 } | Should -Not -Throw
+    }
+
+    It "still updates the indicator controls when a window exists" {
+        $controls = New-WinUtilFakeIndicatorControlSet
+        $script:sync = [Hashtable]::Synchronized(@{
+            Form                    = New-WinUtilFakeForm
+            WPFTweaksProgressBar    = $controls.Bar
+            WPFTweaksProgressLabel  = $controls.Label
+            WPFTweaksProgressValue  = $controls.Value
+        })
+
+        Mock Invoke-WPFUIThread { & $ScriptBlock }
+
+        Set-WinUtilTweaksProgressIndicator -Visible $true -Label "Applying WPFTweaksTelemetry (1/17)" -Percent 42
+
+        $controls.Bar.Visibility | Should -Be ([Windows.Visibility]::Visible)
+        $controls.Label.Text | Should -Be "Applying WPFTweaksTelemetry (1/17)"
+        $controls.Value.Value | Should -Be 42
+    }
+}


### PR DESCRIPTION
## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactor
- [ ] UI/UX improvement

## Description

Running WinUtil headlessly with `-Preset` or `-Config` writes a wall of errors into the session log on every run.

`scripts/main.ps1` handles `-Preset` (lines 37-51) and `-Config` (lines 53-65) in early-return blocks that call `Invoke-WinUtilAutoRun` and then exit. Both return **before** line 67 loads `presentationframework` and **before** line 74 creates `$sync["Form"]`, so the tweak workflow calls UI-only helpers against a window that does not exist:

- `Invoke-WPFUIThread` runs `$sync.form.Dispatcher.Invoke(...)` on `$null` and throws `InvokeMethodOnNull`
- `Set-WinUtilTweaksProgressIndicator` cannot resolve `[Windows.Visibility]` and throws `TypeNotFound`

The errors are non-terminating, so tweaks still apply correctly, but a `-Preset Advanced` run logs six error records before the first tweak even starts. Sample from a real run:

```
[INFO] [Tweaks] Tweaks requested: 17 selected tweak(s), DNS provider: Default
You cannot call a method on a null-valued expression.
+     $sync.form.Dispatcher.Invoke([action]$ScriptBlock)
Unable to find type [Windows.Visibility].
+     $indicatorVisible = if ($Visible) { [Windows.Visibility]::Visible ...
```

### Why the guard goes in the helpers

Loading the WPF assembly earlier does not fix this. `System.Windows.Visibility` lives in **PresentationCore**, which only loads once a WPF object is actually instantiated, so `LoadWithPartialName('presentationframework')` leaves the type error unchanged. And giving `$sync.Form` a real window only trades the dispatcher errors for `PropertyNotFound` on `WPFTweaksProgressBar`, `WPFTweaksProgressLabel` and `WPFTweaksProgressValue`, which are only populated at `main.ps1:135`.

The repo already has a `$hasUI = $null -ne $sync.Form -and $null -ne $sync.Form.Dispatcher` convention in `Invoke-WPFInstall`, `Invoke-WPFUnInstall`, `Invoke-WPFAppxInstall`, `Invoke-WPFAppxRemoval` and `Invoke-WPFOOSU` — but it was never applied to `Invoke-WPFtweaksbutton`, `Invoke-WPFundoall` or `Invoke-WPFFeatureInstall`, which is exactly why these errors appear. Guarding the two helpers covers all three missed workflows in two lines instead of ~15, and any future call site along with them. The existing `$hasUI` blocks become redundant rather than wrong and are left untouched.

### Stray console output

A second commit removes two pieces of output that a GUI click handler silently discards but that reach the console on automation runs:

- `Invoke-WPFRunspace` returns an `IAsyncResult` that no call site uses, printing a `CompletedSynchronously / IsCompleted` block. The return value itself is kept because `pester/runspace.Tests.ps1` asserts it, so the suppression is applied at the four call sites reachable from `Invoke-WinUtilAutoRun`.
- `Set-WinUtilRegistry` was the only `New-PSDrive` call site not piping to `Out-Null`, printing a PSDrive table mid-run. `Invoke-WinUtilCurrentSystem` and `Get-WinUtilToggleStatus` already suppress it.

### Testing

- New `pester/headless-ui.Tests.ps1` (5 tests) covers the no-window cases for both helpers and asserts the GUI path still marshals onto the dispatcher and still updates the indicator controls. The three no-window tests were confirmed to fail against the pre-fix functions, and the two GUI-path tests pass both before and after, so the guard provably does not disable the GUI behaviour.
- Full Pester suite: **480 passed, 0 failed**.
- `.\Compile.ps1` succeeds.
- PSScriptAnalyzer with `lint/PSScriptAnalyser.ps1` on the changed files: no new findings.
- Verified against a live `-Preset Advanced` run that all 17 tweaks apply both before and after this change, including all 12 registry keys for `WPFTweaksTelemetry`. This PR only removes the error noise; it does not change which tweaks run.

No behaviour change in the GUI: when a window exists, both helpers work exactly as before.

## Issue related to PR
<!-- No existing issue; found while reviewing a headless -Preset Advanced session log. -->
