### PR TITLE
Tighten WinPE driver classification and setup media handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,6 +177,6 @@ When the user corrects an agent approach, add or tighten one concrete rule here 
 - Keep UI helpers such as `Invoke-WPFUIThread` and `Set-WinUtilTweaksProgressIndicator` safe to call without a window; the `-Preset` and `-Config` paths run the workflows before the form is created and before PresentationCore is loaded.
 - Log install/uninstall package names and package-manager IDs before queuing background runspace work; do not rely on runspace host output for the package identity.
 - For Win11 Creator, start each new ISO modification in a fresh `WinUtil_Win11ISO_*` temp directory; existing-work detection is only for resuming/exporting already modified media.
-- For Win11 Creator driver injection, keep offline WIM servicing to one mount, one `/Add-Driver`, and one commit; do not export editions or run unrelated WIM cleanup, and reject damaged metadata before ISO export.
+- For Win11 Creator driver injection, keep current-system export on `DISM /Online /Export-Driver`, use PnPUtil only for driver inventory/translation, and keep offline WIM servicing to one mount, one `/Add-Driver`, and one commit.
 - For Script Analyzer cleanup, fix actionable source warnings first and do not globally suppress accepted convention warnings such as plural names, `ShouldProcess` on UI helpers, `$global:sync`, or compile-time cross-file false positives.
 - For DNS DHCP reset, keep the cmdlet reset and explicitly set IPv4 and IPv6 DNS source to DHCP.

--- a/functions/private/Invoke-WinUtilISO.ps1
+++ b/functions/private/Invoke-WinUtilISO.ps1
@@ -293,14 +293,14 @@ function Invoke-WinUtilISOModify {
             $sync["Win11ISOWorkDir"]     = $workDir
             $sync["Win11ISOContentsDir"] = $isoContents
 
-            SetProgress "Modification complete" 100
-            Log "install.wim modification complete. Choose an output option in Step 4."
+            SetProgress "Setup media ready" 100
+            Log "Setup media preparation complete. Choose an output option in Step 4."
 
             $sync["WPFWin11ISOOutputSection"].Dispatcher.Invoke([action]{
                 $sync["WPFWin11ISOOutputSection"].Visibility = "Visible"
             })
         } catch {
-            Log "ERROR during modification: $_"
+            Log "ERROR during setup media preparation: $_"
 
             try {
                 $mountedISO = Get-DiskImage -ImagePath $isoPath
@@ -319,8 +319,8 @@ function Invoke-WinUtilISOModify {
 
             $sync["WPFWin11ISOStatusLog"].Dispatcher.Invoke([action]{
                 [System.Windows.MessageBox]::Show(
-                    "An error occurred during install.wim modification:`n`n$_",
-                    "Modification Error", "OK", "Error")
+                    "An error occurred during setup media preparation:`n`n$_",
+                    "Preparation Error", "OK", "Error")
             })
         } finally {
             Start-Sleep -Milliseconds 800
@@ -615,6 +615,7 @@ function Invoke-WinUtilISOExport {
             })
         }
 
