### PR TITLE
chore(dns): remove Mullvad DNS providers

### DIFF
--- a/config/dns.json
+++ b/config/dns.json
@@ -54,59 +54,5 @@
         "Primary6": "2a10:50c0::bad1:ff",
         "Secondary6": "2a10:50c0::bad2:ff",
         "DohTemplate": "https://family.adguard-dns.com/dns-query"
-    },
-    "Mullvad":{
-        "Primary": "194.242.2.2",
-        "Secondary": "194.242.2.3",
-        "Primary6": "2a07:e340::2",
-        "Secondary6": "2a07:e340::3",
-        "DohOnly": true,
-        "DohTemplate": "https://dns.mullvad.net/dns-query",
-        "SecondaryDohTemplate": "https://adblock.dns.mullvad.net/dns-query"
-    },
-    "Mullvad_Ads_Trackers":{
-        "Primary": "194.242.2.3",
-        "Secondary": "194.242.2.2",
-        "Primary6": "2a07:e340::3",
-        "Secondary6": "2a07:e340::2",
-        "DohOnly": true,
-        "DohTemplate": "https://adblock.dns.mullvad.net/dns-query",
-        "SecondaryDohTemplate": "https://dns.mullvad.net/dns-query"
-    },
-    "Mullvad_Ads_Trackers_Malware":{
-        "Primary": "194.242.2.4",
-        "Secondary": "194.242.2.3",
-        "Primary6": "2a07:e340::4",
-        "Secondary6": "2a07:e340::3",
-        "DohOnly": true,
-        "DohTemplate": "https://base.dns.mullvad.net/dns-query",
-        "SecondaryDohTemplate": "https://adblock.dns.mullvad.net/dns-query"
-    },
-    "Mullvad_Ads_Trackers_Malware_Social":{
-        "Primary": "194.242.2.5",
-        "Secondary": "194.242.2.4",
-        "Primary6": "2a07:e340::5",
-        "Secondary6": "2a07:e340::4",
-        "DohOnly": true,
-        "DohTemplate": "https://extended.dns.mullvad.net/dns-query",
-        "SecondaryDohTemplate": "https://base.dns.mullvad.net/dns-query"
-    },
-    "Mullvad_Ads_Trackers_Malware_Adult_Gambling":{
-        "Primary": "194.242.2.6",
-        "Secondary": "194.242.2.5",
-        "Primary6": "2a07:e340::6",
-        "Secondary6": "2a07:e340::5",
-        "DohOnly": true,
-        "DohTemplate": "https://family.dns.mullvad.net/dns-query",
-        "SecondaryDohTemplate": "https://extended.dns.mullvad.net/dns-query"
-    },
-    "Mullvad_Ads_Trackers_Malware_Adult_Gambling_Social":{
-        "Primary": "194.242.2.9",
-        "Secondary": "194.242.2.6",
-        "Primary6": "2a07:e340::9",
-        "Secondary6": "2a07:e340::6",
-        "DohOnly": true,
-        "DohTemplate": "https://all.dns.mullvad.net/dns-query",
-        "SecondaryDohTemplate": "https://family.dns.mullvad.net/dns-query"
     }
 }

--- a/config/tweaks.json
+++ b/config/tweaks.json
@@ -1885,7 +1885,7 @@
     "category": "z__Advanced Tweaks - CAUTION",
     "panel": "1",
     "Type": "Combobox",
