### PR TITLE
Fix WinOneShot ComboItems compatibility

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -1465,11 +1465,7 @@
     "category": "Customize Preferences",
     "panel": "2",
     "Type": "Combobox",
-    "ComboItems": [
-      "Enabled",
-      "Disabled (Compatibility)",
-      "Fully Disabled"
-    ],
+    "ComboItems": "Enabled|Disabled (Compatibility)|Fully Disabled",
     "ComboDescriptions": {
       "Enabled": "Uses Windows' default overlay behavior.",
       "Disabled (Compatibility)": "Disables MPO using OverlayTestMode=5, the less aggressive compatibility method.",

--- a/functions/public/Invoke-WPFUIElements.ps1
+++ b/functions/public/Invoke-WPFUIElements.ps1
@@ -271,7 +271,11 @@ function Invoke-WPFUIElements {
                         [System.Windows.Automation.AutomationProperties]::SetName($comboBox, $entryInfo.Content)
 
                         $comboItems = if ($entryInfo.ComboItems -is [string]) {
-                            $entryInfo.ComboItems -split " "
+                            if ($entryInfo.ComboItems.Contains("|")) {
+                                $entryInfo.ComboItems -split "\|"
+                            } else {
+                                $entryInfo.ComboItems -split " "
+                            }
                         } else {
                             @($entryInfo.ComboItems)
                         }

--- a/pester/configs.Tests.ps1
+++ b/pester/configs.Tests.ps1
@@ -440,7 +440,11 @@ Describe "UI-rendered config entries" {
                 $statefulRegistry = @($entry.Value.registry | Where-Object Values)
                 if ($statefulRegistry.Count -gt 0) {
                     $comboItems = if ($entry.Value.ComboItems -is [string]) {
-                        @($entry.Value.ComboItems -split "\|")
+                        if ($entry.Value.ComboItems.Contains("|")) {
+                            @($entry.Value.ComboItems -split "\|")
+                        } else {
+                            @($entry.Value.ComboItems -split " ")
+                        }
                     } else {
                         @($entry.Value.ComboItems)
                     }

--- a/pester/configs.Tests.ps1
+++ b/pester/configs.Tests.ps1
@@ -439,7 +439,11 @@ Describe "UI-rendered config entries" {
                 }
                 $statefulRegistry = @($entry.Value.registry | Where-Object Values)
                 if ($statefulRegistry.Count -gt 0) {
-                    $comboItems = @($entry.Value.ComboItems)
+                    $comboItems = if ($entry.Value.ComboItems -is [string]) {
+                        @($entry.Value.ComboItems -split "\|")
+                    } else {
+                        @($entry.Value.ComboItems)
+                    }
                     if ($statefulRegistry.Count -ne @($entry.Value.registry).Count) {
                         $invalidEntries.Add("$($entry.Name) registry states must all use Values")
                     } else {

--- a/pester/multiplane-overlay.Tests.ps1
+++ b/pester/multiplane-overlay.Tests.ps1
@@ -18,9 +18,11 @@ BeforeAll {
 Describe "Multiplane Overlay configuration" {
     It "keeps every state and registry action in tweaks.json" {
         $script:config.WPFMultiplaneOverlay.Type | Should -Be "Combobox"
-        $script:config.WPFMultiplaneOverlay.ComboItems | Should -Be @("Enabled", "Disabled (Compatibility)", "Fully Disabled")
+        $script:config.WPFMultiplaneOverlay.ComboItems | Should -BeOfType [string]
+        $comboItems = @($script:config.WPFMultiplaneOverlay.ComboItems -split "\|")
+        $comboItems | Should -Be @("Enabled", "Disabled (Compatibility)", "Fully Disabled")
         $script:states.Count | Should -Be 2
-        $script:states[0].Values.PSObject.Properties.Name | Should -Be $script:config.WPFMultiplaneOverlay.ComboItems
+        $script:states[0].Values.PSObject.Properties.Name | Should -Be $comboItems
         $script:states[0].Values.PSObject.Properties.Value | Should -Be @("<RemoveEntry>", "5", "5")
         $script:states[1].Values.PSObject.Properties.Value | Should -Be @("<RemoveEntry>", "<RemoveEntry>", "1")
     }


### PR DESCRIPTION
## Summary

- keep the Multiplane Overlay three-state control while publishing `ComboItems` as a string
- support pipe-delimited multi-word combobox labels in the WinUtil renderer
- validate the parsed labels against registry-backed states and update focused coverage

## Root cause

PR #4897 changed `WPFMultiplaneOverlay.ComboItems` from a string to a JSON array. WinOneShot's catalog model expects this field to remain a string, so the compatibility guard correctly failed and WinOneShot would be unable to deserialize `tweaks.json`.

## Impact

The MPO control continues to show `Enabled`, `Disabled (Compatibility)`, and `Fully Disabled`, while the published catalog remains compatible with WinOneShot.

## Validation

- `Compile.ps1`
- focused Pester tests: 50 passed, 0 failed
- full CI-mode Pester suite: 540 passed, 0 failed
- focused PSScriptAnalyzer check: no new findings (existing plural-noun convention warning only)