### PR TITLE
Fix location service startup type

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -114,7 +114,7 @@
     "service": [
       {
         "Name": "lfsvc",
-        "StartupType": "Disable",
+        "StartupType": "Disabled",
         "OriginalType": "Manual"
       }
     ],

--- a/pester/configs.Tests.ps1
+++ b/pester/configs.Tests.ps1
@@ -217,6 +217,16 @@ Describe "Tweaks config" {
             throw ($invalidTweaks -join "`n")
         }
     }
+
+    It "keeps the location service disabled" -TestCases $testCase {
+        param([string]$Path)
+
+        $tweaks = Get-Content -Path $Path -Raw | ConvertFrom-Json
+        $locationServices = @($tweaks.WPFTweaksLocation.service | Where-Object Name -eq "lfsvc")
+
+        $locationServices | Should -HaveCount 1
+        $locationServices[0].StartupType | Should -Be "Disabled"
+    }
 }
 
 Describe "Preset config" {

--- a/pester/configs.Tests.ps1
+++ b/pester/configs.Tests.ps1
@@ -428,6 +428,7 @@ Describe "UI-rendered config entries" {
         $tweaks = Get-WinUtilConfigObject -Name "tweaks"
         $requiredFields = @("Content", "category", "panel", "link")
         $allowedTypes = @("Button", "Combobox", "Toggle", "ToggleButton")
+        $allowedServiceStartupTypes = @("Automatic", "AutomaticDelayedStart", "Disabled", "Manual")
         $supportedButtons = Get-WinUtilButtonSwitchNames
         $invalidEntries = New-Object System.Collections.Generic.List[string]
 
@@ -497,6 +498,13 @@ Describe "UI-rendered config entries" {
 
                 foreach ($missingField in (Get-WinUtilMissingRequiredFields -EntryName "$($entry.Name),service" -Entry $serviceEntry -RequiredFields @("Name", "StartupType", "OriginalType"))) {
                     $invalidEntries.Add($missingField)
+                }
+
+                foreach ($startupTypeField in @("StartupType", "OriginalType")) {
+                    if ((Test-WinUtilHasNonEmptyProperty -Object $serviceEntry -Name $startupTypeField) -and
+                        $allowedServiceStartupTypes -notcontains $serviceEntry.$startupTypeField) {
+                        $invalidEntries.Add("$($entry.Name),service has unsupported $startupTypeField '$($serviceEntry.$startupTypeField)'")
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactor
- [ ] UI/UX improvement

## Description

Use the canonical `Disabled` startup type for the `lfsvc` location service.

PowerShell accepts the unique `Disable` enum prefix, but WinUtil also compares configured startup types with `ServiceController.StartType` as strings. Since the service reports `Disabled`, the previous value prevented WinUtil from recognizing the matching state and could trigger a redundant `Set-Service` call.

This also validates configured `StartupType` and `OriginalType` values against the canonical service startup types so similar typos are caught by Pester.

Microsoft documents `Disabled` as the accepted startup type: https://learn.microsoft.com/powershell/module/microsoft.powershell.management/set-service#-startuptype

## Testing

- `./Compile.ps1`
- `Invoke-Pester -Path 'pester/configs.Tests.ps1' -Output Detailed -CI` (21 passed)
- Verified the new config validation fails on `Disable` before the fix and passes on `Disabled`

## Issue related to PR

- None
