### PR TITLE
Add accessible name to the font scaling slider

### DIFF
--- a/xaml/inputXML.xaml
+++ b/xaml/inputXML.xaml
@@ -1218,7 +1218,8 @@
                                         TickPlacement="BottomRight"
                                         IsSnapToTickEnabled="True"
                                         Width="120"
-                                        VerticalAlignment="Center"/>
+                                        VerticalAlignment="Center"
+                                        AutomationProperties.Name="Font Scaling"/>
                                 <TextBlock Text="Large"
                                            FontSize="{DynamicResource ButtonFontSize}"
                                            Foreground="{DynamicResource MainForegroundColor}"


### PR DESCRIPTION
## Type of Change
- [x] Bug fix
- [x] UI/UX improvement

## Description
`FontScalingSlider` in the font scaling popup has no `AutomationProperties.Name`, so screen readers (Narrator, NVDA) announce it as an unnamed slider with only a raw numeric value — the surrounding "Small"/"Large"/percentage TextBlocks are not associated with the control. This adds `AutomationProperties.Name="Font Scaling"` so the slider is announced by name.

One-attribute XAML change, companion to #4992 (which names the popup's toggle button and the other top-bar controls). Verified with `.\Compile.ps1 -Run` + Narrator; full Pester suite passes (549/549).

## Issue related to PR
- Resolves # (no open issue — same defect class as #4944/#4992)