### PR TITLE
Fix screen reader names for remaining top-bar controls

### DIFF
--- a/xaml/inputXML.xaml
+++ b/xaml/inputXML.xaml
@@ -1120,7 +1120,8 @@
                             Name="SearchBar"
                             Foreground="{DynamicResource MainForegroundColor}" Background="{DynamicResource MainBackgroundColor}"
                             Padding="3,3,30,0"
-                            ToolTip="Press Ctrl-F and type app name to filter application list below. Press Esc to reset the filter">
+                            ToolTip="Press Ctrl-F and type app name to filter application list below. Press Esc to reset the filter"
+                            AutomationProperties.Name="Search">
                         </TextBox>
                         <TextBlock
                             Name="SearchBarIcon"
@@ -1136,6 +1137,7 @@
                     VerticalAlignment="Center" HorizontalAlignment="Right"
                     Name="SearchBarClearButton"
                     Style="{StaticResource SearchBarClearButtonStyle}"
+                    AutomationProperties.Name="Clear Search"
                     Margin="0,0,20,0" Visibility="Collapsed">
                 </Button>
 
@@ -1153,6 +1155,7 @@
                     FontFamily="Segoe MDL2 Assets"
                     Content="N/A"
                     ToolTip="Change the WinUtil UI Theme"
+                    AutomationProperties.Name="Theme"
                 />
                     <Popup Name="ThemePopup"
                     IsOpen="False"
@@ -1191,6 +1194,7 @@
                     FontFamily="Segoe MDL2 Assets"
                     Content="&#xE8D3;"
                     ToolTip="Adjust Font Scaling for Accessibility"
+                    AutomationProperties.Name="Font Scaling"
                 />
                     <Popup Name="FontScalingPopup"
                     IsOpen="False"


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [x] UI/UX improvement

## Description
PR #4944 added `AutomationProperties.Name` to `SettingsButton` and the window controls, but four top-bar controls were left unnamed, so screen readers (Narrator, NVDA) announce them by their raw content:

- **ThemeButton** — announced as "N/A" (placeholder content, glyph set at runtime)
- **FontScalingButton** — announced as raw Unicode `\uE8D3` (ironically, the accessibility button)
- **SearchBar** — an unnamed edit field
- **SearchBarClearButton** — announced as "X"

This adds `AutomationProperties.Name` to all four, completing the top-bar naming pass. XAML-only change; verified with `.\Compile.ps1 -Run` + Narrator, and the full Pester suite passes (549/549).

## Issue related to PR
- Resolves # (no open issue — same defect class as #4944)