### PR TITLE
Add tweak to block Logitech Download Assistant auto-install

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -1001,6 +1001,33 @@
     ],
     "link": "https://winutil.christitus.com/code-reference/tweaks/z--advanced-tweaks---caution/razerblock"
   },
+  "WPFTweaksLogiBlock": {
+    "Content": "Logitech Download Assistant Auto-Install - Disable",
+    "Description": "Blocks the Logi Download Assistant that Windows Update keeps reinstalling with Logitech device drivers. Logitech hardware keeps working without it.",
+    "category": "z__Advanced Tweaks - CAUTION",
+    "panel": "1",
+    "InvokeScript": [
+      "
+      Stop-Process -Name \"logi_download_assistant\" -Force -ErrorAction SilentlyContinue
+
+      $LogiPath = \"$Env:ProgramFiles\\LogiDownloadAssistant\"
+
+      if (Test-Path $LogiPath) {
+        Remove-Item $LogiPath\\* -Recurse -Force
+      } else {
+        New-Item -Path $LogiPath -ItemType Directory
+      }
+
+      icacls $LogiPath /deny \"Everyone:(W)\"
+      "
+    ],
+    "UndoScript": [
+      "
+      icacls \"$Env:ProgramFiles\\LogiDownloadAssistant\" /remove:d Everyone
+      "
+    ],
+    "link": "https://winutil.christitus.com/code-reference/tweaks/z--advanced-tweaks---caution/logiblock"
+  },
   "WPFTweaksDisableNotifications": {
     "Content": "System Tray Notifications & Calendar - Disable",
     "Description": "Disables all Notifications INCLUDING Calendar.",

--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -1010,7 +1010,8 @@
       "
       Stop-Process -Name \"logi_download_assistant\" -Force -ErrorAction SilentlyContinue
 
-      $LogiPath = \"$Env:ProgramFiles\\LogiDownloadAssistant\"
+      $ProgramFiles64 = if ($Env:ProgramW6432) { $Env:ProgramW6432 } else { $Env:ProgramFiles }
+      $LogiPath = \"$ProgramFiles64\\LogiDownloadAssistant\"
 
       if (Test-Path $LogiPath) {
         Remove-Item $LogiPath\\* -Recurse -Force
@@ -1018,12 +1019,19 @@
         New-Item -Path $LogiPath -ItemType Directory
       }
 
-      icacls $LogiPath /deny \"Everyone:(W)\"
+      icacls $LogiPath /deny \"*S-1-1-0:(W)\"
+      if ($LASTEXITCODE -ne 0) { throw \"icacls failed to deny write access on $LogiPath (exit code $LASTEXITCODE)\" }
       "
     ],
     "UndoScript": [
       "
-      icacls \"$Env:ProgramFiles\\LogiDownloadAssistant\" /remove:d Everyone
+      $ProgramFiles64 = if ($Env:ProgramW6432) { $Env:ProgramW6432 } else { $Env:ProgramFiles }
+      $LogiPath = \"$ProgramFiles64\\LogiDownloadAssistant\"
+
+      if (Test-Path $LogiPath) {
+        icacls $LogiPath /remove:d \"*S-1-1-0\"
+        if ($LASTEXITCODE -ne 0) { throw \"icacls failed to remove the write-deny rule on $LogiPath (exit code $LASTEXITCODE)\" }
+      }
       "
     ],
     "link": "https://winutil.christitus.com/code-reference/tweaks/z--advanced-tweaks---caution/logiblock"


### PR DESCRIPTION
## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactor
- [ ] UI/UX improvement

## Description

Adds `WPFTweaksLogiBlock`, a CAUTION-category tweak that stops Windows Update from re-delivering the Logi Download Assistant alongside Logitech device drivers.

It mirrors the `WPFTweaksRazerBlock` folder-deny approach:

- Stops the running `logi_download_assistant` process if present.
- Clears `C:\Program Files\LogiDownloadAssistant` (or pre-creates it empty when not installed).
- Denies `Everyone:(W)` on the folder via icacls so the software-component driver package cannot write the payload back.
- `UndoScript` removes the deny ACE, restoring normal behavior.

Deliberately narrower than the Razer tweak: no global `SearchOrderConfig`/`DisableCoInstallers` registry changes, since those alter driver search system-wide and do not stop software-component packages anyway. Approach was outlined in the issue before implementation.

**Verification:** `.\Compile.ps1` succeeds; full Pester suite passes 581/581 on current `main` plus this change; the icacls deny/undo cycle was functionally tested against a sandbox folder (write blocked after invoke, restored after undo). Not yet soak-tested against a real Logitech driver update cycle.

## Issue related to PR
- Resolves #5029