### PR TITLE
Show configuration keys in UI tooltips

### DIFF
--- a/docs/src/content/docs/guides/automation.mdx
+++ b/docs/src/content/docs/guides/automation.mdx
@@ -29,6 +29,8 @@ To create your own config file:
 3. Choose **Export**.
 4. Save the exported JSON file.
 
+When editing a configuration manually, hover over an application or tweak in WinUtil to see its configuration key, such as `WPFInstallfirefox` or `WPFTweaksTelemetry`.
+
 Once you have exported a config, launch WinUtil with it using this command:
 ```powershell
 & ([ScriptBlock]::Create((irm "https://christitus.com/win"))) -Config "C:\Path\To\Config.json"

--- a/functions/private/Get-WinUtilConfigToolTip.ps1
+++ b/functions/private/Get-WinUtilConfigToolTip.ps1
@@ -1,0 +1,24 @@
+function Get-WinUtilConfigToolTip {
+    <#
+        .SYNOPSIS
+            Builds a tooltip that includes an entry's configuration key.
+        .PARAMETER Description
+            The user-facing description of the configuration entry.
+        .PARAMETER ConfigKey
+            The key used to reference the entry in an exported configuration.
+    #>
+    param(
+        [AllowEmptyString()]
+        [string]$Description,
+
+        [Parameter(Mandatory)]
+        [string]$ConfigKey
+    )
+
+    $configKeyText = "Configuration key: $ConfigKey"
+    if ([string]::IsNullOrWhiteSpace($Description)) {
+        return $configKeyText
+    }
+
+    return "$Description`n`n$configKeyText"
+}

--- a/functions/private/Initialize-InstallAppEntry.ps1
+++ b/functions/private/Initialize-InstallAppEntry.ps1
@@ -19,7 +19,7 @@ function Initialize-InstallAppEntry {
         $border = New-Object Windows.Controls.Border
         $border.Style = $sync.Form.Resources.AppEntryBorderStyle
         $border.Tag = $appKey
-        $border.ToolTip = $app.description
+        $border.ToolTip = Get-WinUtilConfigToolTip -Description $app.description -ConfigKey $appKey
         $border.Add_MouseLeftButtonUp({
             # Resolve through $sync because the border's child is a layout Grid for FOSS entries
             $childCheckbox = $sync.$($this.Tag)

--- a/functions/public/Invoke-WPFUIElements.ps1
+++ b/functions/public/Invoke-WPFUIElements.ps1
@@ -66,9 +66,8 @@ function Invoke-WPFUIElements {
     foreach ($entry in $configHashtable.Keys) {
         $entryInfo = $configHashtable[$entry]
         $entryToolTip = $entryInfo.description
-        $isSelectableEntry = [string]::IsNullOrWhiteSpace([string]$entryInfo.type) -or $entryInfo.type -in @("Toggle", "ToggleButton")
-        $isImportableKey = $entry -match '^(WPFTweaks|WPFToggle|WPFFeature|WPFAppx)'
-        if ($isSelectableEntry -and $isImportableKey) {
+        $isConfigSelectionEntry = [string]::IsNullOrWhiteSpace([string]$entryInfo.type) -and $entry -match '^(WPFTweaks|WPFFeature|WPFAppx)'
+        if ($isConfigSelectionEntry) {
             $entryToolTip = Get-WinUtilConfigToolTip -Description $entryInfo.description -ConfigKey $entry
         }
 
@@ -197,7 +196,7 @@ function Invoke-WPFUIElements {
 
                         $label = New-Object Windows.Controls.Label
                         $label.Content = $entryInfo.Content
-                        $label.ToolTip = $entryInfo.ToolTip
+                        $label.ToolTip = $entryInfo.Description
                         $label.HorizontalAlignment = "Left"
                         $label.SetResourceReference([Windows.Controls.Control]::FontSizeProperty, "FontSize")
                         $label.SetResourceReference([Windows.Controls.Control]::ForegroundProperty, "MainForegroundColor")
@@ -231,7 +230,7 @@ function Invoke-WPFUIElements {
                         $toggleButton = New-Object Windows.Controls.Primitives.ToggleButton
                         $toggleButton.Name = $entryInfo.Name
                         $toggleButton.Content = $entryInfo.Content[1]
-                        $toggleButton.ToolTip = $entryInfo.ToolTip
+                        $toggleButton.ToolTip = $entryInfo.Description
                         $toggleButton.HorizontalAlignment = "Left"
                         $toggleButton.Style = $ToggleButtonStyle
                         [System.Windows.Automation.AutomationProperties]::SetName($toggleButton, $entryInfo.Content[0])

--- a/functions/public/Invoke-WPFUIElements.ps1
+++ b/functions/public/Invoke-WPFUIElements.ps1
@@ -65,6 +65,12 @@ function Invoke-WPFUIElements {
     # Iterate through JSON data and organize by panel and category
     foreach ($entry in $configHashtable.Keys) {
         $entryInfo = $configHashtable[$entry]
+        $entryToolTip = $entryInfo.description
+        $isSelectableEntry = [string]::IsNullOrWhiteSpace([string]$entryInfo.type) -or $entryInfo.type -in @("Toggle", "ToggleButton")
+        $isImportableKey = $entry -match '^(WPFTweaks|WPFToggle|WPFFeature|WPFAppx)'
+        if ($isSelectableEntry -and $isImportableKey) {
+            $entryToolTip = Get-WinUtilConfigToolTip -Description $entryInfo.description -ConfigKey $entry
+        }
 
         # Create an object for the application
         $entryObject = [PSCustomObject]@{
@@ -81,7 +87,7 @@ function Invoke-WPFUIElements {
             Checked     = $entryInfo.Checked
             ButtonWidth = $entryInfo.ButtonWidth
             GroupName   = $entryInfo.GroupName  # Added for RadioButton groupings
-            ToolTip     = Get-WinUtilConfigToolTip -Description $entryInfo.description -ConfigKey $entry
+            ToolTip     = $entryToolTip
         }
 
         if (-not $organizedData.ContainsKey($entryObject.Panel)) {
@@ -269,7 +275,7 @@ function Invoke-WPFUIElements {
                         $label = New-Object Windows.Controls.Label
                         $label.Content = $entryInfo.Content
                         $label.HorizontalAlignment = "Left"
-                        $label.ToolTip = $entryInfo.ToolTip
+                        $label.ToolTip = $entryInfo.Description
                         $label.VerticalAlignment = "Center"
                         $label.SetResourceReference([Windows.Controls.Control]::FontSizeProperty, "ButtonFontSize")
                         $label.UseLayoutRounding = $true
@@ -399,7 +405,6 @@ function Invoke-WPFUIElements {
                         $button = New-Object Windows.Controls.Button
                         $button.Name = $entryInfo.Name
                         $button.Content = $entryInfo.Content
-                        $button.ToolTip = $entryInfo.ToolTip
                         $button.HorizontalAlignment = "Left"
                         $button.SetResourceReference([Windows.Controls.Control]::MarginProperty, "ButtonMargin")
                         $button.SetResourceReference([Windows.Controls.Control]::FontSizeProperty, "ButtonFontSize")
@@ -450,7 +455,7 @@ function Invoke-WPFUIElements {
                         $radioButton.HorizontalAlignment = "Left"
                         $radioButton.SetResourceReference([Windows.Controls.Control]::MarginProperty, "CheckBoxMargin")
                         $radioButton.SetResourceReference([Windows.Controls.Control]::FontSizeProperty, "ButtonFontSize")
-                        $radioButton.ToolTip = $entryInfo.ToolTip
+                        $radioButton.ToolTip = $entryInfo.Description
                         $radioButton.UseLayoutRounding = $true
                         [System.Windows.Automation.AutomationProperties]::SetName($radioButton, $entryInfo.Content)
 

--- a/functions/public/Invoke-WPFUIElements.ps1
+++ b/functions/public/Invoke-WPFUIElements.ps1
@@ -81,6 +81,7 @@ function Invoke-WPFUIElements {
             Checked     = $entryInfo.Checked
             ButtonWidth = $entryInfo.ButtonWidth
             GroupName   = $entryInfo.GroupName  # Added for RadioButton groupings
+            ToolTip     = Get-WinUtilConfigToolTip -Description $entryInfo.description -ConfigKey $entry
         }
 
         if (-not $organizedData.ContainsKey($entryObject.Panel)) {
@@ -190,7 +191,7 @@ function Invoke-WPFUIElements {
 
                         $label = New-Object Windows.Controls.Label
                         $label.Content = $entryInfo.Content
-                        $label.ToolTip = $entryInfo.Description
+                        $label.ToolTip = $entryInfo.ToolTip
                         $label.HorizontalAlignment = "Left"
                         $label.SetResourceReference([Windows.Controls.Control]::FontSizeProperty, "FontSize")
                         $label.SetResourceReference([Windows.Controls.Control]::ForegroundProperty, "MainForegroundColor")
@@ -224,7 +225,7 @@ function Invoke-WPFUIElements {
                         $toggleButton = New-Object Windows.Controls.Primitives.ToggleButton
                         $toggleButton.Name = $entryInfo.Name
                         $toggleButton.Content = $entryInfo.Content[1]
-                        $toggleButton.ToolTip = $entryInfo.Description
+                        $toggleButton.ToolTip = $entryInfo.ToolTip
                         $toggleButton.HorizontalAlignment = "Left"
                         $toggleButton.Style = $ToggleButtonStyle
                         [System.Windows.Automation.AutomationProperties]::SetName($toggleButton, $entryInfo.Content[0])
@@ -268,7 +269,7 @@ function Invoke-WPFUIElements {
                         $label = New-Object Windows.Controls.Label
                         $label.Content = $entryInfo.Content
                         $label.HorizontalAlignment = "Left"
-                        $label.ToolTip = $entryInfo.Description
+                        $label.ToolTip = $entryInfo.ToolTip
                         $label.VerticalAlignment = "Center"
                         $label.SetResourceReference([Windows.Controls.Control]::FontSizeProperty, "ButtonFontSize")
                         $label.UseLayoutRounding = $true
@@ -398,6 +399,7 @@ function Invoke-WPFUIElements {
                         $button = New-Object Windows.Controls.Button
                         $button.Name = $entryInfo.Name
                         $button.Content = $entryInfo.Content
+                        $button.ToolTip = $entryInfo.ToolTip
                         $button.HorizontalAlignment = "Left"
                         $button.SetResourceReference([Windows.Controls.Control]::MarginProperty, "ButtonMargin")
                         $button.SetResourceReference([Windows.Controls.Control]::FontSizeProperty, "ButtonFontSize")
@@ -448,7 +450,7 @@ function Invoke-WPFUIElements {
                         $radioButton.HorizontalAlignment = "Left"
                         $radioButton.SetResourceReference([Windows.Controls.Control]::MarginProperty, "CheckBoxMargin")
                         $radioButton.SetResourceReference([Windows.Controls.Control]::FontSizeProperty, "ButtonFontSize")
-                        $radioButton.ToolTip = $entryInfo.Description
+                        $radioButton.ToolTip = $entryInfo.ToolTip
                         $radioButton.UseLayoutRounding = $true
                         [System.Windows.Automation.AutomationProperties]::SetName($radioButton, $entryInfo.Content)
 
@@ -490,7 +492,7 @@ function Invoke-WPFUIElements {
                         $checkBox.Name = $entryInfo.Name
                         $checkBox.Content = $entryInfo.Content
                         $checkBox.SetResourceReference([Windows.Controls.Control]::FontSizeProperty, "FontSize")
-                        $checkBox.ToolTip = $entryInfo.Description
+                        $checkBox.ToolTip = $entryInfo.ToolTip
                         $checkBox.SetResourceReference([Windows.Controls.Control]::MarginProperty, "CheckBoxMargin")
                         $checkBox.UseLayoutRounding = $true
                         [System.Windows.Automation.AutomationProperties]::SetName($checkBox, $entryInfo.Content)

--- a/pester/config-tooltips.Tests.ps1
+++ b/pester/config-tooltips.Tests.ps1
@@ -1,0 +1,38 @@
+#===========================================================================
+# Tests - Configuration tooltips
+#===========================================================================
+
+BeforeAll {
+    $script:repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+    . (Join-Path $script:repoRoot "functions\private\Get-WinUtilConfigToolTip.ps1")
+}
+
+Describe "Get-WinUtilConfigToolTip" {
+    It "appends the configuration key to an existing description" {
+        $toolTip = Get-WinUtilConfigToolTip `
+            -Description "Installs Mozilla Firefox." `
+            -ConfigKey "WPFInstallfirefox"
+
+        $toolTip | Should -Be "Installs Mozilla Firefox.`n`nConfiguration key: WPFInstallfirefox"
+    }
+
+    It "shows the configuration key when an entry has no description" {
+        Get-WinUtilConfigToolTip -Description "" -ConfigKey "WPFOOSUbutton" |
+            Should -Be "Configuration key: WPFOOSUbutton"
+    }
+}
+
+Describe "Configuration tooltip rendering" {
+    It "uses configuration-key tooltips for install entries" {
+        $entryScript = Get-Content -Path (Join-Path $script:repoRoot "functions\private\Initialize-InstallAppEntry.ps1") -Raw
+
+        $entryScript | Should -Match '\$border\.ToolTip = Get-WinUtilConfigToolTip -Description \$app\.description -ConfigKey \$appKey'
+    }
+
+    It "uses configuration-key tooltips for generated tweak controls" {
+        $rendererScript = Get-Content -Path (Join-Path $script:repoRoot "functions\public\Invoke-WPFUIElements.ps1") -Raw
+
+        $rendererScript | Should -Match 'ToolTip\s*= Get-WinUtilConfigToolTip -Description \$entryInfo\.description -ConfigKey \$entry'
+        $rendererScript | Should -Not -Match '\.ToolTip = \$entryInfo\.Description'
+    }
+}

--- a/pester/config-tooltips.Tests.ps1
+++ b/pester/config-tooltips.Tests.ps1
@@ -29,22 +29,22 @@ Describe "Configuration tooltip rendering" {
         $entryScript | Should -Match '\$border\.ToolTip = Get-WinUtilConfigToolTip -Description \$app\.description -ConfigKey \$appKey'
     }
 
-    It "uses configuration-key tooltips for generated tweak controls" {
+    It "uses configuration-key tooltips for generated config selections" {
         $rendererScript = Get-Content -Path (Join-Path $script:repoRoot "functions\public\Invoke-WPFUIElements.ps1") -Raw
 
-        $rendererScript | Should -Match '\$isSelectableEntry = .*"Toggle", "ToggleButton"'
-        $rendererScript | Should -Match '\$isImportableKey = \$entry -match.*WPFTweaks.*WPFToggle.*WPFFeature.*WPFAppx'
+        $rendererScript | Should -Match '\$isConfigSelectionEntry = .*\$entryInfo\.type.*WPFTweaks.*WPFFeature.*WPFAppx'
         $rendererScript | Should -Match '\$entryToolTip = Get-WinUtilConfigToolTip -Description \$entryInfo\.description -ConfigKey \$entry'
-        $rendererScript | Should -Match '\$label\.ToolTip = \$entryInfo\.ToolTip'
-        $rendererScript | Should -Match '\$toggleButton\.ToolTip = \$entryInfo\.ToolTip'
         $rendererScript | Should -Match '\$checkBox\.ToolTip = \$entryInfo\.ToolTip'
     }
 
     It "keeps non-selectable controls out of configuration-key tooltips" {
         $rendererScript = Get-Content -Path (Join-Path $script:repoRoot "functions\public\Invoke-WPFUIElements.ps1") -Raw
+        $configSelectionLine = ($rendererScript -split "`r?`n") | Where-Object { $_ -like '*$isConfigSelectionEntry*' }
 
+        $configSelectionLine | Should -Not -Match 'WPFToggle'
         $rendererScript | Should -Not -Match '\$button\.ToolTip = \$entryInfo\.ToolTip'
         $rendererScript | Should -Match '\$label\.ToolTip = \$entryInfo\.Description'
+        $rendererScript | Should -Match '\$toggleButton\.ToolTip = \$entryInfo\.Description'
         $rendererScript | Should -Match '\$radioButton\.ToolTip = \$entryInfo\.Description'
     }
 }

--- a/pester/config-tooltips.Tests.ps1
+++ b/pester/config-tooltips.Tests.ps1
@@ -32,7 +32,19 @@ Describe "Configuration tooltip rendering" {
     It "uses configuration-key tooltips for generated tweak controls" {
         $rendererScript = Get-Content -Path (Join-Path $script:repoRoot "functions\public\Invoke-WPFUIElements.ps1") -Raw
 
-        $rendererScript | Should -Match 'ToolTip\s*= Get-WinUtilConfigToolTip -Description \$entryInfo\.description -ConfigKey \$entry'
-        $rendererScript | Should -Not -Match '\.ToolTip = \$entryInfo\.Description'
+        $rendererScript | Should -Match '\$isSelectableEntry = .*"Toggle", "ToggleButton"'
+        $rendererScript | Should -Match '\$isImportableKey = \$entry -match.*WPFTweaks.*WPFToggle.*WPFFeature.*WPFAppx'
+        $rendererScript | Should -Match '\$entryToolTip = Get-WinUtilConfigToolTip -Description \$entryInfo\.description -ConfigKey \$entry'
+        $rendererScript | Should -Match '\$label\.ToolTip = \$entryInfo\.ToolTip'
+        $rendererScript | Should -Match '\$toggleButton\.ToolTip = \$entryInfo\.ToolTip'
+        $rendererScript | Should -Match '\$checkBox\.ToolTip = \$entryInfo\.ToolTip'
+    }
+
+    It "keeps non-selectable controls out of configuration-key tooltips" {
+        $rendererScript = Get-Content -Path (Join-Path $script:repoRoot "functions\public\Invoke-WPFUIElements.ps1") -Raw
+
+        $rendererScript | Should -Not -Match '\$button\.ToolTip = \$entryInfo\.ToolTip'
+        $rendererScript | Should -Match '\$label\.ToolTip = \$entryInfo\.Description'
+        $rendererScript | Should -Match '\$radioButton\.ToolTip = \$entryInfo\.Description'
     }
 }


### PR DESCRIPTION
## What changed

- Append each application's configuration key to its existing hover tooltip.
- Use the same tooltip format for tweak, feature, and AppX checkbox selections consumed by automation.
- Leave action-only controls such as DNS and O&O unchanged so the UI does not advertise identifiers that configuration import cannot use.
- Document where manual configuration authors can find these keys.
- Add focused Pester coverage for tooltip formatting and renderer wiring.

## Why

Users editing exported configuration files currently need to search the source JSON to discover identifiers such as `WPFInstallfirefox` and `WPFTweaksTelemetry`. Exposing the identifier alongside the existing description keeps that information available in the UI without changing the configuration format or interaction model.

Closes #4921.

## Validation

- `Invoke-Pester -Path 'pester/*.Tests.ps1' -Output Normal -CI` — 557 passed
- `./Compile.ps1` — passed
- PSScriptAnalyzer on the changed PowerShell files — no new diagnostics
