### PR TITLE
Preserve clipboard history when disabling activity history

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -1,7 +1,7 @@
 {
   "WPFTweaksActivity": {
     "Content": "Activity History - Disable",
-    "Description": "Erases recent docs, clipboard, and run history.",
+    "Description": "Disables the Activity Feed system (docs, clipboard history, run history, and activity sync).",
     "category": "Essential Tweaks",
     "panel": "1",
     "registry": [

--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -1,14 +1,14 @@
 {
   "WPFTweaksActivity": {
     "Content": "Activity History - Disable",
-    "Description": "Disables the Activity Feed system (docs, clipboard history, run history, and activity sync).",
+    "Description": "Stops Windows from publishing or uploading user activities while preserving clipboard history.",
     "category": "Essential Tweaks",
     "panel": "1",
     "registry": [
       {
         "Path": "HKLM:\\SOFTWARE\\Policies\\Microsoft\\Windows\\System",
         "Name": "EnableActivityFeed",
-        "Value": "0",
+        "Value": "1",
         "Type": "DWord",
         "OriginalValue": "<RemoveEntry>"
       },

--- a/pester/activity-history.Tests.ps1
+++ b/pester/activity-history.Tests.ps1
@@ -1,0 +1,19 @@
+Describe "Activity history config" {
+    It "disables activity publishing while preserving clipboard history" {
+        $configPath = Join-Path $PSScriptRoot "..\config\tweaks.json"
+        $tweaks = Get-Content -Path $configPath -Raw | ConvertFrom-Json
+        $activityRegistry = @($tweaks.WPFTweaksActivity.registry)
+
+        $activityFeed = @($activityRegistry | Where-Object Name -eq "EnableActivityFeed")
+        $activityFeed | Should -HaveCount 1
+        $activityFeed[0].Value | Should -Be "1"
+
+        foreach ($policyName in @("PublishUserActivities", "UploadUserActivities")) {
+            $policy = @($activityRegistry | Where-Object Name -eq $policyName)
+            $policy | Should -HaveCount 1
+            $policy[0].Value | Should -Be "0"
+        }
+
+        $activityRegistry.Name | Should -Not -Contain "AllowClipboardHistory"
+    }
+}


### PR DESCRIPTION
## Type of Change
- [x] UI/UX improvement
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor

## Description

The "Activity History - Disable" tweak previously set `EnableActivityFeed = 0`. On affected Windows 10 and 11 systems, that also disables the Win+V clipboard history and can mark the setting as managed by an organization.

This update:

- Sets `EnableActivityFeed = 1` so applying the tweak preserves clipboard history and repairs the policy value left by earlier versions.
- Keeps `PublishUserActivities = 0` and `UploadUserActivities = 0`, so Windows still cannot publish or upload user activities.
- Updates the tooltip to describe the narrower behavior accurately.
- Adds a regression test for the three policy values and verifies that `AllowClipboardHistory` is not disabled.

The generated tweak documentation is intentionally not edited; it is regenerated after source changes merge.

Microsoft documents these as separate policies: [EnableActivityFeed, PublishUserActivities, and UploadUserActivities](https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-privacy) control activity publication/upload, while [AllowClipboardHistory](https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-experience#allowclipboardhistory) controls local clipboard-history storage.

## Related issue

- Related context: #5023

## Verification

- `.\Compile.ps1` passed on the PR branch and on a synthetic merge with current `main` (`87dd6431`).
- Focused Pester 5.8.0 regression test passed: 1/1.
- Full Pester 5.8.0 suite passed on the PR branch: 582/582.
- Full Pester 5.8.0 suite passed on the synthetic merge: 595/595.
- ScriptAnalyzer reported no diagnostics in the new test; the full-tree run contains only the repository's existing warnings.
- Built-in Codex review found no actionable defects.
- Synthetic merge completed without conflicts and `git diff --check` passed.

## Manual testing

No host registry policies were changed during validation. The behavior is covered by the config regression test and checked against Microsoft's policy definitions; an end-to-end Win+V test on a disposable Windows VM remains recommended.
