### PR TITLE
Add Syncthing

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -1609,6 +1609,15 @@
         "winget": "LizardByte.Sunshine",
         "foss": true
     },
+    "syncthing": {
+        "category": "Selfhosted Tools",
+        "choco": "syncthing",
+        "content": "Syncthing (CLI / Web UI)",
+        "description": "Syncthing is a decentralized, peer-to-peer file synchronization tool that securely syncs files directly across devices without cloud servers, managed via a local web interface.",
+        "link": "https://syncthing.net/",
+        "winget": "Syncthing.Syncthing",
+        "foss": true
+    },
     "tcpview": {
         "category": "Microsoft Tools",
         "choco": "tcpview",


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://winutil.christitus.com/contributing/ -->
<!--Documentation is auto-generated from configs - no manual documentation updates needed -->

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactor
- [ ] UI/UX improvement

<!-- This automatically adds labels to your PR based on the selections above. -->

## Description
Adds **Syncthing** to the `Selfhosted Tools` category. 

This PR specifically adds the official core Syncthing package, which runs as a background daemon and is managed via the local web interface (`http://localhost:8384`). 

*(Note: I have also opened a separate, parallel PR for `SyncTrayzor`, which is the native Windows GUI wrapper for Syncthing. Feel free to merge either one, or both, depending on whether WinUtil should offer the raw Web UI daemon, the native GUI wrapper, or both side-by-side!)*