### PR TITLE
Update issue templates with prefilled titles

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,5 +1,6 @@
 name: "Bug report"
 description: "Report a bug to help us identify and fix issues in the project."
+title: "[Bug Report] - <your summary here> "
 labels: ["bug"]
 
 body:

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,6 +1,6 @@
 name: "Bug report"
 description: "Report a bug to help us identify and fix issues in the project."
-title: "[Bug Report] - <your summary here> "
+title: "[Bug Report] - <your summary here>"
 labels: ["bug"]
 
 body:

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,5 +1,6 @@
 name: "Feature request"
 description: "Suggest a new feature or improvement for the project."
+title: "[Feature Request] - <your summary here> "
 labels: ["enhancement"]
 
 body:

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,6 +1,6 @@
 name: "Feature request"
 description: "Suggest a new feature or improvement for the project."
-title: "[Feature Request] - <your summary here> "
+title: "[Feature Request] - <your summary here>"
 labels: ["enhancement"]
 
 body:


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://winutil.christitus.com/contributing/ -->
<!--Documentation is auto-generated from configs - no manual documentation updates needed -->

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactor
- [ ] UI/UX improvement

<!-- This automatically adds labels to your PR based on the selections above. -->

## Description
<!--[What does this PR do? Provide Screenshots when possible.]-->
This pull request makes a small improvement to the GitHub issue templates by adding default title prefixes for both bug reports and feature requests. This helps standardize issue titles and makes it easier to identify the type of issue at a glance.

- Issue Template Improvements:
  * Added a default title prefix (`[Bug Report] -`) to the bug report template in `.github/ISSUE_TEMPLATE/bug_report.yaml`.
  * Added a default title prefix (`[Feature Request] -`) to the feature request template in `.github/ISSUE_TEMPLATE/feature_request.yaml`.

## Issue related to PR
<!--[List any ISSUES this is related to as it AUTO-CLOSES Them!]-->
- Resolves #
