### PR TITLE
Remove Fullscreen Optimizations disable tweak

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -1168,22 +1168,6 @@
     ],
     "link": "https://winutil.christitus.com/code-reference/tweaks/z--advanced-tweaks---caution/disablebgapps"
   },
-  "WPFTweaksDisableFSO": {
-    "Content": "Fullscreen Optimizations - Disable",
-    "Description": "Disables FSO in all applications. NOTE: This will disable Color Management in Exclusive Fullscreen.",
-    "category": "z__Advanced Tweaks - CAUTION",
-    "panel": "1",
-    "registry": [
-      {
-        "Path": "HKCU:\\System\\GameConfigStore",
-        "Name": "GameDVR_DXGIHonorFSEWindowsCompatible",
-        "Value": "1",
-        "Type": "DWord",
-        "OriginalValue": "0"
-      }
-    ],
-    "link": "https://winutil.christitus.com/code-reference/tweaks/z--advanced-tweaks---caution/disablefso"
-  },
   "WPFTweaksDisableExplorerAutoDiscovery": {
     "Content": "File Explorer Automatic Folder Discovery - Disable",
     "Description": "Windows Explorer automatically tries to guess the type of the folder based on its contents, slowing down the browsing experience. WARNING! Will disable File Explorer grouping.",


### PR DESCRIPTION
## Type of Change
- [x] Refactor

## Description
Removes the WPFTweaksDisableFSO tweak from config/tweaks.json. The tweak disables fullscreen optimizations globally across all games, which causes more issues than it solves. Users experiencing game-specific problems can still use the per-executable compatibility option instead.

## Acceptance Criteria
- [x] Remove WPFTweaksDisableFSO from config/tweaks.json
- [x] Remove any remaining preset or UI references to that tweak, if present
- [x] Do not replace it with another system-wide Fullscreen Optimizations registry override
- [x] Ensure generated tweak documentation no longer includes the removed entry
- [x] Verify Compile.ps1 and the relevant configuration/Pester tests pass

## Issue related to PR
- Resolves #4998