### PR TITLE
Fix icacls tweaks on localized Windows installations

### DIFF
--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -99,10 +99,10 @@
     "category": "Essential Tweaks",
     "panel": "1",
     "InvokeScript": [
-      "icacls \"$Env:LocalAppData\\Packages\\Microsoft.WindowsStore_8wekyb3d8bbwe\\LocalState\\store.db\" /deny Everyone:F"
+      "icacls \"$Env:LocalAppData\\Packages\\Microsoft.WindowsStore_8wekyb3d8bbwe\\LocalState\\store.db\" /deny *S-1-1-0:F"
     ],
     "UndoScript": [
-      "icacls \"$Env:LocalAppData\\Packages\\Microsoft.WindowsStore_8wekyb3d8bbwe\\LocalState\\store.db\" /grant Everyone:F"
+      "icacls \"$Env:LocalAppData\\Packages\\Microsoft.WindowsStore_8wekyb3d8bbwe\\LocalState\\store.db\" /grant *S-1-1-0:F"
     ],
     "link": "https://winutil.christitus.com/code-reference/tweaks/essential-tweaks/disablestoresearch"
   },
@@ -647,7 +647,7 @@
     "InvokeScript": [
       "
       # Deny permission to remove OneDrive folder
-      icacls $Env:OneDrive /deny \"Administrators:(D,DC)\"
+      icacls $Env:OneDrive /deny \"*S-1-5-32-544:(D,DC)\"
 
       Write-Host \"Uninstalling OneDrive...\"
       Start-Process -FilePath (Join-Path $Env:SystemRoot \"System32\\OneDriveSetup.exe\") -ArgumentList '/uninstall' -Wait
@@ -661,7 +661,7 @@
       Remove-Item \"$Env:ProgramData\\Microsoft OneDrive\" -Recurse -Force
 
       # Grant back permission to access OneDrive folder
-      icacls $Env:OneDrive /grant \"Administrators:(D,DC)\"
+      icacls $Env:OneDrive /grant \"*S-1-5-32-544:(D,DC)\"
 
       if (-not (Get-ChildItem -Path $Env:OneDrive)) {
           Remove-Item -Path $Env:OneDrive -Recurse
@@ -991,12 +991,12 @@
         New-Item -Path $RazerPath -ItemType Directory
       }
 
-      icacls $RazerPath /deny \"Everyone:(W)\"
+      icacls $RazerPath /deny \"*S-1-1-0:(W)\"
       "
     ],
     "UndoScript": [
       "
-      icacls \"$Env:SystemRoot\\Installer\\Razer\" /remove:d Everyone
+      icacls \"$Env:SystemRoot\\Installer\\Razer\" /remove:d *S-1-1-0
       "
     ],
     "link": "https://winutil.christitus.com/code-reference/tweaks/z--advanced-tweaks---caution/razerblock"

--- a/pester/configs.Tests.ps1
+++ b/pester/configs.Tests.ps1
@@ -227,6 +227,37 @@ Describe "Tweaks config" {
         $locationServices | Should -HaveCount 1
         $locationServices[0].StartupType | Should -Be "Disabled"
     }
+
+    $icaclsPrincipalCases = @(
+        @{
+            Path          = (Join-Path $configRoot "tweaks.json")
+            Tweak         = "WPFTweaksDisableStoreSearch"
+            Sid           = '*S-1-1-0'
+            ExpectedCount = 2
+        }
+        @{
+            Path          = (Join-Path $configRoot "tweaks.json")
+            Tweak         = "WPFTweaksRazerBlock"
+            Sid           = '*S-1-1-0'
+            ExpectedCount = 2
+        }
+        @{
+            Path          = (Join-Path $configRoot "tweaks.json")
+            Tweak         = "WPFTweaksRemoveOneDrive"
+            Sid           = '*S-1-5-32-544'
+            ExpectedCount = 2
+        }
+    )
+
+    It "identifies the <Tweak> icacls principal by SID" -TestCases $icaclsPrincipalCases {
+        param([string]$Path, [string]$Tweak, [string]$Sid, [int]$ExpectedCount)
+
+        $tweaks = Get-Content -Path $Path -Raw | ConvertFrom-Json
+        $scripts = (@($tweaks.$Tweak.InvokeScript) + @($tweaks.$Tweak.UndoScript)) -join "`n"
+        $sidCount = ([regex]::Matches($scripts, [regex]::Escape($Sid))).Count
+
+        $sidCount | Should -Be $ExpectedCount -Because "$Tweak must pass $Sid to icacls at every call site instead of a localized account name"
+    }
 }
 
 Describe "Preset config" {


### PR DESCRIPTION
## Type of Change

* [ ] New feature
* [x] Bug fix
* [ ] Documentation update
* [ ] Refactor
* [ ] UI/UX improvement

## Description

Several tweaks pass English built in account names such as `Everyone` and `Administrators` to `icacls`. Windows localizes these names, causing the commands to fail with `ERROR_NONE_MAPPED` on non English installations.

Replace the localized names with their well known SIDs:

* `Everyone` → `*S-1-1-0`
* `Administrators` → `*S-1-5-32-544`

This updates every affected `icacls` command in:

* `WPFTweaksDisableStoreSearch`
* `WPFTweaksRazerBlock`
* `WPFTweaksRemoveOneDrive`

Only the principal identifiers change. The existing `/deny`, `/grant` and `/remove:d` operations remain unchanged, keeping ACL lifecycle behavior outside the scope of this localization fix.

This follows the existing SID based pattern in `Invoke-WinUtilSSHServer.ps1`.

Added Pester coverage requiring the expected well known SID at every affected icacls call site.

Verified with:

* 584 Pester tests passing
* Successful `Compile.ps1` execution
* Generated and embedded scripts parsing without errors
* No new ScriptAnalyzer diagnostics
* `git diff --check`

## Issue related to PR

* Resolves #5039