+        $isoSaveTimer = $null
         try {
             Write-WinUtilISOLog "Exporting to ISO: $outputISO"
             SetProgress "Building ISO..." 10
@@ -634,6 +635,7 @@ function Invoke-WinUtilISOExport {
 
             $proc = [System.Diagnostics.Process]::new()
             $proc.StartInfo = $psi
+            $isoSaveTimer = [System.Diagnostics.Stopwatch]::StartNew()
             $proc.Start()
 
             # Stream stdout line-by-line as oscdimg runs
@@ -643,6 +645,8 @@ function Invoke-WinUtilISOExport {
             }
 
             $proc.WaitForExit()
+            $isoSaveTimer.Stop()
+            $isoSaveElapsed = $isoSaveTimer.Elapsed.ToString('hh\:mm\:ss\.fff')
 
             # Flush any stderr after process exits
             $stderr = $proc.StandardError.ReadToEnd()
@@ -652,12 +656,13 @@ function Invoke-WinUtilISOExport {
 
             if ($proc.ExitCode -eq 0) {
                 SetProgress "ISO exported" 100
+                Write-WinUtilISOLog "OSCDIMG save completed in $isoSaveElapsed."
                 Write-WinUtilISOLog "ISO exported successfully: $outputISO"
                 $sync["WPFWin11ISOStatusLog"].Dispatcher.Invoke([action]{
                     [System.Windows.MessageBox]::Show("ISO exported successfully!`n`n$outputISO", "Export Complete", "OK", "Info")
                 })
             } else {
-                Write-WinUtilISOLog "oscdimg exited with code $($proc.ExitCode)."
+                Write-WinUtilISOLog "OSCDIMG save failed with exit code $($proc.ExitCode) after $isoSaveElapsed."
                 $sync["WPFWin11ISOStatusLog"].Dispatcher.Invoke([action]{
                     [System.Windows.MessageBox]::Show(
                         "oscdimg exited with code $($proc.ExitCode).`nCheck the status log for details.",
@@ -665,7 +670,11 @@ function Invoke-WinUtilISOExport {
                 })
             }
         } catch {
-            Write-WinUtilISOLog "ERROR during ISO export: $_"
+            if ($isoSaveTimer -and $isoSaveTimer.IsRunning) {
+                $isoSaveTimer.Stop()
+            }
+            $timing = if ($isoSaveTimer) { " after $($isoSaveTimer.Elapsed.ToString('hh\:mm\:ss\.fff'))" } else { '' }
+            Write-WinUtilISOLog "ERROR during ISO export$timing`: $_"
             $sync["WPFWin11ISOStatusLog"].Dispatcher.Invoke([action]{
                 [System.Windows.MessageBox]::Show("ISO export failed:`n`n$_", "Error", "OK", "Error")
             })

--- a/functions/private/Invoke-WinUtilISO.ps1
+++ b/functions/private/Invoke-WinUtilISO.ps1
@@ -615,7 +615,6 @@ function Invoke-WinUtilISOExport {
             })
         }
 
-        $isoSaveTimer = $null
         try {
             Write-WinUtilISOLog "Exporting to ISO: $outputISO"
             SetProgress "Building ISO..." 10
@@ -635,7 +634,6 @@ function Invoke-WinUtilISOExport {
 
             $proc = [System.Diagnostics.Process]::new()
             $proc.StartInfo = $psi
-            $isoSaveTimer = [System.Diagnostics.Stopwatch]::StartNew()
             $proc.Start()
 
             # Stream stdout line-by-line as oscdimg runs
@@ -645,8 +643,6 @@ function Invoke-WinUtilISOExport {
             }
 
             $proc.WaitForExit()
-            $isoSaveTimer.Stop()
-            $isoSaveElapsed = $isoSaveTimer.Elapsed.ToString('hh\:mm\:ss\.fff')
 
             # Flush any stderr after process exits
             $stderr = $proc.StandardError.ReadToEnd()
@@ -656,13 +652,12 @@ function Invoke-WinUtilISOExport {
 
             if ($proc.ExitCode -eq 0) {
                 SetProgress "ISO exported" 100
-                Write-WinUtilISOLog "OSCDIMG save completed in $isoSaveElapsed."
                 Write-WinUtilISOLog "ISO exported successfully: $outputISO"
                 $sync["WPFWin11ISOStatusLog"].Dispatcher.Invoke([action]{
                     [System.Windows.MessageBox]::Show("ISO exported successfully!`n`n$outputISO", "Export Complete", "OK", "Info")
                 })
             } else {
-                Write-WinUtilISOLog "OSCDIMG save failed with exit code $($proc.ExitCode) after $isoSaveElapsed."
+                Write-WinUtilISOLog "oscdimg exited with code $($proc.ExitCode)."
                 $sync["WPFWin11ISOStatusLog"].Dispatcher.Invoke([action]{
                     [System.Windows.MessageBox]::Show(
                         "oscdimg exited with code $($proc.ExitCode).`nCheck the status log for details.",
@@ -670,11 +665,7 @@ function Invoke-WinUtilISOExport {
                 })
             }
         } catch {
-            if ($isoSaveTimer -and $isoSaveTimer.IsRunning) {
-                $isoSaveTimer.Stop()
-            }
-            $timing = if ($isoSaveTimer) { " after $($isoSaveTimer.Elapsed.ToString('hh\:mm\:ss\.fff'))" } else { '' }
-            Write-WinUtilISOLog "ERROR during ISO export$timing`: $_"
+            Write-WinUtilISOLog "ERROR during ISO export: $_"
             $sync["WPFWin11ISOStatusLog"].Dispatcher.Invoke([action]{
                 [System.Windows.MessageBox]::Show("ISO export failed:`n`n$_", "Error", "OK", "Error")
             })

--- a/functions/private/Invoke-WinUtilISOScript.ps1
+++ b/functions/private/Invoke-WinUtilISOScript.ps1
@@ -36,6 +36,219 @@ function Invoke-WinUtilISOScript {
         [scriptblock]$Log = { param($m) Write-Output $m }
     )
 
+    function Format-WinUtilISOElapsed {
+        param ([Parameter(Mandatory)][System.Diagnostics.Stopwatch]$Stopwatch)
+
+        return $Stopwatch.Elapsed.ToString('hh\:mm\:ss\.fff')
+    }
+
+    function Get-WinUtilISODriverPackageInventory {
+        param (
+            [Parameter(Mandatory)][string]$DriverRoot,
+            [scriptblock]$Logger
+        )
+
+        $driverInfs = @(Get-ChildItem -LiteralPath $DriverRoot -Filter '*.inf' -Recurse -File)
+        $packages = @($driverInfs | Group-Object { $_.Directory.FullName } | ForEach-Object {
+            [pscustomobject]@{
+                Directory = [string]$_.Name
+                InfNames  = @($_.Group | ForEach-Object Name)
+            }
+        })
+
+        $null = & $Logger "Inventoried $($driverInfs.Count) INF files across $($packages.Count) exported package directories."
+        return $packages
+    }
+
+    function Get-WinUtilISOActiveStorageDriverMapping {
+        param ([scriptblock]$Logger)
+
+        try {
+            $driverByDeviceId = @{}
+            foreach ($driver in @(Get-CimInstance -ClassName Win32_PnPSignedDriver -ErrorAction Stop)) {
+                if ($driver.DeviceID -and $driver.InfName) {
+                    $driverByDeviceId[[string]$driver.DeviceID] = $driver
+                }
+            }
+
+            $systemDrive = if ($env:SystemDrive) { $env:SystemDrive } else { 'C:' }
+            $logicalDisk = Get-CimInstance -ClassName Win32_LogicalDisk -Filter "DeviceID='$systemDrive'" -ErrorAction Stop
+            if (-not $logicalDisk) {
+                throw "The system volume '$systemDrive' was not found."
+            }
+
+            $partitions = @(Get-CimAssociatedInstance -InputObject $logicalDisk -Association Win32_LogicalDiskToPartition -ErrorAction Stop)
+            if ($partitions.Count -eq 0) {
+                throw "No partition was associated with system volume '$systemDrive'."
+            }
+
+            $systemDisks = @($partitions | ForEach-Object {
+                Get-CimAssociatedInstance -InputObject $_ -Association Win32_DiskDriveToDiskPartition -ErrorAction Stop
+            })
+            $diskDeviceIds = @($systemDisks | Where-Object PNPDeviceID | ForEach-Object { [string]$_.PNPDeviceID } | Sort-Object -Unique)
+            if ($diskDeviceIds.Count -ne 1) {
+                throw "Expected one physical disk for system volume '$systemDrive', but found $($diskDeviceIds.Count)."
+            }
+
+            $publishedInfNames = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+            $visitedDeviceIds = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+            $deviceId = $diskDeviceIds[0]
+            $maximumParentDepth = 64
+
+            for ($depth = 0; $deviceId; $depth++) {
+                if ($depth -ge $maximumParentDepth) {
+                    throw "The PnP parent chain exceeded $maximumParentDepth devices starting at '$($diskDeviceIds[0])'."
+                }
+                if (-not $visitedDeviceIds.Add($deviceId)) {
+                    throw "The PnP parent chain contains a cycle at '$deviceId'."
+                }
+
+                if ($driverByDeviceId.ContainsKey($deviceId)) {
+                    $driver = $driverByDeviceId[$deviceId]
+                    [void]$publishedInfNames.Add([string]$driver.InfName)
+                    $null = & $Logger "Active storage-path device '$deviceId' uses published INF '$($driver.InfName)'."
+                }
+
+                $parent = Get-PnpDeviceProperty -InstanceId $deviceId -KeyName 'DEVPKEY_Device_Parent' -ErrorAction Stop
+                $deviceId = if ($parent.Data) { [string]$parent.Data } else { $null }
+            }
+            if ($publishedInfNames.Count -eq 0) {
+                throw "No signed driver was mapped to the PnP chain starting at '$($diskDeviceIds[0])'."
+            }
+        } catch {
+            throw "WinPE driver classification failed while discovering the active system-disk path: $_"
+        }
+
+        $activeOemInfNames = @($publishedInfNames | Where-Object { $_ -match '(?i)^oem\d+\.inf$' })
+        $inboxInfNames = @($publishedInfNames | Where-Object { $_ -notmatch '(?i)^oem\d+\.inf$' })
+        if ($inboxInfNames.Count -gt 0) {
+            $null = & $Logger "Ignoring inbox INF names on the active storage path: $($inboxInfNames -join ', ')."
+        }
+        if ($activeOemInfNames.Count -eq 0) {
+            $null = & $Logger 'Active storage-path discovery found no third-party OEM INF requiring WinPE staging.'
+            return @()
+        }
+
+        $pnputilOutput = @(& pnputil.exe /enum-drivers /format csv 2>&1)
+        $pnputilExitCode = $LASTEXITCODE
+        if ($pnputilExitCode -ne 0) {
+            throw "WinPE driver classification failed: PnPUtil driver inventory exited with code $pnputilExitCode."
+        }
+
+        $csvText = ($pnputilOutput | ForEach-Object { [string]$_ }) -join "`r`n"
+        if ([string]::IsNullOrWhiteSpace($csvText)) {
+            throw 'WinPE driver classification failed: PnPUtil returned empty CSV output.'
+        }
+
+        try {
+            $driverInventory = @($csvText | ConvertFrom-Csv -ErrorAction Stop)
+        } catch {
+            throw "WinPE driver classification failed: PnPUtil CSV could not be parsed: $_"
+        }
+        if ($driverInventory.Count -eq 0) {
+            throw 'WinPE driver classification failed: PnPUtil CSV contained no driver records.'
+        }
+
+        $inventoryProperties = @($driverInventory[0].PSObject.Properties.Name)
+        if ('DriverName' -notin $inventoryProperties -or 'OriginalName' -notin $inventoryProperties) {
+            throw 'WinPE driver classification failed: PnPUtil CSV is missing DriverName or OriginalName.'
+        }
+        foreach ($inventoryDriver in $driverInventory) {
+            if ([string]::IsNullOrWhiteSpace([string]$inventoryDriver.DriverName) -or
+                [string]::IsNullOrWhiteSpace([string]$inventoryDriver.OriginalName)) {
+                throw 'WinPE driver classification failed: PnPUtil CSV contains an unusable DriverName or OriginalName value.'
+            }
+        }
+
+        $activeMappings = [System.Collections.Generic.List[object]]::new()
+        foreach ($publishedInfName in $activeOemInfNames) {
+            $inventoryMatches = @($driverInventory | Where-Object { $_.DriverName -eq $publishedInfName })
+            if ($inventoryMatches.Count -gt 1) {
+                throw "WinPE driver classification failed: PnPUtil returned multiple records for published INF '$publishedInfName'."
+            }
+            if ($inventoryMatches.Count -eq 0) {
+                throw "WinPE driver classification failed: PnPUtil did not translate published INF '$publishedInfName'."
+            }
+
+            $originalInfName = [string]$inventoryMatches[0].OriginalName
+            $activeMappings.Add([pscustomobject]@{
+                PublishedInfName = [string]$publishedInfName
+                OriginalInfName  = $originalInfName
+            })
+            $null = & $Logger "Mapped active driver '$publishedInfName' to original INF '$originalInfName'."
+        }
+
+        return @($activeMappings)
+    }
+
+    function Select-WinUtilISOWinPEDriverPackage {
+        param (
+            [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Packages,
+            [scriptblock]$Logger
+        )
+
+        $activeDrivers = @(Get-WinUtilISOActiveStorageDriverMapping -Logger $Logger)
+        if ($activeDrivers.Count -eq 0) {
+            return @()
+        }
+
+        $selectedDirectories = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+        foreach ($activeDriver in $activeDrivers) {
+            $matchingPackages = @($Packages | Where-Object { $_.InfNames -contains $activeDriver.OriginalInfName })
+            if ($matchingPackages.Count -eq 0) {
+                throw "WinPE driver classification failed: active published INF '$($activeDriver.PublishedInfName)' maps to original INF '$($activeDriver.OriginalInfName)', but no exported package directory contains it."
+            }
+            if ($matchingPackages.Count -gt 1) {
+                $directories = $matchingPackages.Directory -join "', '"
+                throw "WinPE driver classification is ambiguous: active published INF '$($activeDriver.PublishedInfName)' maps to original INF '$($activeDriver.OriginalInfName)', which exists in multiple exported package directories: '$directories'."
+            }
+
+            [void]$selectedDirectories.Add([string]$matchingPackages[0].Directory)
+        }
+
+        $amdRaidInfNames = @('rcbottom.inf', 'rcraid.inf', 'rccfg.inf')
+        $selectedPackages = @($Packages | Where-Object { $selectedDirectories.Contains([string]$_.Directory) })
+        $selectedAmdRaidInfs = @($selectedPackages | ForEach-Object InfNames | Where-Object { $_ -in $amdRaidInfNames })
+        if ($selectedAmdRaidInfs.Count -gt 0) {
+            foreach ($amdRaidInfName in $amdRaidInfNames) {
+                $matchingPackages = @($Packages | Where-Object { $_.InfNames -contains $amdRaidInfName })
+                if ($matchingPackages.Count -eq 0) {
+                    throw "WinPE driver classification failed: active AMD RAID package requires '$amdRaidInfName', but no exported package directory contains it."
+                }
+                if ($matchingPackages.Count -gt 1) {
+                    $directories = $matchingPackages.Directory -join "', '"
+                    throw "WinPE driver classification is ambiguous: AMD RAID dependency '$amdRaidInfName' exists in multiple exported package directories: '$directories'."
+                }
+                [void]$selectedDirectories.Add([string]$matchingPackages[0].Directory)
+            }
+        }
+
+        $selectedPackages = @($Packages | Where-Object { $selectedDirectories.Contains([string]$_.Directory) })
+        foreach ($package in $selectedPackages) {
+            $null = & $Logger "Selected active WinPE driver package '$($package.Directory)'."
+        }
+        return $selectedPackages
+    }
+
+    function Copy-WinUtilISODriverPackage {
+        param (
+            [Parameter(Mandatory)][string]$Source,
+            [Parameter(Mandatory)][string]$Destination
+        )
+
+        New-Item -Path $Destination -ItemType Directory -Force | Out-Null
+        $folderName = Split-Path $Source -Leaf
+        $targetPath = Join-Path $Destination $folderName
+        $suffix = 1
+        while (Test-Path -LiteralPath $targetPath) {
+            $targetPath = Join-Path $Destination "${folderName}_$suffix"
+            $suffix++
+        }
+
+        Copy-Item -LiteralPath $Source -Destination $targetPath -Recurse -Force -ErrorAction Stop
+        return $targetPath
+    }
+
     function Add-WinUtilISOStagedDrivers {
         param (
             [Parameter(Mandatory)][string]$ContentRoot,
@@ -44,57 +257,27 @@ function Invoke-WinUtilISOScript {
             [scriptblock]$Logger
         )
 
-        function Copy-WinUtilISODriverFolder {
-            param (
-                [Parameter(Mandatory)][string]$Source,
-                [Parameter(Mandatory)][string]$Destination
-            )
-
-            $folderName = Split-Path $Source -Leaf
-            $targetPath = Join-Path $Destination $folderName
-            $suffix = 1
-            while (Test-Path -LiteralPath $targetPath) {
-                $targetPath = Join-Path $Destination "${folderName}_$suffix"
-                $suffix++
-            }
-
-            Copy-Item -LiteralPath $Source -Destination $targetPath -Recurse -Force -ErrorAction Stop
-            return $targetPath
-        }
-
-        function Test-WinUtilISOStorageDriver {
-            param ([Parameter(Mandatory)][System.IO.FileInfo]$InfFile)
-
-            if ($InfFile.BaseName -match '(?i)(iaahci|iastor|vmd|irst|rst)') {
-                return $true
-            }
-
-            try {
-                return (Get-Content -LiteralPath $InfFile.FullName -Raw -ErrorAction Stop) -match '(?im)^\s*Class\s*=\s*(SCSIAdapter|HDC)\s*(?:;.*)?$'
-            } catch {
-                & $Logger "Warning: could not classify storage driver '$($InfFile.FullName)': $_"
-                return $false
-            }
-        }
-
         function Invoke-WinUtilISODism {
             param (
                 [Parameter(Mandatory)][string[]]$Arguments,
                 [Parameter(Mandatory)][string]$Operation
             )
 
+            $operationTimer = [System.Diagnostics.Stopwatch]::StartNew()
             $output = @(& dism.exe @Arguments 2>&1)
             $exitCode = $LASTEXITCODE
+            $operationTimer.Stop()
+            $elapsed = Format-WinUtilISOElapsed -Stopwatch $operationTimer
             if ($exitCode -ne 0) {
                 foreach ($line in @($output | Select-Object -Last 20)) {
                     if (-not [string]::IsNullOrWhiteSpace([string]$line)) {
                         & $Logger "  dism[$Operation]: $line"
                     }
                 }
-                throw "DISM $Operation failed with exit code $exitCode."
+                throw "DISM $Operation failed with exit code $exitCode after $elapsed."
             }
             if ($Operation -ne 'metadata') {
-                & $Logger "DISM $Operation completed."
+                $null = & $Logger "DISM $Operation completed in $elapsed."
             }
             return $output
         }
@@ -156,43 +339,57 @@ function Invoke-WinUtilISOScript {
         try {
             & $Logger "Exporting current system drivers before modifying install.wim..."
             $dismLog = Join-Path $env:TEMP "WinUtil_DismDriverExport_$(Get-Date -Format 'yyyyMMdd_HHmmss').log"
-            $dismProcess = Start-Process -FilePath "dism.exe" -ArgumentList "/online /export-driver /destination:`"$driverExportRoot`" /LogPath:`"$dismLog`"" -Wait -NoNewWindow -PassThru
-            if ($dismProcess.ExitCode -ne 0) {
-                throw "dism.exe driver export failed with exit code $($dismProcess.ExitCode)."
+            $driverExportTimer = [System.Diagnostics.Stopwatch]::StartNew()
+            try {
+                $dismProcess = Start-Process -FilePath "dism.exe" -ArgumentList "/online /export-driver /destination:`"$driverExportRoot`" /LogPath:`"$dismLog`"" -Wait -NoNewWindow -PassThru
+            } catch {
+                $driverExportTimer.Stop()
+                throw "dism.exe driver export failed after $(Format-WinUtilISOElapsed -Stopwatch $driverExportTimer): $_"
+            } finally {
+                if ($driverExportTimer.IsRunning) {
+                    $driverExportTimer.Stop()
+                }
             }
+            $driverExportElapsed = Format-WinUtilISOElapsed -Stopwatch $driverExportTimer
+            if ($dismProcess.ExitCode -ne 0) {
+                throw "dism.exe driver export failed with exit code $($dismProcess.ExitCode) after $driverExportElapsed."
+            }
+            $null = & $Logger "Driver export completed in $driverExportElapsed."
 
-            $driverInfs = @(Get-ChildItem -Path $driverExportRoot -Filter '*.inf' -Recurse -File)
+            $driverInfs = @(Get-ChildItem -LiteralPath $driverExportRoot -Filter '*.inf' -Recurse -File)
             if ($driverInfs.Count -eq 0) {
                 throw 'DISM exported no driver INF files.'
             }
-            $driverFolders = @($driverInfs | Group-Object { $_.Directory.FullName })
-            $winpeDriverDir = Join-Path $ContentRoot '$WinpeDriver$'
-            $storageCount = 0
+
+            $classificationTimer = [System.Diagnostics.Stopwatch]::StartNew()
+            try {
+                $driverPackages = @(Get-WinUtilISODriverPackageInventory -DriverRoot $driverExportRoot -Logger $Logger)
+                $winpeDriverPackages = @(Select-WinUtilISOWinPEDriverPackage -Packages $driverPackages -Logger $Logger)
+            } catch {
+                $classificationTimer.Stop()
+                $null = & $Logger "Driver inventory/classification failed after $(Format-WinUtilISOElapsed -Stopwatch $classificationTimer)."
+                throw
+            }
+            $classificationTimer.Stop()
+            $null = & $Logger "Driver inventory/classification completed in $(Format-WinUtilISOElapsed -Stopwatch $classificationTimer)."
+
+            $winpeDriverDir = Join-Path $ContentRoot '$WinPEDriver$'
             $copyFailures = 0
-
-            foreach ($driverFolderGroup in $driverFolders) {
-                $driverFolder = [string]$driverFolderGroup.Name
-                $storageInfs = @($driverFolderGroup.Group | Where-Object { Test-WinUtilISOStorageDriver -InfFile $_ })
-                if ($storageInfs.Count -eq 0) {
-                    continue
-                }
-
+            foreach ($driverPackage in $winpeDriverPackages) {
                 try {
-                    New-Item -Path $winpeDriverDir -ItemType Directory -Force | Out-Null
-                    $winpeTarget = Copy-WinUtilISODriverFolder -Source $driverFolder -Destination $winpeDriverDir
-                    $storageCount++
-                    & $Logger "Staged boot-storage package '$driverFolder' for WinPE as '$winpeTarget'."
+                    $winpeTarget = Copy-WinUtilISODriverPackage -Source $driverPackage.Directory -Destination $winpeDriverDir
+                    $null = & $Logger "Staged active storage package '$($driverPackage.Directory)' for WinPE as '$winpeTarget'."
                 } catch {
                     $copyFailures++
-                    & $Logger "Warning: failed to stage boot-storage package '$driverFolder': $_"
+                    $null = & $Logger "Warning: failed to stage active storage package '$($driverPackage.Directory)': $_"
                 }
             }
 
             if ($copyFailures -gt 0) {
-                throw "Failed to stage $copyFailures boot-storage driver package folders."
+                throw "Failed to stage $copyFailures active storage driver package directories."
             }
 
-            & $Logger "Exported $($driverInfs.Count) driver INF files across $($driverFolders.Count) package folders; staged $storageCount boot-storage packages for WinPE."
+            $null = & $Logger "Exported $($driverInfs.Count) driver INF files across $($driverPackages.Count) package directories; staged $($winpeDriverPackages.Count) active packages for WinPE."
             $metadataBefore = Get-WinUtilISOWimMetadata -ImagePath $InstallImagePath -Index $InstallImageIndex
             Assert-WinUtilISOWimMetadata -Before $metadataBefore
 
@@ -512,7 +709,7 @@ $appxList
 
         $useConfigurationSet = $xmlDoc.SelectSingleNode('/u:unattend/u:settings[@pass="windowsPE"]/u:component[@name="Microsoft-Windows-Setup"]/u:UseConfigurationSet', $nsMgr)
         if ($useConfigurationSet) {
-            $useConfigurationSet.InnerText = 'true'
+            $useConfigurationSet.InnerText = 'false'
             [System.IO.File]::WriteAllText((Join-Path $ContentRoot 'autounattend.xml'), $xmlDoc.OuterXml, [System.Text.UTF8Encoding]::new($false))
         }
         & $Logger "Staged $stagedCount WinUtil setup script fallback files at '$setupScriptsRoot'."

--- a/functions/private/Invoke-WinUtilISOScript.ps1
+++ b/functions/private/Invoke-WinUtilISOScript.ps1
@@ -36,12 +36,6 @@ function Invoke-WinUtilISOScript {
         [scriptblock]$Log = { param($m) Write-Output $m }
     )
 
-    function Format-WinUtilISOElapsed {
-        param ([Parameter(Mandatory)][System.Diagnostics.Stopwatch]$Stopwatch)
-
-        return $Stopwatch.Elapsed.ToString('hh\:mm\:ss\.fff')
-    }
-
     function Get-WinUtilISODriverPackageInventory {
         param (
             [Parameter(Mandatory)][AllowEmptyCollection()][System.IO.FileInfo[]]$DriverInfs,
@@ -272,21 +266,18 @@ function Invoke-WinUtilISOScript {
                 [Parameter(Mandatory)][string]$Operation
             )
 
-            $operationTimer = [System.Diagnostics.Stopwatch]::StartNew()
             $output = @(& dism.exe @Arguments 2>&1)
             $exitCode = $LASTEXITCODE
-            $operationTimer.Stop()
-            $elapsed = Format-WinUtilISOElapsed -Stopwatch $operationTimer
             if ($exitCode -ne 0) {
                 foreach ($line in @($output | Select-Object -Last 20)) {
                     if (-not [string]::IsNullOrWhiteSpace([string]$line)) {
                         & $Logger "  dism[$Operation]: $line"
                     }
                 }
-                throw "DISM $Operation failed with exit code $exitCode after $elapsed."
+                throw "DISM $Operation failed with exit code $exitCode."
             }
             if ($Operation -ne 'metadata') {
-                $null = & $Logger "DISM $Operation completed in $elapsed."
+                $null = & $Logger "DISM $Operation completed."
             }
             return $output
         }
@@ -348,39 +339,23 @@ function Invoke-WinUtilISOScript {
         try {
             & $Logger "Exporting current system drivers before modifying install.wim..."
             $dismLog = Join-Path $env:TEMP "WinUtil_DismDriverExport_$(Get-Date -Format 'yyyyMMdd_HHmmss').log"
-            $driverExportTimer = [System.Diagnostics.Stopwatch]::StartNew()
             try {
                 $dismProcess = Start-Process -FilePath "dism.exe" -ArgumentList "/online /export-driver /destination:`"$driverExportRoot`" /LogPath:`"$dismLog`"" -Wait -NoNewWindow -PassThru
             } catch {
-                $driverExportTimer.Stop()
-                throw "dism.exe driver export failed after $(Format-WinUtilISOElapsed -Stopwatch $driverExportTimer): $_"
-            } finally {
-                if ($driverExportTimer.IsRunning) {
-                    $driverExportTimer.Stop()
-                }
+                throw "dism.exe driver export failed: $_"
             }
-            $driverExportElapsed = Format-WinUtilISOElapsed -Stopwatch $driverExportTimer
             if ($dismProcess.ExitCode -ne 0) {
-                throw "dism.exe driver export failed with exit code $($dismProcess.ExitCode) after $driverExportElapsed."
+                throw "dism.exe driver export failed with exit code $($dismProcess.ExitCode)."
             }
-            $null = & $Logger "Driver export completed in $driverExportElapsed."
+            $null = & $Logger "Driver export completed."
 
             $driverInfs = @(Get-ChildItem -LiteralPath $driverExportRoot -Filter '*.inf' -Recurse -File)
             if ($driverInfs.Count -eq 0) {
                 throw 'DISM exported no driver INF files.'
             }
 
-            $classificationTimer = [System.Diagnostics.Stopwatch]::StartNew()
-            try {
-                $driverPackages = @(Get-WinUtilISODriverPackageInventory -DriverInfs $driverInfs -Logger $Logger)
-                $winpeDriverPackages = @(Select-WinUtilISOWinPEDriverPackage -Packages $driverPackages -Logger $Logger)
-            } catch {
-                $classificationTimer.Stop()
-                $null = & $Logger "Driver inventory/classification failed after $(Format-WinUtilISOElapsed -Stopwatch $classificationTimer)."
-                throw
-            }
-            $classificationTimer.Stop()
-            $null = & $Logger "Driver inventory/classification completed in $(Format-WinUtilISOElapsed -Stopwatch $classificationTimer)."
+            $driverPackages = @(Get-WinUtilISODriverPackageInventory -DriverInfs $driverInfs -Logger $Logger)
+            $winpeDriverPackages = @(Select-WinUtilISOWinPEDriverPackage -Packages $driverPackages -Logger $Logger)
 
             $winpeDriverDir = Join-Path $ContentRoot '$WinPEDriver$'
             $copyFailures = 0

--- a/functions/private/Invoke-WinUtilISOScript.ps1
+++ b/functions/private/Invoke-WinUtilISOScript.ps1
@@ -44,19 +44,18 @@ function Invoke-WinUtilISOScript {
 
     function Get-WinUtilISODriverPackageInventory {
         param (
-            [Parameter(Mandatory)][string]$DriverRoot,
+            [Parameter(Mandatory)][AllowEmptyCollection()][System.IO.FileInfo[]]$DriverInfs,
             [scriptblock]$Logger
         )
 
-        $driverInfs = @(Get-ChildItem -LiteralPath $DriverRoot -Filter '*.inf' -Recurse -File)
-        $packages = @($driverInfs | Group-Object { $_.Directory.FullName } | ForEach-Object {
+        $packages = @($DriverInfs | Group-Object { $_.Directory.FullName } | ForEach-Object {
             [pscustomobject]@{
                 Directory = [string]$_.Name
                 InfNames  = @($_.Group | ForEach-Object Name)
             }
         })
 
-        $null = & $Logger "Inventoried $($driverInfs.Count) INF files across $($packages.Count) exported package directories."
+        $null = & $Logger "Inventoried $($DriverInfs.Count) INF files across $($packages.Count) exported package directories."
         return $packages
     }
 
@@ -90,6 +89,11 @@ function Invoke-WinUtilISOScript {
                 throw "Expected one physical disk for system volume '$systemDrive', but found $($diskDeviceIds.Count)."
             }
 
+            # Devices with Setup Class outside this set (chipset/platform "System" devices, ACPI,
+            # generic PCI bridges, ...) are where WinPE driver staging stops climbing: they sit in
+            # the disk's PnP ancestry but are not demonstrably needed to enumerate the disk/controller.
+            $storageEnumerationDeviceClasses = @('DiskDrive', 'SCSIAdapter', 'HDC', 'USB', 'SDHost', 'PCMCIA')
+
             $publishedInfNames = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
             $visitedDeviceIds = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
             $deviceId = $diskDeviceIds[0]
@@ -103,10 +107,15 @@ function Invoke-WinUtilISOScript {
                     throw "The PnP parent chain contains a cycle at '$deviceId'."
                 }
 
-                if ($driverByDeviceId.ContainsKey($deviceId)) {
-                    $driver = $driverByDeviceId[$deviceId]
+                $driver = $driverByDeviceId[$deviceId]
+                if ($depth -gt 0 -and (-not $driver -or [string]$driver.DeviceClass -notin $storageEnumerationDeviceClasses)) {
+                    $null = & $Logger "Stopped at PnP ancestor '$deviceId' outside the storage-enumeration device classes."
+                    break
+                }
+
+                if ($driver) {
                     [void]$publishedInfNames.Add([string]$driver.InfName)
-                    $null = & $Logger "Active storage-path device '$deviceId' uses published INF '$($driver.InfName)'."
+                    $null = & $Logger "Active storage-path device '$deviceId' uses published INF '$($driver.InfName)' (class '$($driver.DeviceClass)')."
                 }
 
                 $parent = Get-PnpDeviceProperty -InstanceId $deviceId -KeyName 'DEVPKEY_Device_Parent' -ErrorAction Stop
@@ -363,7 +372,7 @@ function Invoke-WinUtilISOScript {
 
             $classificationTimer = [System.Diagnostics.Stopwatch]::StartNew()
             try {
-                $driverPackages = @(Get-WinUtilISODriverPackageInventory -DriverRoot $driverExportRoot -Logger $Logger)
+                $driverPackages = @(Get-WinUtilISODriverPackageInventory -DriverInfs $driverInfs -Logger $Logger)
                 $winpeDriverPackages = @(Select-WinUtilISOWinPEDriverPackage -Packages $driverPackages -Logger $Logger)
             } catch {
                 $classificationTimer.Stop()

--- a/pester/win11creator.Tests.ps1
+++ b/pester/win11creator.Tests.ps1
@@ -43,6 +43,12 @@ Describe "Win11 Creator setup media" {
         $script:writeUsbFunction = Get-WinUtilFunctionText -Path $script:isoUsbWorkflowPath -FunctionName "Invoke-WinUtilISOWriteUSB"
         $script:editionIdFunction = Get-WinUtilFunctionText -Path $script:isoWorkflowPath -FunctionName "Get-WinUtilEditionIdFromName"
         $script:wimMetadataAssertionFunction = Get-WinUtilFunctionText -Path $script:isoScriptPath -FunctionName "Assert-WinUtilISOWimMetadata"
+        $script:driverClassifierFunctions = @(
+            'Get-WinUtilISODriverPackageInventory',
+            'Get-WinUtilISOActiveStorageDriverMapping',
+            'Select-WinUtilISOWinPEDriverPackage',
+            'Copy-WinUtilISODriverPackage'
+        ) | ForEach-Object { Get-WinUtilFunctionText -Path $script:isoScriptPath -FunctionName $_ }
     }
 
     It "autounattend template does not force a product key" {
@@ -131,11 +137,13 @@ Describe "Win11 Creator setup media" {
         }
     }
 
-    It "stages only boot-storage drivers in WinPE" {
+    It "uses active storage-path inventory without adding another driver delivery path" {
         $isoScriptContent = Get-Content -Path $script:isoScriptPath -Raw
 
-        $isoScriptContent | Should -Match ([regex]::Escape("Join-Path `$ContentRoot '`$WinpeDriver$'"))
-        $isoScriptContent | Should -Match 'SCSIAdapter\|HDC'
+        $isoScriptContent | Should -Match ([regex]::Escape("Join-Path `$ContentRoot '`$WinPEDriver$'"))
+        $isoScriptContent | Should -Match ([regex]::Escape("Get-PnpDeviceProperty -InstanceId `$deviceId -KeyName 'DEVPKEY_Device_Parent'"))
+        $isoScriptContent | Should -Match ([regex]::Escape('& pnputil.exe /enum-drivers /format csv'))
+        $isoScriptContent | Should -Not -Match 'Class\s*=\s*\(SCSIAdapter\|HDC\)'
         $isoScriptContent | Should -Not -Match ([regex]::Escape('sources\$OEM$\$$\Drivers'))
         $isoScriptContent | Should -Not -Match ([regex]::Escape('WinUtil-InstallDrivers.ps1'))
         $isoScriptContent | Should -Not -Match ([regex]::Escape('SetupComplete.cmd'))
@@ -154,6 +162,247 @@ Describe "Win11 Creator setup media" {
         { Assert-WinUtilISOWimMetadata -Before $valid -After $invalidAfter } | Should -Throw '*validation failed*'
     }
 
+    It "maps the active system-disk parent chain from published to original INF names" {
+        . ([scriptblock]::Create($script:driverClassifierFunctions[1]))
+
+        $logicalDisk = New-CimInstance -ClassName Win32_LogicalDisk -ClientOnly -Property @{ DeviceID = $env:SystemDrive }
+        $partition = New-CimInstance -ClassName Win32_DiskPartition -ClientOnly -Property @{ DeviceID = 'Disk #0, Partition #1' }
+        Mock Get-CimInstance {
+            param($ClassName)
+            if ($ClassName -eq 'Win32_PnPSignedDriver') {
+                return @(
+                    [pscustomobject]@{ DeviceID = 'SCSI\DISK0'; InfName = 'disk.inf' },
+                    [pscustomobject]@{ DeviceID = 'PCI\STORAGE0'; InfName = 'oem10.inf' }
+                )
+            }
+            if ($ClassName -eq 'Win32_LogicalDisk') {
+                return $logicalDisk
+            }
+        }
+        Mock Get-CimAssociatedInstance {
+            param($Association)
+            if ($Association -eq 'Win32_LogicalDiskToPartition') {
+                return $partition
+            }
+            return [pscustomobject]@{ PNPDeviceID = 'SCSI\DISK0' }
+        }
+        Mock Get-PnpDeviceProperty {
+            param($InstanceId)
+            [pscustomobject]@{ Data = if ($InstanceId -eq 'SCSI\DISK0') { 'PCI\STORAGE0' } else { $null } }
+        }
+        function pnputil.exe {
+            $global:LASTEXITCODE = 0
+            'DriverName,OriginalName,ProviderName'
+            '"oem10.inf","iaStorVD.inf","Intel"'
+        }
+
+        try {
+            $logs = [System.Collections.Generic.List[string]]::new()
+            $mappings = @(Get-WinUtilISOActiveStorageDriverMapping -Logger { param($message) $null = $logs.Add([string]$message) })
+
+            $mappings.Count | Should -Be 1
+            $mappings[0].PublishedInfName | Should -Be 'oem10.inf'
+            $mappings[0].OriginalInfName | Should -Be 'iaStorVD.inf'
+            ($logs -join '|') | Should -Match 'Ignoring inbox INF names.*disk\.inf'
+            ($logs -join '|') | Should -Match "Mapped active driver 'oem10.inf' to original INF 'iaStorVD.inf'"
+            Should -Invoke Get-PnpDeviceProperty -Times 2 -Exactly
+        } finally {
+            Remove-Item Function:\pnputil.exe -ErrorAction SilentlyContinue
+        }
+    }
+
+    It "allows a verified inbox-only active path to produce an empty WinPE mapping" {
+        . ([scriptblock]::Create($script:driverClassifierFunctions[1]))
+
+        $logicalDisk = New-CimInstance -ClassName Win32_LogicalDisk -ClientOnly -Property @{ DeviceID = $env:SystemDrive }
+        $partition = New-CimInstance -ClassName Win32_DiskPartition -ClientOnly -Property @{ DeviceID = 'Disk #0, Partition #1' }
+        Mock Get-CimInstance {
+            param($ClassName)
+            if ($ClassName -eq 'Win32_PnPSignedDriver') {
+                return [pscustomobject]@{ DeviceID = 'SCSI\DISK0'; InfName = 'disk.inf' }
+            }
+            if ($ClassName -eq 'Win32_LogicalDisk') {
+                return $logicalDisk
+            }
+        }
+        Mock Get-CimAssociatedInstance {
+            param($Association)
+            if ($Association -eq 'Win32_LogicalDiskToPartition') {
+                return $partition
+            }
+            return [pscustomobject]@{ PNPDeviceID = 'SCSI\DISK0' }
+        }
+        Mock Get-PnpDeviceProperty { [pscustomobject]@{ Data = $null } }
+        function pnputil.exe { throw 'PnPUtil should not run without an active OEM INF.' }
+
+        try {
+            $logs = [System.Collections.Generic.List[string]]::new()
+            @(Get-WinUtilISOActiveStorageDriverMapping -Logger { param($message) $null = $logs.Add([string]$message) }).Count | Should -Be 0
+            ($logs -join '|') | Should -Match 'no third-party OEM INF requiring WinPE staging'
+        } finally {
+            Remove-Item Function:\pnputil.exe -ErrorAction SilentlyContinue
+        }
+    }
+
+    It "fails explicitly for unusable PnPUtil driver inventory" -TestCases @(
+        @{ InventoryOutput = @(); ExitCode = 5; ExpectedError = '*PnPUtil driver inventory exited with code 5*' }
+        @{ InventoryOutput = @(); ExitCode = 0; ExpectedError = '*empty CSV output*' }
+        @{ InventoryOutput = @('DriverName,OriginalName'); ExitCode = 0; ExpectedError = '*contained no driver records*' }
+        @{ InventoryOutput = @('DriverName,DriverName,OriginalName', '"oem10.inf","duplicate","storage.inf"'); ExitCode = 0; ExpectedError = '*CSV could not be parsed*' }
+        @{ InventoryOutput = @('DriverName,ProviderName', '"oem10.inf","Vendor"'); ExitCode = 0; ExpectedError = '*missing DriverName or OriginalName*' }
+        @{ InventoryOutput = @('DriverName,OriginalName', '"oem10.inf",""'); ExitCode = 0; ExpectedError = '*unusable DriverName or OriginalName*' }
+        @{ InventoryOutput = @('DriverName,OriginalName', '"oem10.inf","storage.inf"', '"oem10.inf","storage-old.inf"'); ExitCode = 0; ExpectedError = '*multiple records for published INF ''oem10.inf''*' }
+        @{ InventoryOutput = @('DriverName,OriginalName', '"oem11.inf","other.inf"'); ExitCode = 0; ExpectedError = '*did not translate published INF ''oem10.inf''*' }
+    ) {
+        param($InventoryOutput, $ExitCode, $ExpectedError)
+
+        . ([scriptblock]::Create($script:driverClassifierFunctions[1]))
+        $logicalDisk = New-CimInstance -ClassName Win32_LogicalDisk -ClientOnly -Property @{ DeviceID = $env:SystemDrive }
+        $partition = New-CimInstance -ClassName Win32_DiskPartition -ClientOnly -Property @{ DeviceID = 'Disk #0, Partition #1' }
+        Mock Get-CimInstance {
+            param($ClassName)
+            if ($ClassName -eq 'Win32_PnPSignedDriver') {
+                return [pscustomobject]@{ DeviceID = 'SCSI\DISK0'; InfName = 'oem10.inf' }
+            }
+            if ($ClassName -eq 'Win32_LogicalDisk') {
+                return $logicalDisk
+            }
+        }
+        Mock Get-CimAssociatedInstance {
+            param($Association)
+            if ($Association -eq 'Win32_LogicalDiskToPartition') {
+                return $partition
+            }
+            return [pscustomobject]@{ PNPDeviceID = 'SCSI\DISK0' }
+        }
+        Mock Get-PnpDeviceProperty { [pscustomobject]@{ Data = $null } }
+        $script:testPnPUtilOutput = $InventoryOutput
+        $script:testPnPUtilExitCode = $ExitCode
+        function pnputil.exe {
+            $global:LASTEXITCODE = $script:testPnPUtilExitCode
+            $script:testPnPUtilOutput
+        }
+
+        try {
+            { Get-WinUtilISOActiveStorageDriverMapping -Logger { param($message) $null = $message } } | Should -Throw $ExpectedError
+        } finally {
+            Remove-Item Function:\pnputil.exe -ErrorAction SilentlyContinue
+        }
+    }
+
+    It "selects only uniquely resolved active packages" {
+        . ([scriptblock]::Create($script:driverClassifierFunctions[2]))
+        function Get-WinUtilISOActiveStorageDriverMapping {
+            param([scriptblock]$Logger)
+            $null = $Logger
+            [pscustomobject]@{ PublishedInfName = 'oem10.inf'; OriginalInfName = 'storage.inf' }
+        }
+
+        $packages = @(
+            [pscustomobject]@{ Directory = 'storage'; InfNames = @('storage.inf') },
+            [pscustomobject]@{ Directory = 'network'; InfNames = @('network.inf') },
+            [pscustomobject]@{ Directory = 'audio'; InfNames = @('audio.inf') }
+        )
+
+        $selected = @(Select-WinUtilISOWinPEDriverPackage -Packages $packages -Logger { param($message) $null = $message })
+        $selected.Count | Should -Be 1
+        $selected[0].Directory | Should -Be 'storage'
+    }
+
+    It "rejects missing and duplicate exported matches for an active OEM INF" -TestCases @(
+        @{ Packages = @([pscustomobject]@{ Directory = 'other'; InfNames = @('other.inf') }); ExpectedError = '*no exported package directory contains it*' }
+        @{ Packages = @([pscustomobject]@{ Directory = 'first'; InfNames = @('storage.inf') }, [pscustomobject]@{ Directory = 'second'; InfNames = @('storage.inf') }); ExpectedError = '*multiple exported package directories*' }
+    ) {
+        param($Packages, $ExpectedError)
+
+        . ([scriptblock]::Create($script:driverClassifierFunctions[2]))
+        function Get-WinUtilISOActiveStorageDriverMapping {
+            param([scriptblock]$Logger)
+            $null = $Logger
+            [pscustomobject]@{ PublishedInfName = 'oem10.inf'; OriginalInfName = 'storage.inf' }
+        }
+
+        $packagesUnderTest = $Packages
+        { Select-WinUtilISOWinPEDriverPackage -Packages $packagesUnderTest -Logger { param($message) $null = $message } } | Should -Throw $ExpectedError
+    }
+
+    It "completes the AMD RAID trio without selecting unrelated packages" {
+        . ([scriptblock]::Create($script:driverClassifierFunctions[2]))
+        function Get-WinUtilISOActiveStorageDriverMapping {
+            param([scriptblock]$Logger)
+            $null = $Logger
+            [pscustomobject]@{ PublishedInfName = 'oem42.inf'; OriginalInfName = 'rcbottom.inf' }
+        }
+
+        $packages = @(
+            [pscustomobject]@{ Directory = 'bottom'; InfNames = @('rcbottom.inf') },
+            [pscustomobject]@{ Directory = 'raid'; InfNames = @('rcraid.inf') },
+            [pscustomobject]@{ Directory = 'config'; InfNames = @('rccfg.inf') },
+            [pscustomobject]@{ Directory = 'unrelated'; InfNames = @('network.inf') }
+        )
+
+        $selected = @(Select-WinUtilISOWinPEDriverPackage -Packages $packages -Logger { param($message) $null = $message })
+        @($selected.Directory) | Should -HaveCount 3
+        @($selected.Directory) | Should -Contain 'bottom'
+        @($selected.Directory) | Should -Contain 'raid'
+        @($selected.Directory) | Should -Contain 'config'
+        @($selected.Directory) | Should -Not -Contain 'unrelated'
+    }
+
+    It "rejects missing or ambiguous AMD RAID dependencies" -TestCases @(
+        @{
+            Packages = @(
+                [pscustomobject]@{ Directory = 'bottom'; InfNames = @('rcbottom.inf') },
+                [pscustomobject]@{ Directory = 'config'; InfNames = @('rccfg.inf') }
+            )
+            ExpectedError = "*requires 'rcraid.inf'*"
+        }
+        @{
+            Packages = @(
+                [pscustomobject]@{ Directory = 'bottom'; InfNames = @('rcbottom.inf') },
+                [pscustomobject]@{ Directory = 'raid-one'; InfNames = @('rcraid.inf') },
+                [pscustomobject]@{ Directory = 'raid-two'; InfNames = @('rcraid.inf') },
+                [pscustomobject]@{ Directory = 'config'; InfNames = @('rccfg.inf') }
+            )
+            ExpectedError = "*AMD RAID dependency 'rcraid.inf'*multiple exported package directories*"
+        }
+    ) {
+        param($Packages, $ExpectedError)
+
+        . ([scriptblock]::Create($script:driverClassifierFunctions[2]))
+        function Get-WinUtilISOActiveStorageDriverMapping {
+            param([scriptblock]$Logger)
+            $null = $Logger
+            [pscustomobject]@{ PublishedInfName = 'oem42.inf'; OriginalInfName = 'rcbottom.inf' }
+        }
+
+        $packagesUnderTest = $Packages
+        { Select-WinUtilISOWinPEDriverPackage -Packages $packagesUnderTest -Logger { param($message) $null = $message } } | Should -Throw $ExpectedError
+    }
+
+    It "copies complete exported package directories for WinPE" {
+        . ([scriptblock]::Create($script:driverClassifierFunctions[3]))
+        $testRoot = Join-Path ([IO.Path]::GetTempPath()) "WinUtilPackageCopy_$([guid]::NewGuid())"
+        $source = Join-Path $testRoot 'source\storage-package'
+        $destination = Join-Path $testRoot '$WinPEDriver$'
+
+        try {
+            New-Item -Path (Join-Path $source 'subdir') -ItemType Directory -Force | Out-Null
+            Set-Content -Path (Join-Path $source 'storage.inf') -Value 'inf' -Encoding ASCII
+            Set-Content -Path (Join-Path $source 'storage.cat') -Value 'cat' -Encoding ASCII
+            Set-Content -Path (Join-Path $source 'storage.sys') -Value 'sys' -Encoding ASCII
+            Set-Content -Path (Join-Path $source 'subdir\coinstaller.dll') -Value 'dll' -Encoding ASCII
+
+            $copiedPath = Copy-WinUtilISODriverPackage -Source $source -Destination $destination
+            Test-Path (Join-Path $copiedPath 'storage.inf') | Should -BeTrue
+            Test-Path (Join-Path $copiedPath 'storage.cat') | Should -BeTrue
+            Test-Path (Join-Path $copiedPath 'storage.sys') | Should -BeTrue
+            Test-Path (Join-Path $copiedPath 'subdir\coinstaller.dll') | Should -BeTrue
+        } finally {
+            Remove-Item -Path $testRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
     It "tracks every background ISO workflow with the shared busy state" {
         foreach ($functionText in @(
             $script:mountAndVerifyFunction,
@@ -165,6 +414,13 @@ Describe "Win11 Creator setup media" {
             $functionText | Should -Match ([regex]::Escape('$sync["Win11ISOProcessRunning"] = $true'))
             $functionText | Should -Match ([regex]::Escape('$sync["Win11ISOProcessRunning"] = $false'))
         }
+    }
+
+    It "times OSCDIMG save and uses setup-media completion wording" {
+        $script:exportFunction | Should -Match ([regex]::Escape('$isoSaveTimer = [System.Diagnostics.Stopwatch]::StartNew()'))
+        $script:exportFunction | Should -Match 'OSCDIMG save completed in \$isoSaveElapsed'
+        $script:modifyFunction | Should -Match ([regex]::Escape('Setup media preparation complete. Choose an output option in Step 4.'))
+        $script:modifyFunction | Should -Not -Match ([regex]::Escape('install.wim modification complete'))
     }
 
     It "runs ISO mount and verification outside the UI thread" {
@@ -315,7 +571,7 @@ Describe "Win11 Creator setup media" {
         }
     }
 
-    It "stages storage drivers for WinPE and adds all drivers to one install.wim index" {
+    It "stages the active storage package and services all exported drivers in one WIM lifecycle" {
         $contentRoot = Join-Path ([IO.Path]::GetTempPath()) "WinUtilIsoDrivers_$([guid]::NewGuid())"
         $installWim = Join-Path $contentRoot 'sources\install.wim'
         $template = Get-Content -Path $script:autoUnattendPath -Raw
@@ -352,22 +608,45 @@ Describe "Win11 Creator setup media" {
 
             $exportRoot = $destinationMatch.Groups[1].Value
             $fixtures = @(
-                @{ Path = 'system_pkg'; Name = 'chipset.inf'; Class = 'System' },
-                @{ Path = 'storage_pkg'; Name = 'iaStorAC.inf'; Class = 'System' },
-                @{ Path = 'scsi_pkg'; Name = 'controller.inf'; Class = 'SCSIAdapter' },
-                @{ Path = 'net_pkg'; Name = 'network.inf'; Class = 'Net' },
-                @{ Path = 'group_a\duplicate'; Name = 'audio.inf'; Class = 'Media' },
-                @{ Path = 'group_b\duplicate'; Name = 'extension.inf'; Class = 'Extension' }
+                @{ Path = 'storage_pkg'; Name = 'iaStorAC.inf' },
+                @{ Path = 'net_pkg'; Name = 'network.inf' }
             )
 
             foreach ($fixture in $fixtures) {
                 $fixturePath = Join-Path $exportRoot $fixture.Path
                 New-Item -Path $fixturePath -ItemType Directory -Force | Out-Null
-                Set-Content -Path (Join-Path $fixturePath $fixture.Name) -Value "[Version]`r`nClass=$($fixture.Class)" -Encoding ASCII
+                Set-Content -Path (Join-Path $fixturePath $fixture.Name) -Value '[Version]' -Encoding ASCII
+                Set-Content -Path (Join-Path $fixturePath "$($fixture.Name).cat") -Value 'catalog' -Encoding ASCII
+                Set-Content -Path (Join-Path $fixturePath "$($fixture.Name).sys") -Value 'binary' -Encoding ASCII
             }
 
             return [pscustomobject]@{ ExitCode = 0 }
         } -ParameterFilter { $FilePath -eq 'dism.exe' }
+
+        $logicalDisk = New-CimInstance -ClassName Win32_LogicalDisk -ClientOnly -Property @{ DeviceID = $env:SystemDrive }
+        $partition = New-CimInstance -ClassName Win32_DiskPartition -ClientOnly -Property @{ DeviceID = 'Disk #0, Partition #1' }
+        Mock Get-CimInstance {
+            param($ClassName)
+            if ($ClassName -eq 'Win32_PnPSignedDriver') {
+                return [pscustomobject]@{ DeviceID = 'SCSI\DISK0'; InfName = 'oem10.inf' }
+            }
+            if ($ClassName -eq 'Win32_LogicalDisk') {
+                return $logicalDisk
+            }
+        }
+        Mock Get-CimAssociatedInstance {
+            param($Association)
+            if ($Association -eq 'Win32_LogicalDiskToPartition') {
+                return $partition
+            }
+            return [pscustomobject]@{ PNPDeviceID = 'SCSI\DISK0' }
+        }
+        Mock Get-PnpDeviceProperty { [pscustomobject]@{ Data = $null } }
+        function pnputil.exe {
+            $global:LASTEXITCODE = 0
+            'DriverName,OriginalName,ProviderName'
+            '"oem10.inf","iaStorAC.inf","Intel"'
+        }
 
         try {
             New-Item -Path (Split-Path $installWim -Parent) -ItemType Directory -Force | Out-Null
@@ -378,11 +657,11 @@ Describe "Win11 Creator setup media" {
                 $logs.Add([string]$message)
             }
 
-            $winpeDriverRoot = Join-Path $contentRoot '$WinpeDriver$'
-            @(Get-ChildItem -Path $winpeDriverRoot -Directory).Count | Should -Be 2
-            Test-Path (Join-Path $winpeDriverRoot 'system_pkg\chipset.inf') | Should -BeFalse
+            $winpeDriverRoot = Join-Path $contentRoot '$WinPEDriver$'
+            @(Get-ChildItem -Path $winpeDriverRoot -Directory).Count | Should -Be 1
             Test-Path (Join-Path $winpeDriverRoot 'storage_pkg\iaStorAC.inf') | Should -BeTrue
-            Test-Path (Join-Path $winpeDriverRoot 'scsi_pkg\controller.inf') | Should -BeTrue
+            Test-Path (Join-Path $winpeDriverRoot 'storage_pkg\iaStorAC.inf.cat') | Should -BeTrue
+            Test-Path (Join-Path $winpeDriverRoot 'storage_pkg\iaStorAC.inf.sys') | Should -BeTrue
             Test-Path (Join-Path $winpeDriverRoot 'net_pkg\network.inf') | Should -BeFalse
 
             @($script:dismCalls | Where-Object { $_ -match '/Mount-Image' }).Count | Should -Be 1
@@ -390,15 +669,62 @@ Describe "Win11 Creator setup media" {
             @($script:dismCalls | Where-Object { $_ -match '/Unmount-Image\|.*\|/Commit' }).Count | Should -Be 1
             @($script:dismCalls | Where-Object { $_ -match '/Get-WimInfo' }).Count | Should -Be 2
             ($script:dismCalls -join "`n") | Should -Not -Match '/Cleanup-Image|/Export-Image'
+            ($script:dismCalls | Where-Object { $_ -match '/Add-Driver' }) | Should -Match '/Driver:.*WinUtil_DriverExport_.*\|/Recurse'
+            ($script:dismCalls | Where-Object { $_ -match '/Add-Driver' }) | Should -Not -Match '\$WinPEDriver\$'
+            Should -Invoke Start-Process -Times 1 -Exactly -ParameterFilter {
+                $FilePath -eq 'dism.exe' -and $ArgumentList -match '/online /export-driver /destination:'
+            }
 
             [xml]$answerFile = Get-Content -Path (Join-Path $contentRoot 'autounattend.xml') -Raw
             $nsMgr = New-Object System.Xml.XmlNamespaceManager($answerFile.NameTable)
             $nsMgr.AddNamespace('sg', 'https://schneegans.de/windows/unattend-generator/')
             $answerFile.SelectSingleNode('//sg:File[@path="C:\Windows\Setup\Scripts\WinUtil-InstallDrivers.ps1"]', $nsMgr) | Should -BeNullOrEmpty
-            ($logs -join '|') | Should -Match 'staged 2 boot-storage packages for WinPE'
+            ($logs -join '|') | Should -Match 'staged 1 active packages for WinPE'
             ($logs -join '|') | Should -Match 'install.wim metadata validation passed'
-            ($logs -join '|') | Should -Match 'DISM mount completed.'
+            ($logs -join '|') | Should -Match 'Driver export completed in \d{2}:\d{2}:\d{2}\.\d{3}'
+            ($logs -join '|') | Should -Match 'Driver inventory/classification completed in \d{2}:\d{2}:\d{2}\.\d{3}'
+            ($logs -join '|') | Should -Match 'DISM mount completed in \d{2}:\d{2}:\d{2}\.\d{3}'
+            ($logs -join '|') | Should -Match 'DISM add-driver completed in \d{2}:\d{2}:\d{2}\.\d{3}'
+            ($logs -join '|') | Should -Match 'DISM commit completed in \d{2}:\d{2}:\d{2}\.\d{3}'
             ($logs -join '|') | Should -Not -Match '100.0%'
+        } finally {
+            Remove-Item Function:\dism.exe -ErrorAction SilentlyContinue
+            Remove-Item Function:\pnputil.exe -ErrorAction SilentlyContinue
+            Remove-Item -Path $contentRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It "preserves DISM export failure and no-INF cleanup semantics" -TestCases @(
+        @{ ExitCode = 5; ExpectedError = '*dism.exe driver export failed with exit code 5*' }
+        @{ ExitCode = 0; ExpectedError = '*DISM exported no driver INF files*' }
+    ) {
+        param($ExitCode, $ExpectedError)
+
+        $contentRoot = Join-Path ([IO.Path]::GetTempPath()) "WinUtilIsoExportFailure_$([guid]::NewGuid())"
+        $installWim = Join-Path $contentRoot 'sources\install.wim'
+        $script:mockExportRoot = $null
+        $script:mockExportExitCode = $ExitCode
+
+        function dism.exe {
+            $global:LASTEXITCODE = 0
+        }
+        Mock Start-Process {
+            param($ArgumentList)
+            $destinationMatch = [regex]::Match([string]$ArgumentList, '/destination:"([^"]+)"')
+            $script:mockExportRoot = $destinationMatch.Groups[1].Value
+            [pscustomobject]@{ ExitCode = $script:mockExportExitCode }
+        } -ParameterFilter { $FilePath -eq 'dism.exe' }
+
+        try {
+            New-Item -Path (Split-Path $installWim -Parent) -ItemType Directory -Force | Out-Null
+            Set-Content -Path $installWim -Value 'mock-wim'
+            . $script:isoScriptPath
+
+            { Invoke-WinUtilISOScript -ISOContentsDir $contentRoot -AutoUnattendXml (Get-Content -Path $script:autoUnattendPath -Raw) -InjectCurrentSystemDrivers $true -InstallImagePath $installWim -InstallEditionId 'Professional' } |
+                Should -Throw $ExpectedError
+
+            $script:mockExportRoot | Should -Not -BeNullOrEmpty
+            Test-Path -LiteralPath $script:mockExportRoot | Should -BeFalse
         } finally {
             Remove-Item Function:\dism.exe -ErrorAction SilentlyContinue
             Remove-Item -Path $contentRoot -Recurse -Force -ErrorAction SilentlyContinue
@@ -436,6 +762,10 @@ Describe "Win11 Creator setup media" {
         Mock Start-Process {
             param($FilePath, $ArgumentList)
 
+            if ($FilePath -ne 'dism.exe') {
+                throw "Unexpected process in driver export mock: $FilePath"
+            }
+
             $destinationMatch = [regex]::Match([string]$ArgumentList, '/destination:"([^"]+)"')
             $exportRoot = $destinationMatch.Groups[1].Value
             $fixturePath = Join-Path $exportRoot 'storage_pkg'
@@ -443,6 +773,31 @@ Describe "Win11 Creator setup media" {
             Set-Content -Path (Join-Path $fixturePath 'iaStorAC.inf') -Value "[Version]`r`nClass=System" -Encoding ASCII
             return [pscustomobject]@{ ExitCode = 0 }
         } -ParameterFilter { $FilePath -eq 'dism.exe' }
+
+        $logicalDisk = New-CimInstance -ClassName Win32_LogicalDisk -ClientOnly -Property @{ DeviceID = $env:SystemDrive }
+        $partition = New-CimInstance -ClassName Win32_DiskPartition -ClientOnly -Property @{ DeviceID = 'Disk #0, Partition #1' }
+        Mock Get-CimInstance {
+            param($ClassName)
+            if ($ClassName -eq 'Win32_PnPSignedDriver') {
+                return [pscustomobject]@{ DeviceID = 'SCSI\DISK0'; InfName = 'oem10.inf' }
+            }
+            if ($ClassName -eq 'Win32_LogicalDisk') {
+                return $logicalDisk
+            }
+        }
+        Mock Get-CimAssociatedInstance {
+            param($Association)
+            if ($Association -eq 'Win32_LogicalDiskToPartition') {
+                return $partition
+            }
+            return [pscustomobject]@{ PNPDeviceID = 'SCSI\DISK0' }
+        }
+        Mock Get-PnpDeviceProperty { [pscustomobject]@{ Data = $null } }
+        function pnputil.exe {
+            $global:LASTEXITCODE = 0
+            'DriverName,OriginalName,ProviderName'
+            '"oem10.inf","iaStorAC.inf","Intel"'
+        }
 
         try {
             New-Item -Path (Split-Path $installWim -Parent) -ItemType Directory -Force | Out-Null
@@ -456,6 +811,7 @@ Describe "Win11 Creator setup media" {
             @($script:dismCalls | Where-Object { $_ -match '/Unmount-Image\|.*\|/Discard' }).Count | Should -Be 1
         } finally {
             Remove-Item Function:\dism.exe -ErrorAction SilentlyContinue
+            Remove-Item Function:\pnputil.exe -ErrorAction SilentlyContinue
             Remove-Item -Path $contentRoot -Recurse -Force -ErrorAction SilentlyContinue
         }
     }
@@ -468,7 +824,7 @@ Describe "Win11 Creator setup media" {
             . $script:isoScriptPath
             Invoke-WinUtilISOScript -ISOContentsDir $contentRoot -AutoUnattendXml (Get-Content -Path $script:autoUnattendPath -Raw) -InjectCurrentSystemDrivers $false -InstallEditionId 'Core'
 
-            Test-Path (Join-Path $contentRoot '$WinpeDriver$') | Should -BeFalse
+            Test-Path (Join-Path $contentRoot '$WinPEDriver$') | Should -BeFalse
             [xml]$answerFile = Get-Content -Path (Join-Path $contentRoot 'autounattend.xml') -Raw
             $nsMgr = New-Object System.Xml.XmlNamespaceManager($answerFile.NameTable)
             $nsMgr.AddNamespace('sg', 'https://schneegans.de/windows/unattend-generator/')
@@ -478,21 +834,50 @@ Describe "Win11 Creator setup media" {
         }
     }
 
-    It "enables configuration-set fallback when staging OEM setup scripts" {
+    It "forces an existing UseConfigurationSet node to false" {
         $contentRoot = Join-Path ([IO.Path]::GetTempPath()) "WinUtilIsoFallback_$([guid]::NewGuid())"
 
         try {
             New-Item -Path $contentRoot -ItemType Directory -Force | Out-Null
+            [xml]$template = Get-Content -Path $script:autoUnattendPath -Raw
+            $templateNs = New-Object System.Xml.XmlNamespaceManager($template.NameTable)
+            $templateNs.AddNamespace('u', 'urn:schemas-microsoft-com:unattend')
+            $template.SelectSingleNode('/u:unattend/u:settings[@pass="windowsPE"]/u:component[@name="Microsoft-Windows-Setup"]/u:UseConfigurationSet', $templateNs).InnerText = 'true'
             . $script:isoScriptPath
-            Invoke-WinUtilISOScript -ISOContentsDir $contentRoot -AutoUnattendXml (Get-Content -Path $script:autoUnattendPath -Raw) -InstallEditionId 'Core'
+            Invoke-WinUtilISOScript -ISOContentsDir $contentRoot -AutoUnattendXml $template.OuterXml -InstallEditionId 'Core'
 
             [xml]$answerFile = Get-Content -Path (Join-Path $contentRoot 'autounattend.xml') -Raw
             $nsMgr = New-Object System.Xml.XmlNamespaceManager($answerFile.NameTable)
             $nsMgr.AddNamespace('u', 'urn:schemas-microsoft-com:unattend')
 
             $answerFile.SelectSingleNode('/u:unattend/u:settings[@pass="windowsPE"]/u:component[@name="Microsoft-Windows-Setup"]/u:UseConfigurationSet', $nsMgr).InnerText |
-                Should -Be 'true'
+                Should -Be 'false'
             Test-Path (Join-Path $contentRoot 'sources\$OEM$\$$\Setup\Scripts\FirstLogon.ps1') | Should -BeTrue
+        } finally {
+            Remove-Item -Path $contentRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It "leaves an absent UseConfigurationSet node absent" {
+        $contentRoot = Join-Path ([IO.Path]::GetTempPath()) "WinUtilIsoNoConfigurationSet_$([guid]::NewGuid())"
+
+        try {
+            New-Item -Path $contentRoot -ItemType Directory -Force | Out-Null
+            [xml]$template = Get-Content -Path $script:autoUnattendPath -Raw
+            $templateNs = New-Object System.Xml.XmlNamespaceManager($template.NameTable)
+            $templateNs.AddNamespace('u', 'urn:schemas-microsoft-com:unattend')
+            $configurationSetNode = $template.SelectSingleNode('/u:unattend/u:settings[@pass="windowsPE"]/u:component[@name="Microsoft-Windows-Setup"]/u:UseConfigurationSet', $templateNs)
+            [void]$configurationSetNode.ParentNode.RemoveChild($configurationSetNode)
+
+            . $script:isoScriptPath
+            Invoke-WinUtilISOScript -ISOContentsDir $contentRoot -AutoUnattendXml $template.OuterXml -InstallEditionId 'Core'
+
+            [xml]$answerFile = Get-Content -Path (Join-Path $contentRoot 'autounattend.xml') -Raw
+            $nsMgr = New-Object System.Xml.XmlNamespaceManager($answerFile.NameTable)
+            $nsMgr.AddNamespace('u', 'urn:schemas-microsoft-com:unattend')
+            $answerFile.SelectSingleNode('/u:unattend/u:settings[@pass="windowsPE"]/u:component[@name="Microsoft-Windows-Setup"]/u:UseConfigurationSet', $nsMgr) |
+                Should -BeNullOrEmpty
+            $answerFile.OuterXml | Should -Not -Match '<UseConfigurationSet>true</UseConfigurationSet>'
         } finally {
             Remove-Item -Path $contentRoot -Recurse -Force -ErrorAction SilentlyContinue
         }

--- a/pester/win11creator.Tests.ps1
+++ b/pester/win11creator.Tests.ps1
@@ -508,9 +508,7 @@ Describe "Win11 Creator setup media" {
         }
     }
 
-    It "times OSCDIMG save and uses setup-media completion wording" {
-        $script:exportFunction | Should -Match ([regex]::Escape('$isoSaveTimer = [System.Diagnostics.Stopwatch]::StartNew()'))
-        $script:exportFunction | Should -Match 'OSCDIMG save completed in \$isoSaveElapsed'
+    It "uses setup-media completion wording" {
         $script:modifyFunction | Should -Match ([regex]::Escape('Setup media preparation complete. Choose an output option in Step 4.'))
         $script:modifyFunction | Should -Not -Match ([regex]::Escape('install.wim modification complete'))
     }
@@ -773,11 +771,10 @@ Describe "Win11 Creator setup media" {
             $answerFile.SelectSingleNode('//sg:File[@path="C:\Windows\Setup\Scripts\WinUtil-InstallDrivers.ps1"]', $nsMgr) | Should -BeNullOrEmpty
             ($logs -join '|') | Should -Match 'staged 1 active packages for WinPE'
             ($logs -join '|') | Should -Match 'install.wim metadata validation passed'
-            ($logs -join '|') | Should -Match 'Driver export completed in \d{2}:\d{2}:\d{2}\.\d{3}'
-            ($logs -join '|') | Should -Match 'Driver inventory/classification completed in \d{2}:\d{2}:\d{2}\.\d{3}'
-            ($logs -join '|') | Should -Match 'DISM mount completed in \d{2}:\d{2}:\d{2}\.\d{3}'
-            ($logs -join '|') | Should -Match 'DISM add-driver completed in \d{2}:\d{2}:\d{2}\.\d{3}'
-            ($logs -join '|') | Should -Match 'DISM commit completed in \d{2}:\d{2}:\d{2}\.\d{3}'
+            ($logs -join '|') | Should -Match 'Driver export completed'
+            ($logs -join '|') | Should -Match 'DISM mount completed'
+            ($logs -join '|') | Should -Match 'DISM add-driver completed'
+            ($logs -join '|') | Should -Match 'DISM commit completed'
             ($logs -join '|') | Should -Not -Match '100.0%'
         } finally {
             Remove-Item Function:\dism.exe -ErrorAction SilentlyContinue

--- a/pester/win11creator.Tests.ps1
+++ b/pester/win11creator.Tests.ps1
@@ -171,8 +171,8 @@ Describe "Win11 Creator setup media" {
             param($ClassName)
             if ($ClassName -eq 'Win32_PnPSignedDriver') {
                 return @(
-                    [pscustomobject]@{ DeviceID = 'SCSI\DISK0'; InfName = 'disk.inf' },
-                    [pscustomobject]@{ DeviceID = 'PCI\STORAGE0'; InfName = 'oem10.inf' }
+                    [pscustomobject]@{ DeviceID = 'SCSI\DISK0'; InfName = 'disk.inf'; DeviceClass = 'DiskDrive' },
+                    [pscustomobject]@{ DeviceID = 'PCI\STORAGE0'; InfName = 'oem10.inf'; DeviceClass = 'SCSIAdapter' }
                 )
             }
             if ($ClassName -eq 'Win32_LogicalDisk') {
@@ -206,6 +206,98 @@ Describe "Win11 Creator setup media" {
             ($logs -join '|') | Should -Match 'Ignoring inbox INF names.*disk\.inf'
             ($logs -join '|') | Should -Match "Mapped active driver 'oem10.inf' to original INF 'iaStorVD.inf'"
             Should -Invoke Get-PnpDeviceProperty -Times 2 -Exactly
+        } finally {
+            Remove-Item Function:\pnputil.exe -ErrorAction SilentlyContinue
+        }
+    }
+
+    It "excludes OEM INFs on ancestors beyond the storage-enumeration device classes" {
+        . ([scriptblock]::Create($script:driverClassifierFunctions[1]))
+
+        $logicalDisk = New-CimInstance -ClassName Win32_LogicalDisk -ClientOnly -Property @{ DeviceID = $env:SystemDrive }
+        $partition = New-CimInstance -ClassName Win32_DiskPartition -ClientOnly -Property @{ DeviceID = 'Disk #0, Partition #1' }
+        Mock Get-CimInstance {
+            param($ClassName)
+            if ($ClassName -eq 'Win32_PnPSignedDriver') {
+                return @(
+                    [pscustomobject]@{ DeviceID = 'SCSI\DISK0'; InfName = 'disk.inf'; DeviceClass = 'DiskDrive' },
+                    [pscustomobject]@{ DeviceID = 'PCI\STORAGE0'; InfName = 'stornvme.inf'; DeviceClass = 'SCSIAdapter' },
+                    [pscustomobject]@{ DeviceID = 'PCI\ROOTPORT0'; InfName = 'oem2.inf'; DeviceClass = 'System' }
+                )
+            }
+            if ($ClassName -eq 'Win32_LogicalDisk') {
+                return $logicalDisk
+            }
+        }
+        Mock Get-CimAssociatedInstance {
+            param($Association)
+            if ($Association -eq 'Win32_LogicalDiskToPartition') {
+                return $partition
+            }
+            return [pscustomobject]@{ PNPDeviceID = 'SCSI\DISK0' }
+        }
+        Mock Get-PnpDeviceProperty {
+            param($InstanceId)
+            $parentByDeviceId = @{ 'SCSI\DISK0' = 'PCI\STORAGE0'; 'PCI\STORAGE0' = 'PCI\ROOTPORT0' }
+            [pscustomobject]@{ Data = $parentByDeviceId[$InstanceId] }
+        }
+        function pnputil.exe { throw 'PnPUtil should not run for a device outside the storage-enumeration classes.' }
+
+        try {
+            $logs = [System.Collections.Generic.List[string]]::new()
+            @(Get-WinUtilISOActiveStorageDriverMapping -Logger { param($message) $null = $logs.Add([string]$message) }).Count | Should -Be 0
+            Should -Invoke Get-PnpDeviceProperty -Times 2 -Exactly
+            ($logs -join '|') | Should -Not -Match 'oem2\.inf'
+            ($logs -join '|') | Should -Match "Stopped at PnP ancestor 'PCI\\ROOTPORT0' outside the storage-enumeration device classes"
+        } finally {
+            Remove-Item Function:\pnputil.exe -ErrorAction SilentlyContinue
+        }
+    }
+
+    It "includes an OEM controller two hops above the disk when every ancestor is a storage-enumeration class" {
+        . ([scriptblock]::Create($script:driverClassifierFunctions[1]))
+
+        $logicalDisk = New-CimInstance -ClassName Win32_LogicalDisk -ClientOnly -Property @{ DeviceID = $env:SystemDrive }
+        $partition = New-CimInstance -ClassName Win32_DiskPartition -ClientOnly -Property @{ DeviceID = 'Disk #0, Partition #1' }
+        Mock Get-CimInstance {
+            param($ClassName)
+            if ($ClassName -eq 'Win32_PnPSignedDriver') {
+                return @(
+                    [pscustomobject]@{ DeviceID = 'SCSI\DISK0'; InfName = 'disk.inf'; DeviceClass = 'DiskDrive' },
+                    [pscustomobject]@{ DeviceID = 'PCI\NVME0'; InfName = 'stornvme.inf'; DeviceClass = 'SCSIAdapter' },
+                    [pscustomobject]@{ DeviceID = 'PCI\VMD0'; InfName = 'oem5.inf'; DeviceClass = 'SCSIAdapter' }
+                )
+            }
+            if ($ClassName -eq 'Win32_LogicalDisk') {
+                return $logicalDisk
+            }
+        }
+        Mock Get-CimAssociatedInstance {
+            param($Association)
+            if ($Association -eq 'Win32_LogicalDiskToPartition') {
+                return $partition
+            }
+            return [pscustomobject]@{ PNPDeviceID = 'SCSI\DISK0' }
+        }
+        Mock Get-PnpDeviceProperty {
+            param($InstanceId)
+            $parentByDeviceId = @{ 'SCSI\DISK0' = 'PCI\NVME0'; 'PCI\NVME0' = 'PCI\VMD0' }
+            [pscustomobject]@{ Data = $parentByDeviceId[$InstanceId] }
+        }
+        function pnputil.exe {
+            $global:LASTEXITCODE = 0
+            'DriverName,OriginalName,ProviderName'
+            '"oem5.inf","iaStorAVC.inf","Intel"'
+        }
+
+        try {
+            $logs = [System.Collections.Generic.List[string]]::new()
+            $mappings = @(Get-WinUtilISOActiveStorageDriverMapping -Logger { param($message) $null = $logs.Add([string]$message) })
+
+            $mappings.Count | Should -Be 1
+            $mappings[0].PublishedInfName | Should -Be 'oem5.inf'
+            $mappings[0].OriginalInfName | Should -Be 'iaStorAVC.inf'
+            Should -Invoke Get-PnpDeviceProperty -Times 3 -Exactly
         } finally {
             Remove-Item Function:\pnputil.exe -ErrorAction SilentlyContinue
         }


### PR DESCRIPTION
## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [x] Refactor
- [ ] UI/UX improvement

## Description

This is a small tightening pass on the Win11 Creator driver handling. A separate, broader PR will update the Win11 Creator docs, since they've gone stale since the last big refactor.

- WinPE storage driver classification now walks the active disk's PnP parent chain and stops climbing once it hits a device outside a known storage-enumeration set (DiskDrive, SCSIAdapter, HDC, USB, SDHost, PCMCIA). Chipset/platform "System" devices, ACPI, and generic PCI bridges no longer get pulled into WinPE staging just because they sit in the ancestry.
- The driver package inventory now reuses the INF list from the export step instead of rescanning the export folder again.
- `UseConfigurationSet` is now set to `false` in autounattend.xml. We only use a plain autounattend.xml plus the existing OEM/script staging, we don't build an actual configuration-set layout, so leaving it `true` told Windows Setup to apply configuration-set semantics we don't need and could make it look for media resources that aren't there.
- Two Win11ISO log/error messages still said "install.wim modification" from before the refactor. Reworded to match what's actually happening (setup media preparation).

## Verification

- `.\Compile.ps1`: generates cleanly.
- `Invoke-ScriptAnalyzer -Path . -Settings .\lint\PSScriptAnalyser.ps1 -Recurse`: no new warnings in the changed files, only pre-existing plural-noun warnings already accepted repo-wide.
- Ran the full test suite and verified in a VM install. Changes here are small, so this was a light pass rather than an exhaustive one.

## Issue related to PR
- Resolves #