### PR TITLE
Fix OSCDIMG detection

### DIFF
--- a/functions/private/Invoke-WinUtilISO.ps1
+++ b/functions/private/Invoke-WinUtilISO.ps1
@@ -529,6 +529,34 @@ function Invoke-WinUtilISOCleanAndReset {
     $script.BeginInvoke()
 }
 
+function Get-WinUtilOSCDImgPath {
+    # Windows ADK installation
+    $oscdimg = Get-ChildItem "C:\Program Files (x86)\Windows Kits" -Recurse -Filter "oscdimg.exe" -ErrorAction SilentlyContinue |
+               Select-Object -First 1 -ExpandProperty FullName
+    if (-not $oscdimg) {
+        # Per-user winget installation
+        $oscdimg = Get-ChildItem "$env:LOCALAPPDATA\Microsoft\WinGet\Packages" -Recurse -Filter "oscdimg.exe" -ErrorAction SilentlyContinue |
+                   Where-Object { $_.FullName -match 'Microsoft\.OSCDIMG' } |
+                   Select-Object -First 1 -ExpandProperty FullName
+    }
+
+    if (-not $oscdimg) {
+        # Installation available through the current process PATH
+        $oscdimg = Get-Command oscdimg.exe -CommandType Application -ErrorAction SilentlyContinue |
+                   Select-Object -First 1 -ExpandProperty Source
+    }
+
+    if (-not $oscdimg) {
+        # WinGet links that may not yet be available through the current process PATH
+        $oscdimg = @(
+            "$env:LOCALAPPDATA\Microsoft\WinGet\Links\oscdimg.exe"
+            "$env:ProgramFiles\WinGet\Links\oscdimg.exe"
+        ) | Where-Object { Test-Path -LiteralPath $_ } | Select-Object -First 1
+    }
+
+    return $oscdimg
+}
+
 function Invoke-WinUtilISOExport {
     $contentsDir = $sync["Win11ISOContentsDir"]
 
@@ -551,21 +579,7 @@ function Invoke-WinUtilISOExport {
 
     $outputISO = $dlg.FileName
 
-    # Windows ADK installation
-    $oscdimg = Get-ChildItem "C:\Program Files (x86)\Windows Kits" -Recurse -Filter "oscdimg.exe" |
-               Select-Object -First 1 -ExpandProperty FullName
-    if (-not $oscdimg) {
-        # Per-user winget installation
-        $oscdimg = Get-ChildItem "$env:LOCALAPPDATA\Microsoft\WinGet\Packages" -Recurse -Filter "oscdimg.exe" |
-                   Where-Object { $_.FullName -match 'Microsoft\.OSCDIMG' } |
-                   Select-Object -First 1 -ExpandProperty FullName
-    }
-
-    if (-not $oscdimg) {
-        # Installation available through PATH, including machine-wide winget links
-        $oscdimg = Get-Command oscdimg.exe -CommandType Application -ErrorAction SilentlyContinue |
-                   Select-Object -First 1 -ExpandProperty Source
-    }
+    $oscdimg = Get-WinUtilOSCDImgPath
 
     if (-not $oscdimg) {
         Write-WinUtilISOLog "oscdimg.exe not found. Attempting to install via winget..."
@@ -576,9 +590,7 @@ function Invoke-WinUtilISOExport {
             $winget = Get-Command winget
             $result = & $winget install -e --id Microsoft.OSCDIMG --accept-package-agreements --accept-source-agreements
             Write-WinUtilISOLog "winget output: $result"
-            $oscdimg = Get-ChildItem "$env:LOCALAPPDATA\Microsoft\WinGet\Packages" -Recurse -Filter "oscdimg.exe" |
-                       Where-Object { $_.FullName -match 'Microsoft\.OSCDIMG' } |
-                       Select-Object -First 1 -ExpandProperty FullName
+            $oscdimg = Get-WinUtilOSCDImgPath
         } catch {
             Write-WinUtilISOLog "winget not available or install failed: $_"
         }

--- a/functions/private/Invoke-WinUtilISO.ps1
+++ b/functions/private/Invoke-WinUtilISO.ps1
@@ -551,13 +551,20 @@ function Invoke-WinUtilISOExport {
 
     $outputISO = $dlg.FileName
 
-    # Locate oscdimg.exe (Windows ADK or winget per-user install)
+    # Windows ADK installation
     $oscdimg = Get-ChildItem "C:\Program Files (x86)\Windows Kits" -Recurse -Filter "oscdimg.exe" |
                Select-Object -First 1 -ExpandProperty FullName
     if (-not $oscdimg) {
+        # Per-user winget installation
         $oscdimg = Get-ChildItem "$env:LOCALAPPDATA\Microsoft\WinGet\Packages" -Recurse -Filter "oscdimg.exe" |
                    Where-Object { $_.FullName -match 'Microsoft\.OSCDIMG' } |
                    Select-Object -First 1 -ExpandProperty FullName
+    }
+
+    if (-not $oscdimg) {
+        # Installation available through PATH, including machine-wide winget links
+        $oscdimg = Get-Command oscdimg.exe -CommandType Application -ErrorAction SilentlyContinue |
+                   Select-Object -First 1 -ExpandProperty Source
     }
 
     if (-not $oscdimg) {


### PR DESCRIPTION
## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactor
- [ ] UI/UX improvement

## Description

Win11 Creator only checked the Windows ADK and per-user WinGet package directories for `oscdimg.exe`. This caused machine-wide installations to be reported as missing. Since WinGet can install OSCDIMG outside the default per-user directory, the same discovery checks now run again after installation.

I reproduced the issue by installing OSCDIMG machine-wide:

```powershell
winget install -e --id Microsoft.OSCDIMG --scope machine
```

The existing lookup failed to find this installation and produced the error shown below:

<img width="309" height="193" alt="Screenshot 2026-08-13 202227" src="https://github.com/user-attachments/assets/807e9d55-3d07-48ee-bb56-f4b56c8e172c" />

The updated lookup also checks for `oscdimg.exe` on PATH. This successfully detects the machine-wide WinGet installation through its executable link:

```text
C:\Program Files\WinGet\Links\oscdimg.exe
```

It also covers other valid installations available on PATH, including the working symlink reported in the linked issue.

## Issue related to PR

- Resolves #4978