### PR TITLE
Add Cloudflare WARP to Pro Tools

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -2039,5 +2039,14 @@
         "content": "Lua",
         "link": "https://github.com/rjpcomputing/luaforwindows",
         "foss": true
+    },
+    "CloudflareWARP": {
+        "category":"Pro Tools",
+        "choco": "warp",
+        "winget": "Cloudflare.Warp",
+        "description": "The Cloudflare WARP client allows individuals to have a faster, more secure, and more private experience online.",
+        "content": "Cloudflare WARP",
+        "link": "https://developers.cloudflare.com/warp-client/",
+        "foss": false
     }
 }


### PR DESCRIPTION
## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactor
- [ ] UI/UX improvement

## Description

Added Cloudflare WARP to the WinUtil Pro Tools section.

Changes:
- Added Cloudflare WARP application entry to `config/applications.json`
- Added category, description, Winget ID, Chocolatey package ID, and official download link
- Allows users to easily install Cloudflare WARP through WinUtil

Cloudflare WARP provides a faster, more secure, and more private internet connection by using Cloudflare's network.

## Issue related to PR

No related issue.

## Testing

- Verified the application appears correctly in WinUtil.
- Verified Cloudflare WARP installs successfully through Winget.
- Verified Cloudflare WARP installs successfully through Chocolatey.