-    "ComboItems": "Default DHCP Google Cloudflare Cloudflare_Malware Cloudflare_Malware_Adult Open_DNS Quad9 AdGuard_Ads_Trackers AdGuard_Ads_Trackers_Malware_Adult Mullvad Mullvad_Ads_Trackers Mullvad_Ads_Trackers_Malware Mullvad_Ads_Trackers_Malware_Social Mullvad_Ads_Trackers_Malware_Adult_Gambling Mullvad_Ads_Trackers_Malware_Adult_Gambling_Social",
+    "ComboItems": "Default DHCP Google Cloudflare Cloudflare_Malware Cloudflare_Malware_Adult Open_DNS Quad9 AdGuard_Ads_Trackers AdGuard_Ads_Trackers_Malware_Adult",
     "link": "https://winutil.christitus.com/code-reference/tweaks/z--advanced-tweaks---caution/changedns"
   },
   "WPFAddUltPerf": {

--- a/docs/src/content/docs/guides/tweaks.mdx
+++ b/docs/src/content/docs/guides/tweaks.mdx
@@ -73,14 +73,6 @@ Use the DNS section to switch both IPv4 and IPv6 DNS providers without editing a
 * [**Quad9**](https://quad9.net/): Focuses on security by blocking known malicious domains.
 * [**AdGuard_Ads_Trackers**](https://adguard-dns.io/en/welcome.html): AdGuard DNS blocks ads, trackers, and other unwanted DNS requests. Visit the website and sign in for a dashboard, statistics, and additional server-side customization.
 * [**AdGuard_Ads_Trackers_Malware_Adult**](https://adguard-dns.io/en/welcome.html): AdGuard DNS blocks ads, trackers, malware, and adult content, and enables Safe Search and Safe Mode where possible.
-* [**Mullvad**](https://mullvad.net/en/help/dns-over-https-and-dns-over-tls): Mullvad DNS without content blocking.
-* [**Mullvad_Ads_Trackers**](https://mullvad.net/en/help/dns-over-https-and-dns-over-tls): Blocks ads and trackers.
-* [**Mullvad_Ads_Trackers_Malware**](https://mullvad.net/en/help/dns-over-https-and-dns-over-tls): Blocks ads, trackers, and malware.
-* [**Mullvad_Ads_Trackers_Malware_Social**](https://mullvad.net/en/help/dns-over-https-and-dns-over-tls): Blocks ads, trackers, malware, and social media.
-* [**Mullvad_Ads_Trackers_Malware_Adult_Gambling**](https://mullvad.net/en/help/dns-over-https-and-dns-over-tls): Blocks ads, trackers, malware, adult content, and gambling.
-* [**Mullvad_Ads_Trackers_Malware_Adult_Gambling_Social**](https://mullvad.net/en/help/dns-over-https-and-dns-over-tls): Applies all available Mullvad filters.
-
-Mullvad profiles require DNS over HTTPS support in Windows. If the selected primary resolver is unavailable, WinUtil uses the closest Mullvad secondary resolver to preserve connectivity; that fallback may use a different filtering level and can be less restrictive.
 
 ### Customize Preferences
 

--- a/pester/dns.Tests.ps1
+++ b/pester/dns.Tests.ps1
@@ -53,22 +53,22 @@ Describe "Set-WinUtilDNS" {
                         Secondary6 = "2606:4700:4700::1001"
                         DohTemplate = "https://cloudflare-dns.com/dns-query"
                     }
-                    Mullvad = [pscustomobject]@{
-                        Primary = "194.242.2.2"
-                        Secondary = "194.242.2.3"
-                        Primary6 = "2a07:e340::2"
-                        Secondary6 = "2a07:e340::3"
+                    DohOnlyProvider = [pscustomobject]@{
+                        Primary = "192.0.2.1"
+                        Secondary = "192.0.2.2"
+                        Primary6 = "2001:db8::1"
+                        Secondary6 = "2001:db8::2"
                         DohOnly = $true
-                        DohTemplate = "https://dns.mullvad.net/dns-query"
-                        SecondaryDohTemplate = "https://adblock.dns.mullvad.net/dns-query"
+                        DohTemplate = "https://doh.example.com/dns-query"
+                        SecondaryDohTemplate = "https://secondary.doh.example.com/dns-query"
                     }
-                    MullvadNoSecondary = [pscustomobject]@{
-                        Primary = "194.242.2.2"
+                    DohOnlyNoSecondary = [pscustomobject]@{
+                        Primary = "192.0.2.1"
                         Secondary = ""
-                        Primary6 = "2a07:e340::2"
+                        Primary6 = "2001:db8::1"
                         Secondary6 = ""
                         DohOnly = $true
-                        DohTemplate = "https://dns.mullvad.net/dns-query"
+                        DohTemplate = "https://doh.example.com/dns-query"
                     }
                 }
             }
@@ -151,58 +151,58 @@ Describe "Set-WinUtilDNS" {
     }
 
     It "filters empty DNS server addresses" {
-        Set-WinUtilDNS -DNSProvider "MullvadNoSecondary"
+        Set-WinUtilDNS -DNSProvider "DohOnlyNoSecondary"
 
         Should -Invoke -CommandName Set-DnsClientServerAddress -Times 1 -Exactly -ParameterFilter {
             $InterfaceIndex -eq 7 -and
                 $ServerAddresses.Count -eq 1 -and
-                $ServerAddresses[0] -eq "194.242.2.2"
+                $ServerAddresses[0] -eq "192.0.2.1"
         }
         Should -Invoke -CommandName Set-DnsClientServerAddress -Times 1 -Exactly -ParameterFilter {
             $InterfaceIndex -eq 7 -and
                 $ServerAddresses.Count -eq 1 -and
-                $ServerAddresses[0] -eq "2a07:e340::2"
+                $ServerAddresses[0] -eq "2001:db8::1"
         }
         Should -Invoke -CommandName Add-DnsClientDohServerAddress -Times 2 -Exactly
     }
 
     It "applies the matching DoH template to secondary resolvers" {
-        Set-WinUtilDNS -DNSProvider "Mullvad"
+        Set-WinUtilDNS -DNSProvider "DohOnlyProvider"
 
         Should -Invoke -CommandName Add-DnsClientDohServerAddress -Times 2 -Exactly -ParameterFilter {
-            $ServerAddress -in @("194.242.2.2", "2a07:e340::2") -and
-                $DohTemplate -eq "https://dns.mullvad.net/dns-query"
+            $ServerAddress -in @("192.0.2.1", "2001:db8::1") -and
+                $DohTemplate -eq "https://doh.example.com/dns-query"
         }
         Should -Invoke -CommandName Add-DnsClientDohServerAddress -Times 2 -Exactly -ParameterFilter {
-            $ServerAddress -in @("194.242.2.3", "2a07:e340::3") -and
-                $DohTemplate -eq "https://adblock.dns.mullvad.net/dns-query"
+            $ServerAddress -in @("192.0.2.2", "2001:db8::2") -and
+                $DohTemplate -eq "https://secondary.doh.example.com/dns-query"
         }
     }
 
     It "does not apply a DoH-only provider when DoH is unsupported" {
         Mock Get-Command { return $null } -ParameterFilter { $Name -eq "Add-DnsClientDohServerAddress" }
 
-        $result = Set-WinUtilDNS -DNSProvider "Mullvad"
+        $result = Set-WinUtilDNS -DNSProvider "DohOnlyProvider"
 
         $result | Should -BeFalse
         Should -Invoke -CommandName Set-DnsClientServerAddress -Times 0 -Exactly
         Should -Invoke -CommandName Add-DnsClientDohServerAddress -Times 0 -Exactly
         Should -Invoke -CommandName Write-Warning -Times 1 -Exactly -ParameterFilter {
-            $Message -eq "DNS provider Mullvad requires DNS over HTTPS, which is not supported on this system."
+            $Message -eq "DNS provider DohOnlyProvider requires DNS over HTTPS, which is not supported on this system."
         }
     }
 
     It "does not change adapter DNS when DoH registration fails" {
         Mock Add-DnsClientDohServerAddress { throw "DoH registration failed" }
 
-        $result = Set-WinUtilDNS -DNSProvider "Mullvad"
+        $result = Set-WinUtilDNS -DNSProvider "DohOnlyProvider"
 
         $result | Should -BeFalse
         Should -Invoke -CommandName Set-DnsClientServerAddress -Times 0 -Exactly
         Should -Invoke -CommandName Write-WinUtilLog -Times 1 -Exactly -ParameterFilter {
             $Level -eq "ERROR" -and
                 $Component -eq "DNS" -and
-                $Message -like "DNS provider Mullvad was not completed: *"
+                $Message -like "DNS provider DohOnlyProvider was not completed: *"
         }
     }
 


### PR DESCRIPTION
## Type of Change
- [ ] New feature
- [ ] Bug fix
- [x] Documentation update
- [x] Refactor
- [ ] UI/UX improvement

## Description

Mullvad [announced](https://mullvad.net/en/blog/shutting-down-our-public-encrypted-dns-servers-and-sponsoring-quad9-instead) that it is shutting down its public encrypted DNS servers and sponsoring Quad9 instead. The six Mullvad profiles in the DNS combobox will resolve nothing once those servers go dark, so this removes them. Quad9 already ships as a provider, so users have a documented destination.

### What changed

- **`config/dns.json`** - removed all six Mullvad profiles. Eight providers remain.
- **`config/tweaks.json`** - removed the same six names from the `WPFchangedns` ComboItems. These two files are coupled: `pester/configs.Tests.ps1` asserts every provider in `dns.json` appears in the combobox, so changing one without the other fails the suite.
- **`docs/src/content/docs/guides/tweaks.mdx`** - removed the six bullets and the DoH-fallback paragraph from the DNS section.
- **`pester/dns.Tests.ps1`** - renamed the Mullvad test fixtures and swapped in documentation addresses (RFC 5737 / RFC 3849) and `example.com` templates.

### Notes for the reviewer

**Two config fields are now unreachable and can be deleted if you want them gone.** Mullvad was the only provider setting `DohOnly` and `SecondaryDohTemplate`, so the branches that read them in `functions/private/Set-WinUtilDNS.ps1` are no longer exercised by any shipped config:

- `Set-WinUtilDNS.ps1:37` - the DoH-unsupported early return
- `Set-WinUtilDNS.ps1:80-84` - the secondary-template selection, which would collapse to `$dns.DohTemplate`
- `Set-WinUtilDNS.ps1:102-104` - the rethrow when DoH registration fails

I left them alone to keep this PR scoped to the provider removal. Happy to strip them in a follow-up, or add a commit here if you would rather it land together. One wrinkle if anyone does: of the four tests using those fixtures, `pester/dns.Tests.ps1:153` ("filters empty DNS server addresses") is **not** about `DohOnly` at all. It covers the empty-address filtering that is still live for every provider, so it needs retargeting to a normal fixture rather than deleting with the others.

Only the hand-written guide page under `docs/guides/` is edited here, since the generator does not write that one.

### Verification

- Full Pester suite (5.8.0): **827 passed, 0 failed, 1 skipped**. The skip is the pre-existing UAC-prompt guard in `headless.Tests.ps1`, unrelated to this change.
- `.\Compile.ps1 -Run` succeeds and confirms the Mullvad entries are gone from the DNS section.

## Issue related to PR
N/A
