### PR TITLE
Fix PowerShell MSI Upgrade Handling

### DIFF
--- a/functions/private/Install-WinUtilProgramWinget.ps1
+++ b/functions/private/Install-WinUtilProgramWinget.ps1
@@ -35,7 +35,7 @@ Function Update-WinUtilPowerShellMSI {
 
             if ($asset.digest) {
                 $hash = (Get-FileHash $msiPath -Algorithm SHA256).Hash.ToLower()
-                if ($hash -ne $asset.digest.Replace("sha256:","").ToLower()) {
+                if ($hash -ne $asset.digest.Replace("sha256:", "").ToLower()) {
                     throw "PowerShell MSI SHA256 verification failed"
                 }
             }
@@ -46,7 +46,7 @@ Function Update-WinUtilPowerShellMSI {
             }
 
             $install = Start-Process msiexec.exe -ArgumentList "/i `"$msiPath`" /qn /norestart" -Wait -PassThru
-            if ($install.ExitCode -notin @(0,3010,1641)) {
+            if ($install.ExitCode -notin @(0, 3010, 1641)) {
                 throw "PowerShell MSI installation failed with exit code $($install.ExitCode)"
             }
 
@@ -133,10 +133,10 @@ Function Install-WinUtilProgramWinget {
 
         $arguments = switch ($Action) {
             "Uninstall" { @("uninstall", "--id", $program, "--source", $source, "--silent") }
+            # --include-unknown because the scan that found these ran with it: without it winget
+            # refuses every package whose installed version it could not read
             "Upgrade" {
                 if ($upgradeAll) {
-                    # --include-unknown because the scan that found these ran with it: without it winget
-                    # refuses every package whose installed version it could not read
                     @("upgrade", "--all", "--accept-package-agreements", "--accept-source-agreements", "--include-unknown", "--silent")
                 } else {
                     @("upgrade", "--id", $program, "--accept-package-agreements", "--accept-source-agreements", "--source", $source, "--include-unknown", "--silent")

--- a/functions/private/Install-WinUtilProgramWinget.ps1
+++ b/functions/private/Install-WinUtilProgramWinget.ps1
@@ -9,7 +9,10 @@ Function Update-WinUtilPowerShellMSI {
         Select-Object -First 1
 
     if (-not $msi) {
-        return $false
+        return [pscustomobject]@{
+            State = "NotInstalled"
+            Detail = "PowerShell is not installed through MSI"
+        }
     }
 
     try {
@@ -20,7 +23,10 @@ Function Update-WinUtilPowerShellMSI {
 
         if ($installed -and $latest -and [version]$installed -ge [version]$latest) {
             Write-WinUtilLog -Component "Package" -Message "PowerShell is already current ($installed)"
-            return $true
+            return [pscustomobject]@{
+                State = "Succeeded"
+                Detail = "PowerShell $installed is already current"
+            }
         }
 
         $asset = $release.assets | Where-Object { $_.name -match "^PowerShell-.*-win-$arch\.msi$" } | Select-Object -First 1
@@ -41,7 +47,11 @@ Function Update-WinUtilPowerShellMSI {
             }
 
             $signature = Get-AuthenticodeSignature $msiPath
-            if ($signature.Status -ne "Valid" -or $signature.SignerCertificate.Subject -notmatch "Microsoft") {
+            if (
+                $signature.Status -ne "Valid" -or
+                -not $signature.SignerCertificate -or
+                $signature.SignerCertificate.Subject -notmatch '(^|,\s*)CN=Microsoft Corporation(,|$)'
+            ) {
                 throw "PowerShell MSI signature verification failed"
             }
 
@@ -51,7 +61,10 @@ Function Update-WinUtilPowerShellMSI {
             }
 
             Write-WinUtilLog -Component "Package" -Message "PowerShell MSI upgrade succeeded (exit code $($install.ExitCode))"
-            return $true
+            return [pscustomobject]@{
+                State = "Succeeded"
+                Detail = "PowerShell MSI upgrade succeeded (exit code $($install.ExitCode))"
+            }
         }
         finally {
             Remove-Item $msiPath -Force -ErrorAction SilentlyContinue
@@ -59,7 +72,10 @@ Function Update-WinUtilPowerShellMSI {
     }
     catch {
         Write-WinUtilLog -Level "ERROR" -Component "Package" -Message "PowerShell MSI upgrade failed: $($_.Exception.Message)"
-        return $false
+        return [pscustomobject]@{
+            State = "Failed"
+            Detail = $_.Exception.Message
+        }
     }
 }
 
@@ -114,9 +130,30 @@ Function Install-WinUtilProgramWinget {
         }
 
         $upgradeAll = $Action -eq "Upgrade" -and $program -eq "all"
+        $powerShellMsiResult = $null
 
         if ($Action -eq "Upgrade" -and ($program -eq "Microsoft.PowerShell" -or $upgradeAll)) {
-            Update-WinUtilPowerShellMSI
+            $powerShellMsiResult = Update-WinUtilPowerShellMSI
+
+            if ($program -eq "Microsoft.PowerShell" -and $powerShellMsiResult.State -ne "NotInstalled") {
+                $outcome = if ($powerShellMsiResult.State -eq "Succeeded") { "Succeeded" } else { "Failed" }
+                $exitCode = if ($powerShellMsiResult.State -eq "Succeeded") { 0 } else { -1 }
+                $detail = $powerShellMsiResult.Detail
+                $level = if ($outcome -eq "Failed") { "ERROR" } else { "INFO" }
+
+                Write-WinUtilLog -Level $level -Component "Package" -Message "$Action PowerShell MSI package $($outcome.ToLowerInvariant()): $detail"
+
+                [pscustomobject]@{
+                    Package = $program
+                    Manager = "msi"
+                    Action = $Action
+                    ExitCode = $exitCode
+                    Outcome = $outcome
+                    Detail = $detail
+                }
+
+                continue
+            }
         }
 
         $source = if ($upgradeAll) { "all configured sources" } else { "winget" }

--- a/functions/private/Install-WinUtilProgramWinget.ps1
+++ b/functions/private/Install-WinUtilProgramWinget.ps1
@@ -1,3 +1,8 @@
+Function Get-WinUtilPowerShellVersion {
+    param ([string]$Path)
+    & $Path -NoLogo -NoProfile -Command '$PSVersionTable.PSVersion.ToString()'
+}
+
 Function Install-WinUtilProgramWinget {
     <#
 
@@ -5,8 +10,7 @@ Function Install-WinUtilProgramWinget {
         Installs or uninstalls packages with WinGet and reports the outcome of each one
 
     .DESCRIPTION
-        Emits one result object per package so the caller can tell what actually happened
-        rather than assuming the run succeeded.
+        Emits one result object per package so the caller can tell what actually happened.
 
         Runs one winget command per package so a failure names the package that failed rather
         than the whole batch. Progress moves per package: winget hides its own progress bar once
@@ -22,18 +26,13 @@ Function Install-WinUtilProgramWinget {
         [string[]]$Programs
     )
 
-    # APPINSTALLER_CLI_ERROR_ADMIN_CONTEXT_ACTION_PROHIBITED. WinGet refuses to act on a package
-    # that was installed in user scope while it is running elevated, and WinUtil is always
-    # elevated, so every per-user app answers this and nothing happens.
     $adminContextProhibited = -1978335107
 
-    # WinGet reports "there was nothing to do" through the exit code rather than as success
     $nothingToDo = @{
         -1978335135 = "already installed"
         -1978335189 = "no applicable update"
     }
-    # The installer worked and wants a restart to finish. Windows reports that as its own exit
-    # code rather than as zero, and treating it as a failure marks working installs as broken.
+
     $rebootExitCodes = @{
         3010 = "installed, a restart is needed to finish"
         1641 = "installed, the installer started a restart"
@@ -49,7 +48,87 @@ Function Install-WinUtilProgramWinget {
         }
 
         $upgradeAll = $Action -eq "Upgrade" -and $program -eq "all"
+
+        # WinGet cannot upgrade PowerShell when it was installed through MSI.
+        if ($Action -eq "Upgrade" -and ($program -eq "Microsoft.PowerShell" -or $upgradeAll)) {
+            $msi = Get-ItemProperty `
+                "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*" ,
+                "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*" `
+                -ErrorAction SilentlyContinue |
+                Where-Object {
+                    $_.WindowsInstaller -eq 1 -and
+                    $_.DisplayName -match "^PowerShell\s+7" -and
+                    $_.InstallLocation -and
+                    (Test-Path (Join-Path $_.InstallLocation "pwsh.exe"))
+                } |
+                Select-Object -First 1
+
+            if ($msi) {
+                try {
+                    $installed = Get-WinUtilPowerShellVersion (Join-Path $msi.InstallLocation "pwsh.exe")
+                    $arch = switch ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture) {
+                        "Arm64" { "arm64" }
+                        "X86"   { "x86" }
+                        default { "x64" }
+                    }
+
+                    $release = Invoke-RestMethod `
+                        "https://api.github.com/repos/PowerShell/PowerShell/releases/latest" `
+                        -TimeoutSec 30
+                    $latest = ([string]$release.tag_name).TrimStart("v")
+
+                    if ($installed -and $latest -and [version]$installed -ge [version]$latest) {
+                        Write-WinUtilLog -Component "Package" -Message "PowerShell is already current ($installed)"
+                    }
+                    else {
+                        $asset = $release.assets |
+                            Where-Object { $_.name -match "^PowerShell-.*-win-$arch\.msi$" } |
+                            Select-Object -First 1
+
+                        if (-not $asset) {
+                            throw "No PowerShell MSI found for $arch"
+                        }
+
+                        $msiPath = Join-Path $env:TEMP "PowerShell-$arch.msi"
+
+                        Invoke-WebRequest $asset.browser_download_url -OutFile $msiPath -TimeoutSec 300
+
+                        if ($asset.digest) {
+                            $hash = (Get-FileHash $msiPath -Algorithm SHA256).Hash.ToLower()
+                            if ($hash -ne $asset.digest.Replace("sha256:", "").ToLower()) {
+                                throw "PowerShell MSI SHA256 verification failed"
+                            }
+                        }
+
+                        $signature = Get-AuthenticodeSignature $msiPath
+                        if ($signature.Status -ne "Valid" -or
+                            $signature.SignerCertificate.Subject -notmatch "Microsoft") {
+                            throw "PowerShell MSI signature verification failed"
+                        }
+
+                        $install = Start-Process msiexec.exe `
+                            -ArgumentList "/i `"$msiPath`" /qn /norestart" `
+                            -Wait -PassThru
+
+                        Remove-Item $msiPath -Force -ErrorAction SilentlyContinue
+
+                        if ($install.ExitCode -notin @(0, 3010, 1641)) {
+                            throw "PowerShell MSI installation failed with exit code $($install.ExitCode)"
+                        }
+
+                        Write-WinUtilLog -Component "Package" `
+                            -Message "PowerShell MSI upgrade succeeded (exit code $($install.ExitCode))"
+                    }
+                }
+                catch {
+                    Write-WinUtilLog -Level "ERROR" -Component "Package" `
+                        -Message "PowerShell MSI upgrade failed: $($_.Exception.Message)"
+                }
+            }
+        }
+
         $source = if ($upgradeAll) { "all configured sources" } else { "winget" }
+
         if (-not $upgradeAll -and $program.StartsWith("msstore:", [System.StringComparison]::OrdinalIgnoreCase)) {
             $source = "msstore"
             $program = $program.Substring("msstore:".Length)
@@ -62,9 +141,9 @@ Function Install-WinUtilProgramWinget {
         $exitCode = -1
 
         $arguments = switch ($Action) {
-            "Uninstall" { @("uninstall", "--id", $program, "--source", $source, "--silent") }
-            # --include-unknown because the scan that found these ran with it: without it winget
-            # refuses every package whose installed version it could not read
+            "Uninstall" {
+                @("uninstall", "--id", $program, "--source", $source, "--silent")
+            }
             "Upgrade" {
                 if ($upgradeAll) {
                     @("upgrade", "--all", "--accept-package-agreements", "--accept-source-agreements", "--include-unknown", "--silent")
@@ -72,7 +151,9 @@ Function Install-WinUtilProgramWinget {
                     @("upgrade", "--id", $program, "--accept-package-agreements", "--accept-source-agreements", "--source", $source, "--include-unknown", "--silent")
                 }
             }
-            default     { @("install", "--id", $program, "--accept-package-agreements", "--accept-source-agreements", "--source", $source, "--silent") }
+            default {
+                @("install", "--id", $program, "--accept-package-agreements", "--accept-source-agreements", "--source", $source, "--silent")
+            }
         }
 
         $process = Start-Process -FilePath winget -ArgumentList $arguments -NoNewWindow -Wait -PassThru
@@ -96,8 +177,6 @@ Function Install-WinUtilProgramWinget {
             }
         } else {
             $outcome = "Failed"
-            # The client module reports the same failure as a bare HRESULT, so the hex form and
-            # Microsoft's own list serve both paths
             $detail = "WinGet reported 0x{0:X8}. See https://learn.microsoft.com/windows/package-manager/winget/returnCodes" -f $exitCode
         }
 

--- a/functions/private/Install-WinUtilProgramWinget.ps1
+++ b/functions/private/Install-WinUtilProgramWinget.ps1
@@ -3,10 +3,72 @@ Function Get-WinUtilPowerShellVersion {
     & $Path -NoLogo -NoProfile -Command '$PSVersionTable.PSVersion.ToString()'
 }
 
+Function Update-WinUtilPowerShellMSI {
+    $msi = Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*","HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*" -ErrorAction SilentlyContinue |
+        Where-Object { $_.WindowsInstaller -eq 1 -and $_.DisplayName -match "^PowerShell\s+7" -and $_.InstallLocation -and (Test-Path (Join-Path $_.InstallLocation "pwsh.exe")) } |
+        Select-Object -First 1
+
+    if (-not $msi) {
+        return $false
+    }
+
+    try {
+        $installed = Get-WinUtilPowerShellVersion (Join-Path $msi.InstallLocation "pwsh.exe")
+        $arch = ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture).ToString().ToLowerInvariant()
+        $release = Invoke-RestMethod "https://api.github.com/repos/PowerShell/PowerShell/releases/latest" -TimeoutSec 30
+        $latest = ([string]$release.tag_name).TrimStart("v")
+
+        if ($installed -and $latest -and [version]$installed -ge [version]$latest) {
+            Write-WinUtilLog -Component "Package" -Message "PowerShell is already current ($installed)"
+            return $true
+        }
+
+        $asset = $release.assets | Where-Object { $_.name -match "^PowerShell-.*-win-$arch\.msi$" } | Select-Object -First 1
+        if (-not $asset) {
+            throw "No PowerShell MSI found for $arch"
+        }
+
+        $msiPath = Join-Path $env:TEMP "PowerShell-$arch.msi"
+
+        try {
+            Invoke-WebRequest $asset.browser_download_url -OutFile $msiPath -TimeoutSec 300
+
+            if ($asset.digest) {
+                $hash = (Get-FileHash $msiPath -Algorithm SHA256).Hash.ToLower()
+                if ($hash -ne $asset.digest.Replace("sha256:","").ToLower()) {
+                    throw "PowerShell MSI SHA256 verification failed"
+                }
+            }
+
+            $signature = Get-AuthenticodeSignature $msiPath
+            if ($signature.Status -ne "Valid" -or $signature.SignerCertificate.Subject -notmatch "Microsoft") {
+                throw "PowerShell MSI signature verification failed"
+            }
+
+            $install = Start-Process msiexec.exe -ArgumentList "/i `"$msiPath`" /qn /norestart" -Wait -PassThru
+            if ($install.ExitCode -notin @(0,3010,1641)) {
+                throw "PowerShell MSI installation failed with exit code $($install.ExitCode)"
+            }
+
+            Write-WinUtilLog -Component "Package" -Message "PowerShell MSI upgrade succeeded (exit code $($install.ExitCode))"
+            return $true
+        }
+        finally {
+            Remove-Item $msiPath -Force -ErrorAction SilentlyContinue
+        }
+    }
+    catch {
+        Write-WinUtilLog -Level "ERROR" -Component "Package" -Message "PowerShell MSI upgrade failed: $($_.Exception.Message)"
+        return $false
+    }
+}
+
 Function Install-WinUtilProgramWinget {
     <#
+
     .SYNOPSIS
         Installs or uninstalls packages with WinGet and reports the outcome of each one
+
     .DESCRIPTION
         Emits one result object per package so the caller can tell what actually happened
         rather than assuming the run succeeded.
@@ -14,20 +76,29 @@ Function Install-WinUtilProgramWinget {
         Runs one winget command per package so a failure names the package that failed rather
         than the whole batch. Progress moves per package: winget hides its own progress bar once
         its output is redirected, so there is nothing to report from inside a single install.
+
     #>
     param (
         [Parameter(Mandatory=$true)]
         [ValidateSet("Install", "Uninstall", "Upgrade")]
         [string]$Action,
+
         [Parameter(Mandatory=$true)]
         [string[]]$Programs
     )
 
+    # APPINSTALLER_CLI_ERROR_ADMIN_CONTEXT_ACTION_PROHIBITED. WinGet refuses to act on a package
+    # that was installed in user scope while it is running elevated, and WinUtil is always
+    # elevated, so every per-user app answers this and nothing happens.
     $adminContextProhibited = -1978335107
+
+    # WinGet reports "there was nothing to do" through the exit code rather than as success
     $nothingToDo = @{
         -1978335135 = "already installed"
         -1978335189 = "no applicable update"
     }
+    # The installer worked and wants a restart to finish. Windows reports that as its own exit
+    # code rather than as zero, and treating it as a failure marks working installs as broken.
     $rebootExitCodes = @{
         3010 = "installed, a restart is needed to finish"
         1641 = "installed, the installer started a restart"
@@ -38,58 +109,14 @@ Function Install-WinUtilProgramWinget {
     }
 
     foreach ($program in $Programs) {
-        if ([string]::IsNullOrWhiteSpace($program) -or $program -eq "na") { continue }
+        if ([string]::IsNullOrWhiteSpace($program) -or $program -eq "na") {
+            continue
+        }
 
         $upgradeAll = $Action -eq "Upgrade" -and $program -eq "all"
 
         if ($Action -eq "Upgrade" -and ($program -eq "Microsoft.PowerShell" -or $upgradeAll)) {
-            $msi = Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*","HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*" -ErrorAction SilentlyContinue |
-                Where-Object { $_.WindowsInstaller -eq 1 -and $_.DisplayName -match "^PowerShell\s+7" -and $_.InstallLocation -and (Test-Path (Join-Path $_.InstallLocation "pwsh.exe")) } |
-                Select-Object -First 1
-
-            if ($msi) {
-                try {
-                    $installed = Get-WinUtilPowerShellVersion (Join-Path $msi.InstallLocation "pwsh.exe")
-                    $arch = switch ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture) {
-                        "Arm64" { "arm64" }
-                        "X86" { "x86" }
-                        default { "x64" }
-                    }
-                    $release = Invoke-RestMethod "https://api.github.com/repos/PowerShell/PowerShell/releases/latest" -TimeoutSec 30
-                    $latest = ([string]$release.tag_name).TrimStart("v")
-
-                    if ($installed -and $latest -and [version]$installed -ge [version]$latest) {
-                        Write-WinUtilLog -Component "Package" -Message "PowerShell is already current ($installed)"
-                    } else {
-                        $asset = $release.assets | Where-Object { $_.name -match "^PowerShell-.*-win-$arch\.msi$" } | Select-Object -First 1
-                        if (-not $asset) { throw "No PowerShell MSI found for $arch" }
-
-                        $msiPath = Join-Path $env:TEMP "PowerShell-$arch.msi"
-                        try {
-                            Invoke-WebRequest $asset.browser_download_url -OutFile $msiPath -TimeoutSec 300
-
-                            if ($asset.digest) {
-                                $hash = (Get-FileHash $msiPath -Algorithm SHA256).Hash.ToLower()
-                                if ($hash -ne $asset.digest.Replace("sha256:","").ToLower()) { throw "PowerShell MSI SHA256 verification failed" }
-                            }
-
-                            $signature = Get-AuthenticodeSignature $msiPath
-                            if ($signature.Status -ne "Valid" -or $signature.SignerCertificate.Subject -notmatch "Microsoft") {
-                                throw "PowerShell MSI signature verification failed"
-                            }
-
-                            $install = Start-Process msiexec.exe -ArgumentList "/i `"$msiPath`" /qn /norestart" -Wait -PassThru
-                            if ($install.ExitCode -notin @(0,3010,1641)) { throw "PowerShell MSI installation failed with exit code $($install.ExitCode)" }
-
-                            Write-WinUtilLog -Component "Package" -Message "PowerShell MSI upgrade succeeded (exit code $($install.ExitCode))"
-                        } finally {
-                            Remove-Item $msiPath -Force -ErrorAction SilentlyContinue
-                        }
-                    }
-                } catch {
-                    Write-WinUtilLog -Level "ERROR" -Component "Package" -Message "PowerShell MSI upgrade failed: $($_.Exception.Message)"
-                }
-            }
+            Update-WinUtilPowerShellMSI
         }
 
         $source = if ($upgradeAll) { "all configured sources" } else { "winget" }
@@ -108,12 +135,14 @@ Function Install-WinUtilProgramWinget {
             "Uninstall" { @("uninstall", "--id", $program, "--source", $source, "--silent") }
             "Upgrade" {
                 if ($upgradeAll) {
+                    # --include-unknown because the scan that found these ran with it: without it winget
+                    # refuses every package whose installed version it could not read
                     @("upgrade", "--all", "--accept-package-agreements", "--accept-source-agreements", "--include-unknown", "--silent")
                 } else {
                     @("upgrade", "--id", $program, "--accept-package-agreements", "--accept-source-agreements", "--source", $source, "--include-unknown", "--silent")
                 }
             }
-            default { @("install", "--id", $program, "--accept-package-agreements", "--accept-source-agreements", "--source", $source, "--silent") }
+            default     { @("install", "--id", $program, "--accept-package-agreements", "--accept-source-agreements", "--source", $source, "--silent") }
         }
 
         $process = Start-Process -FilePath winget -ArgumentList $arguments -NoNewWindow -Wait -PassThru

--- a/functions/private/Install-WinUtilProgramWinget.ps1
+++ b/functions/private/Install-WinUtilProgramWinget.ps1
@@ -5,48 +5,57 @@ Function Get-WinUtilPowerShellVersion {
 
 Function Update-WinUtilPowerShellMSI {
     $msi = Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*","HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*" -ErrorAction SilentlyContinue |
-        Where-Object { $_.WindowsInstaller -eq 1 -and $_.DisplayName -match "^PowerShell\s+7" -and $_.InstallLocation -and (Test-Path (Join-Path $_.InstallLocation "pwsh.exe")) } |
+        Where-Object {
+            $_.WindowsInstaller -eq 1 -and
+            $_.DisplayName -match "^PowerShell\s+7(?:\s|$)" -and
+            $_.DisplayName -notmatch "preview|daily" -and
+            $_.InstallLocation -and
+            (Test-Path -LiteralPath (Join-Path $_.InstallLocation "pwsh.exe"))
+        } |
         Select-Object -First 1
 
     if (-not $msi) {
         return [pscustomobject]@{
-            State = "NotInstalled"
+            Outcome = "NotInstalled"
             Detail = "PowerShell is not installed through MSI"
         }
     }
 
     try {
         $installed = Get-WinUtilPowerShellVersion (Join-Path $msi.InstallLocation "pwsh.exe")
-        $arch = ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture).ToString().ToLowerInvariant()
         $release = Invoke-RestMethod "https://api.github.com/repos/PowerShell/PowerShell/releases/latest" -TimeoutSec 30
         $latest = ([string]$release.tag_name).TrimStart("v")
 
-        if ($installed -and $latest -and [version]$installed -ge [version]$latest) {
+        if ([version]$installed -ge [version]$latest) {
             Write-WinUtilLog -Component "Package" -Message "PowerShell is already current ($installed)"
             return [pscustomobject]@{
-                State = "Succeeded"
-                Detail = "PowerShell $installed is already current"
+                Outcome = "Skipped"
+                Detail = "PowerShell is already current"
             }
         }
 
-        $asset = $release.assets | Where-Object { $_.name -match "^PowerShell-.*-win-$arch\.msi$" } | Select-Object -First 1
+        $arch = ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture).ToString().ToLowerInvariant()
+        $asset = $release.assets |
+            Where-Object { $_.name -match "^PowerShell-.*-win-$arch\.msi$" } |
+            Select-Object -First 1
+
         if (-not $asset) {
             throw "No PowerShell MSI found for $arch"
         }
 
-        $msiPath = Join-Path $env:TEMP "PowerShell-$arch.msi"
+        $msiPath = Join-Path $env:TEMP "PowerShell-$arch-$([guid]::NewGuid()).msi"
 
         try {
-            Invoke-WebRequest $asset.browser_download_url -OutFile $msiPath -TimeoutSec 300
+            Invoke-WebRequest $asset.browser_download_url -OutFile $msiPath -UseBasicParsing -TimeoutSec 300
 
             if ($asset.digest) {
-                $hash = (Get-FileHash $msiPath -Algorithm SHA256).Hash.ToLower()
-                if ($hash -ne $asset.digest.Replace("sha256:", "").ToLower()) {
+                $hash = (Get-FileHash -LiteralPath $msiPath -Algorithm SHA256).Hash.ToLowerInvariant()
+                if ($hash -ne $asset.digest.Replace("sha256:", "").ToLowerInvariant()) {
                     throw "PowerShell MSI SHA256 verification failed"
                 }
             }
 
-            $signature = Get-AuthenticodeSignature $msiPath
+            $signature = Get-AuthenticodeSignature -LiteralPath $msiPath
             if (
                 $signature.Status -ne "Valid" -or
                 -not $signature.SignerCertificate -or
@@ -56,25 +65,30 @@ Function Update-WinUtilPowerShellMSI {
             }
 
             $install = Start-Process msiexec.exe -ArgumentList "/i `"$msiPath`" /qn /norestart" -Wait -PassThru
-            if ($install.ExitCode -notin @(0, 3010, 1641)) {
+
+            if ($install.ExitCode -notin @(0,3010,1641)) {
                 throw "PowerShell MSI installation failed with exit code $($install.ExitCode)"
             }
 
             Write-WinUtilLog -Component "Package" -Message "PowerShell MSI upgrade succeeded (exit code $($install.ExitCode))"
+
             return [pscustomobject]@{
-                State = "Succeeded"
-                Detail = "PowerShell MSI upgrade succeeded (exit code $($install.ExitCode))"
+                Outcome = "Succeeded"
+                ExitCode = $install.ExitCode
+                Detail = "PowerShell MSI upgrade succeeded"
             }
         }
         finally {
-            Remove-Item $msiPath -Force -ErrorAction SilentlyContinue
+            Remove-Item -LiteralPath $msiPath -Force -ErrorAction SilentlyContinue
         }
     }
     catch {
         Write-WinUtilLog -Level "ERROR" -Component "Package" -Message "PowerShell MSI upgrade failed: $($_.Exception.Message)"
+
         return [pscustomobject]@{
-            State = "Failed"
-            Detail = $_.Exception.Message
+            Outcome = "Failed"
+            ExitCode = -1
+            Detail = "PowerShell MSI upgrade failed: $($_.Exception.Message)"
         }
     }
 }
@@ -113,13 +127,12 @@ Function Install-WinUtilProgramWinget {
         -1978335135 = "already installed"
         -1978335189 = "no applicable update"
     }
+
     # The installer worked and wants a restart to finish. Windows reports that as its own exit
     # code rather than as zero, and treating it as a failure marks working installs as broken.
     $rebootExitCodes = @{
         3010 = "installed, a restart is needed to finish"
         1641 = "installed, the installer started a restart"
-        # WinGet's own equivalents. -1978334966 is deliberately absent: it means a reboot is
-        # required before the install can proceed, which is not a completed install.
         -1978334967 = "installed, a restart is needed to finish"
         -1978334965 = "installed, the installer started a restart"
     }
@@ -130,26 +143,18 @@ Function Install-WinUtilProgramWinget {
         }
 
         $upgradeAll = $Action -eq "Upgrade" -and $program -eq "all"
-        $powerShellMsiResult = $null
 
-        if ($Action -eq "Upgrade" -and ($program -eq "Microsoft.PowerShell" -or $upgradeAll)) {
-            $powerShellMsiResult = Update-WinUtilPowerShellMSI
+        if ($Action -in @("Install", "Upgrade") -and $program -eq "Microsoft.PowerShell") {
+            $result = Update-WinUtilPowerShellMSI
 
-            if ($program -eq "Microsoft.PowerShell" -and $powerShellMsiResult.State -ne "NotInstalled") {
-                $outcome = if ($powerShellMsiResult.State -eq "Succeeded") { "Succeeded" } else { "Failed" }
-                $exitCode = if ($powerShellMsiResult.State -eq "Succeeded") { 0 } else { -1 }
-                $detail = $powerShellMsiResult.Detail
-                $level = if ($outcome -eq "Failed") { "ERROR" } else { "INFO" }
-
-                Write-WinUtilLog -Level $level -Component "Package" -Message "$Action PowerShell MSI package $($outcome.ToLowerInvariant()): $detail"
-
+            if ($result.Outcome -ne "NotInstalled") {
                 [pscustomobject]@{
-                    Package = $program
-                    Manager = "msi"
-                    Action = $Action
-                    ExitCode = $exitCode
-                    Outcome = $outcome
-                    Detail = $detail
+                    Package  = "Microsoft.PowerShell"
+                    Manager  = "msi"
+                    Action   = $Action
+                    ExitCode = $result.ExitCode
+                    Outcome  = $result.Outcome
+                    Detail   = $result.Detail
                 }
 
                 continue
@@ -157,6 +162,7 @@ Function Install-WinUtilProgramWinget {
         }
 
         $source = if ($upgradeAll) { "all configured sources" } else { "winget" }
+
         if (-not $upgradeAll -and $program.StartsWith("msstore:", [System.StringComparison]::OrdinalIgnoreCase)) {
             $source = "msstore"
             $program = $program.Substring("msstore:".Length)
@@ -169,9 +175,9 @@ Function Install-WinUtilProgramWinget {
         $exitCode = -1
 
         $arguments = switch ($Action) {
-            "Uninstall" { @("uninstall", "--id", $program, "--source", $source, "--silent") }
-            # --include-unknown because the scan that found these ran with it: without it winget
-            # refuses every package whose installed version it could not read
+            "Uninstall" {
+                @("uninstall", "--id", $program, "--source", $source, "--silent")
+            }
             "Upgrade" {
                 if ($upgradeAll) {
                     @("upgrade", "--all", "--accept-package-agreements", "--accept-source-agreements", "--include-unknown", "--silent")
@@ -179,7 +185,9 @@ Function Install-WinUtilProgramWinget {
                     @("upgrade", "--id", $program, "--accept-package-agreements", "--accept-source-agreements", "--source", $source, "--include-unknown", "--silent")
                 }
             }
-            default     { @("install", "--id", $program, "--accept-package-agreements", "--accept-source-agreements", "--source", $source, "--silent") }
+            default {
+                @("install", "--id", $program, "--accept-package-agreements", "--accept-source-agreements", "--source", $source, "--silent")
+            }
         }
 
         $process = Start-Process -FilePath winget -ArgumentList $arguments -NoNewWindow -Wait -PassThru
@@ -203,21 +211,20 @@ Function Install-WinUtilProgramWinget {
             }
         } else {
             $outcome = "Failed"
-            # The client module reports the same failure as a bare HRESULT, so the hex form and
-            # Microsoft's own list serve both paths
             $detail = "WinGet reported 0x{0:X8}. See https://learn.microsoft.com/windows/package-manager/winget/returnCodes" -f $exitCode
         }
 
         $level = if ($outcome -eq "Failed") { "ERROR" } else { "INFO" }
+
         Write-WinUtilLog -Level $level -Component "Package" -Message "$Action winget package $($outcome.ToLowerInvariant()): $program ($detail)"
 
         [pscustomobject]@{
-            Package = $program
-            Manager = "winget"
-            Action = $Action
+            Package  = $program
+            Manager  = "winget"
+            Action   = $Action
             ExitCode = $exitCode
-            Outcome = $outcome
-            Detail = $detail
+            Outcome  = $outcome
+            Detail   = $detail
         }
     }
 }

--- a/functions/private/Install-WinUtilProgramWinget.ps1
+++ b/functions/private/Install-WinUtilProgramWinget.ps1
@@ -166,6 +166,8 @@ Function Install-WinUtilProgramWinget {
             }
         } else {
             $outcome = "Failed"
+            # The client module reports the same failure as a bare HRESULT, so the hex form and
+            # Microsoft's own list serve both paths
             $detail = "WinGet reported 0x{0:X8}. See https://learn.microsoft.com/windows/package-manager/winget/returnCodes" -f $exitCode
         }
 

--- a/functions/private/Install-WinUtilProgramWinget.ps1
+++ b/functions/private/Install-WinUtilProgramWinget.ps1
@@ -5,34 +5,29 @@ Function Get-WinUtilPowerShellVersion {
 
 Function Install-WinUtilProgramWinget {
     <#
-
     .SYNOPSIS
         Installs or uninstalls packages with WinGet and reports the outcome of each one
-
     .DESCRIPTION
-        Emits one result object per package so the caller can tell what actually happened.
+        Emits one result object per package so the caller can tell what actually happened
+        rather than assuming the run succeeded.
 
         Runs one winget command per package so a failure names the package that failed rather
         than the whole batch. Progress moves per package: winget hides its own progress bar once
         its output is redirected, so there is nothing to report from inside a single install.
-
     #>
     param (
         [Parameter(Mandatory=$true)]
         [ValidateSet("Install", "Uninstall", "Upgrade")]
         [string]$Action,
-
         [Parameter(Mandatory=$true)]
         [string[]]$Programs
     )
 
     $adminContextProhibited = -1978335107
-
     $nothingToDo = @{
         -1978335135 = "already installed"
         -1978335189 = "no applicable update"
     }
-
     $rebootExitCodes = @{
         3010 = "installed, a restart is needed to finish"
         1641 = "installed, the installer started a restart"
@@ -43,24 +38,13 @@ Function Install-WinUtilProgramWinget {
     }
 
     foreach ($program in $Programs) {
-        if ([string]::IsNullOrWhiteSpace($program) -or $program -eq "na") {
-            continue
-        }
+        if ([string]::IsNullOrWhiteSpace($program) -or $program -eq "na") { continue }
 
         $upgradeAll = $Action -eq "Upgrade" -and $program -eq "all"
 
-        # WinGet cannot upgrade PowerShell when it was installed through MSI.
         if ($Action -eq "Upgrade" -and ($program -eq "Microsoft.PowerShell" -or $upgradeAll)) {
-            $msi = Get-ItemProperty `
-                "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*" ,
-                "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*" `
-                -ErrorAction SilentlyContinue |
-                Where-Object {
-                    $_.WindowsInstaller -eq 1 -and
-                    $_.DisplayName -match "^PowerShell\s+7" -and
-                    $_.InstallLocation -and
-                    (Test-Path (Join-Path $_.InstallLocation "pwsh.exe"))
-                } |
+            $msi = Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*","HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*" -ErrorAction SilentlyContinue |
+                Where-Object { $_.WindowsInstaller -eq 1 -and $_.DisplayName -match "^PowerShell\s+7" -and $_.InstallLocation -and (Test-Path (Join-Path $_.InstallLocation "pwsh.exe")) } |
                 Select-Object -First 1
 
             if ($msi) {
@@ -68,67 +52,47 @@ Function Install-WinUtilProgramWinget {
                     $installed = Get-WinUtilPowerShellVersion (Join-Path $msi.InstallLocation "pwsh.exe")
                     $arch = switch ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture) {
                         "Arm64" { "arm64" }
-                        "X86"   { "x86" }
+                        "X86" { "x86" }
                         default { "x64" }
                     }
-
-                    $release = Invoke-RestMethod `
-                        "https://api.github.com/repos/PowerShell/PowerShell/releases/latest" `
-                        -TimeoutSec 30
+                    $release = Invoke-RestMethod "https://api.github.com/repos/PowerShell/PowerShell/releases/latest" -TimeoutSec 30
                     $latest = ([string]$release.tag_name).TrimStart("v")
 
                     if ($installed -and $latest -and [version]$installed -ge [version]$latest) {
                         Write-WinUtilLog -Component "Package" -Message "PowerShell is already current ($installed)"
-                    }
-                    else {
-                        $asset = $release.assets |
-                            Where-Object { $_.name -match "^PowerShell-.*-win-$arch\.msi$" } |
-                            Select-Object -First 1
-
-                        if (-not $asset) {
-                            throw "No PowerShell MSI found for $arch"
-                        }
+                    } else {
+                        $asset = $release.assets | Where-Object { $_.name -match "^PowerShell-.*-win-$arch\.msi$" } | Select-Object -First 1
+                        if (-not $asset) { throw "No PowerShell MSI found for $arch" }
 
                         $msiPath = Join-Path $env:TEMP "PowerShell-$arch.msi"
+                        try {
+                            Invoke-WebRequest $asset.browser_download_url -OutFile $msiPath -TimeoutSec 300
 
-                        Invoke-WebRequest $asset.browser_download_url -OutFile $msiPath -TimeoutSec 300
-
-                        if ($asset.digest) {
-                            $hash = (Get-FileHash $msiPath -Algorithm SHA256).Hash.ToLower()
-                            if ($hash -ne $asset.digest.Replace("sha256:", "").ToLower()) {
-                                throw "PowerShell MSI SHA256 verification failed"
+                            if ($asset.digest) {
+                                $hash = (Get-FileHash $msiPath -Algorithm SHA256).Hash.ToLower()
+                                if ($hash -ne $asset.digest.Replace("sha256:","").ToLower()) { throw "PowerShell MSI SHA256 verification failed" }
                             }
+
+                            $signature = Get-AuthenticodeSignature $msiPath
+                            if ($signature.Status -ne "Valid" -or $signature.SignerCertificate.Subject -notmatch "Microsoft") {
+                                throw "PowerShell MSI signature verification failed"
+                            }
+
+                            $install = Start-Process msiexec.exe -ArgumentList "/i `"$msiPath`" /qn /norestart" -Wait -PassThru
+                            if ($install.ExitCode -notin @(0,3010,1641)) { throw "PowerShell MSI installation failed with exit code $($install.ExitCode)" }
+
+                            Write-WinUtilLog -Component "Package" -Message "PowerShell MSI upgrade succeeded (exit code $($install.ExitCode))"
+                        } finally {
+                            Remove-Item $msiPath -Force -ErrorAction SilentlyContinue
                         }
-
-                        $signature = Get-AuthenticodeSignature $msiPath
-                        if ($signature.Status -ne "Valid" -or
-                            $signature.SignerCertificate.Subject -notmatch "Microsoft") {
-                            throw "PowerShell MSI signature verification failed"
-                        }
-
-                        $install = Start-Process msiexec.exe `
-                            -ArgumentList "/i `"$msiPath`" /qn /norestart" `
-                            -Wait -PassThru
-
-                        Remove-Item $msiPath -Force -ErrorAction SilentlyContinue
-
-                        if ($install.ExitCode -notin @(0, 3010, 1641)) {
-                            throw "PowerShell MSI installation failed with exit code $($install.ExitCode)"
-                        }
-
-                        Write-WinUtilLog -Component "Package" `
-                            -Message "PowerShell MSI upgrade succeeded (exit code $($install.ExitCode))"
                     }
-                }
-                catch {
-                    Write-WinUtilLog -Level "ERROR" -Component "Package" `
-                        -Message "PowerShell MSI upgrade failed: $($_.Exception.Message)"
+                } catch {
+                    Write-WinUtilLog -Level "ERROR" -Component "Package" -Message "PowerShell MSI upgrade failed: $($_.Exception.Message)"
                 }
             }
         }
 
         $source = if ($upgradeAll) { "all configured sources" } else { "winget" }
-
         if (-not $upgradeAll -and $program.StartsWith("msstore:", [System.StringComparison]::OrdinalIgnoreCase)) {
             $source = "msstore"
             $program = $program.Substring("msstore:".Length)
@@ -141,9 +105,7 @@ Function Install-WinUtilProgramWinget {
         $exitCode = -1
 
         $arguments = switch ($Action) {
-            "Uninstall" {
-                @("uninstall", "--id", $program, "--source", $source, "--silent")
-            }
+            "Uninstall" { @("uninstall", "--id", $program, "--source", $source, "--silent") }
             "Upgrade" {
                 if ($upgradeAll) {
                     @("upgrade", "--all", "--accept-package-agreements", "--accept-source-agreements", "--include-unknown", "--silent")
@@ -151,9 +113,7 @@ Function Install-WinUtilProgramWinget {
                     @("upgrade", "--id", $program, "--accept-package-agreements", "--accept-source-agreements", "--source", $source, "--include-unknown", "--silent")
                 }
             }
-            default {
-                @("install", "--id", $program, "--accept-package-agreements", "--accept-source-agreements", "--source", $source, "--silent")
-            }
+            default { @("install", "--id", $program, "--accept-package-agreements", "--accept-source-agreements", "--source", $source, "--silent") }
         }
 
         $process = Start-Process -FilePath winget -ArgumentList $arguments -NoNewWindow -Wait -PassThru

--- a/pester/powershell-msi-upgrade.Tests.ps1
+++ b/pester/powershell-msi-upgrade.Tests.ps1
@@ -3,11 +3,7 @@ Describe "PowerShell MSI upgrade" {
         . "$PSScriptRoot/../functions/private/Install-WinUtilProgramWinget.ps1"
 
         Mock Write-WinUtilLog {}
-
-        Mock Test-Path {
-            $true
-        }
-
+        Mock Test-Path { $true }
         Mock Remove-Item {}
 
         Mock Get-ItemProperty {
@@ -49,89 +45,54 @@ Describe "PowerShell MSI upgrade" {
 
     It "upgrades MSI-installed PowerShell successfully" {
         Mock Start-Process {
-            [pscustomobject]@{
-                ExitCode = 0
-            }
+            [pscustomobject]@{ ExitCode = 0 }
         }
 
-        $result = Install-WinUtilProgramWinget `
-            -Action Upgrade `
-            -Programs @("Microsoft.PowerShell")
+        $result = Update-WinUtilPowerShellMSI
 
+        $result | Should -BeTrue
         Should -Invoke Get-ItemProperty -Times 1
         Should -Invoke Get-WinUtilPowerShellVersion -Times 1
         Should -Invoke Invoke-RestMethod -Times 1
         Should -Invoke Invoke-WebRequest -Times 1
         Should -Invoke Get-AuthenticodeSignature -Times 1
-        Should -Invoke Start-Process -Times 2
+        Should -Invoke Start-Process -Times 1
     }
 
-    It "treats MSI upgrade exit code 3010 as success" {
+    It "treats MSI exit code 3010 as success" {
         Mock Start-Process {
-            param($FilePath)
-
-            if ($FilePath -eq "msiexec.exe") {
-                [pscustomobject]@{
-                    ExitCode = 3010
-                }
-            }
-            else {
-                [pscustomobject]@{
-                    ExitCode = 0
-                }
-            }
+            [pscustomobject]@{ ExitCode = 3010 }
         }
 
-        Install-WinUtilProgramWinget `
-            -Action Upgrade `
-            -Programs @("Microsoft.PowerShell")
+        $result = Update-WinUtilPowerShellMSI
 
-        Should -Invoke Start-Process -Times 2
+        $result | Should -BeTrue
+        Should -Invoke Write-WinUtilLog -ParameterFilter {
+            $Message -match "PowerShell MSI upgrade succeeded"
+        }
     }
 
-    It "treats MSI upgrade exit code 1641 as success" {
+    It "treats MSI exit code 1641 as success" {
         Mock Start-Process {
-            param($FilePath)
-
-            if ($FilePath -eq "msiexec.exe") {
-                [pscustomobject]@{
-                    ExitCode = 1641
-                }
-            }
-            else {
-                [pscustomobject]@{
-                    ExitCode = 0
-                }
-            }
+            [pscustomobject]@{ ExitCode = 1641 }
         }
 
-        Install-WinUtilProgramWinget `
-            -Action Upgrade `
-            -Programs @("Microsoft.PowerShell")
+        $result = Update-WinUtilPowerShellMSI
 
-        Should -Invoke Start-Process -Times 2
+        $result | Should -BeTrue
+        Should -Invoke Write-WinUtilLog -ParameterFilter {
+            $Message -match "PowerShell MSI upgrade succeeded"
+        }
     }
 
-    It "logs an error when MSI installation fails" {
+    It "reports MSI installation failure" {
         Mock Start-Process {
-            param($FilePath)
-
-            if ($FilePath -eq "msiexec.exe") {
-                [pscustomobject]@{
-                    ExitCode = 1603
-                }
-            }
-            else {
-                [pscustomobject]@{
-                    ExitCode = 0
-                }
-            }
+            [pscustomobject]@{ ExitCode = 1603 }
         }
 
-        Install-WinUtilProgramWinget `
-            -Action Upgrade `
-            -Programs @("Microsoft.PowerShell")
+        $result = Update-WinUtilPowerShellMSI
 
+        $result | Should -BeFalse
         Should -Invoke Write-WinUtilLog -ParameterFilter {
             $Level -eq "ERROR" -and
             $Message -match "PowerShell MSI upgrade failed"
@@ -143,19 +104,34 @@ Describe "PowerShell MSI upgrade" {
             "7.5.3"
         }
 
-        Install-WinUtilProgramWinget `
-            -Action Upgrade `
-            -Programs @("Microsoft.PowerShell")
+        $result = Update-WinUtilPowerShellMSI
 
+        $result | Should -BeTrue
         Should -Invoke Invoke-RestMethod -Times 1
         Should -Invoke Invoke-WebRequest -Times 0
         Should -Invoke Get-AuthenticodeSignature -Times 0
+        Should -Invoke Start-Process -Times 0
+    }
+
+    It "returns false when PowerShell is not MSI-installed" {
+        Mock Get-ItemProperty {
+            $null
+        }
+
+        $result = Update-WinUtilPowerShellMSI
+
+        $result | Should -BeFalse
+        Should -Invoke Invoke-RestMethod -Times 0
+        Should -Invoke Invoke-WebRequest -Times 0
+        Should -Invoke Start-Process -Times 0
     }
 
     It "checks MSI-installed PowerShell during Upgrade All" {
-        Install-WinUtilProgramWinget `
-            -Action Upgrade `
-            -Programs @("all")
+        Mock Start-Process {
+            [pscustomobject]@{ ExitCode = 0 }
+        }
+
+        Install-WinUtilProgramWinget -Action Upgrade -Programs @("all")
 
         Should -Invoke Get-ItemProperty -Times 1
         Should -Invoke Get-WinUtilPowerShellVersion -Times 1
@@ -168,9 +144,7 @@ Describe "PowerShell MSI upgrade" {
         }
 
         Mock Start-Process {
-            [pscustomobject]@{
-                ExitCode = 0
-            }
+            [pscustomobject]@{ ExitCode = 0 }
         }
 
         $result = Install-WinUtilProgramWinget `
@@ -179,6 +153,7 @@ Describe "PowerShell MSI upgrade" {
 
         Should -Invoke Invoke-RestMethod -Times 0
         Should -Invoke Invoke-WebRequest -Times 0
+        Should -Invoke Get-AuthenticodeSignature -Times 0
         Should -Invoke Start-Process -Times 1
     }
 }

--- a/pester/powershell-msi-upgrade.Tests.ps1
+++ b/pester/powershell-msi-upgrade.Tests.ps1
@@ -11,12 +11,11 @@ Describe "PowerShell MSI upgrade" {
                 WindowsInstaller = 1
                 DisplayName = "PowerShell 7"
                 InstallLocation = "C:\Program Files\PowerShell\7"
+                DisplayVersion = "7.5.2"
             }
         }
 
-        Mock Get-WinUtilPowerShellVersion {
-            "7.5.2"
-        }
+        Mock Get-WinUtilPowerShellVersion { "7.5.2" }
 
         Mock Invoke-RestMethod {
             [pscustomobject]@{
@@ -32,119 +31,89 @@ Describe "PowerShell MSI upgrade" {
         }
 
         Mock Invoke-WebRequest {}
-
         Mock Get-AuthenticodeSignature {
             [pscustomobject]@{
                 Status = "Valid"
                 SignerCertificate = [pscustomobject]@{
-                    Subject = "CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"
+                    Subject = "CN=Microsoft Corporation"
                 }
             }
         }
     }
 
-    It "upgrades MSI-installed PowerShell successfully" {
-        Mock Start-Process {
-            [pscustomobject]@{ ExitCode = 0 }
-        }
+    It "upgrades MSI PowerShell successfully" {
+        Mock Start-Process { [pscustomobject]@{ ExitCode = 0 } }
 
         $result = Update-WinUtilPowerShellMSI
 
-        $result.State | Should -Be "Succeeded"
-        Should -Invoke Get-ItemProperty -Times 1
-        Should -Invoke Get-WinUtilPowerShellVersion -Times 1
-        Should -Invoke Invoke-RestMethod -Times 1
+        $result.Outcome | Should -Be "Succeeded"
         Should -Invoke Invoke-WebRequest -Times 1
         Should -Invoke Get-AuthenticodeSignature -Times 1
         Should -Invoke Start-Process -Times 1
     }
 
-    It "treats MSI exit code 3010 as success" {
-        Mock Start-Process {
-            [pscustomobject]@{ ExitCode = 3010 }
-        }
+    It "treats 3010 and 1641 as successful MSI upgrades" {
+        foreach ($exitCode in @(3010, 1641)) {
+            Mock Start-Process { [pscustomobject]@{ ExitCode = $exitCode } }
 
-        $result = Update-WinUtilPowerShellMSI
+            $result = Update-WinUtilPowerShellMSI
 
-        $result.State | Should -Be "Succeeded"
-        Should -Invoke Write-WinUtilLog -ParameterFilter {
-            $Message -match "PowerShell MSI upgrade succeeded"
-        }
-    }
+            $result.Outcome | Should -Be "Succeeded"
+            $result.ExitCode | Should -Be $exitCode
 
-    It "treats MSI exit code 1641 as success" {
-        Mock Start-Process {
-            [pscustomobject]@{ ExitCode = 1641 }
-        }
-
-        $result = Update-WinUtilPowerShellMSI
-
-        $result.State | Should -Be "Succeeded"
-        Should -Invoke Write-WinUtilLog -ParameterFilter {
-            $Message -match "PowerShell MSI upgrade succeeded"
+            Should -Invoke Start-Process -Times 1
         }
     }
 
     It "reports MSI installation failure" {
-        Mock Start-Process {
-            [pscustomobject]@{ ExitCode = 1603 }
-        }
+        Mock Start-Process { [pscustomobject]@{ ExitCode = 1603 } }
 
         $result = Update-WinUtilPowerShellMSI
 
-        $result.State | Should -Be "Failed"
+        $result.Outcome | Should -Be "Failed"
         Should -Invoke Write-WinUtilLog -ParameterFilter {
-            $Level -eq "ERROR" -and
-            $Message -match "PowerShell MSI upgrade failed"
+            $Level -eq "ERROR"
         }
     }
 
-    It "does not download when PowerShell is already current" {
-        Mock Get-WinUtilPowerShellVersion {
-            "7.5.3"
-        }
+    It "skips download when PowerShell is already current" {
+        Mock Get-WinUtilPowerShellVersion { "7.5.3" }
+        Mock Start-Process { [pscustomobject]@{ ExitCode = 0 } }
 
         $result = Update-WinUtilPowerShellMSI
 
-        $result.State | Should -Be "Succeeded"
-        Should -Invoke Invoke-RestMethod -Times 1
+        $result.Outcome | Should -Be "Skipped"
         Should -Invoke Invoke-WebRequest -Times 0
-        Should -Invoke Get-AuthenticodeSignature -Times 0
         Should -Invoke Start-Process -Times 0
     }
 
     It "returns NotInstalled when PowerShell is not MSI-installed" {
-        Mock Get-ItemProperty {
-            $null
-        }
+        Mock Get-ItemProperty { $null }
 
         $result = Update-WinUtilPowerShellMSI
 
-        $result.State | Should -Be "NotInstalled"
+        $result.Outcome | Should -Be "NotInstalled"
         Should -Invoke Invoke-RestMethod -Times 0
-        Should -Invoke Invoke-WebRequest -Times 0
         Should -Invoke Start-Process -Times 0
     }
 
-    It "rejects a missing signer certificate" {
+    It "rejects an invalid or missing signer certificate" {
         Mock Get-AuthenticodeSignature {
             [pscustomobject]@{
-                Status = "Valid"
+                Status = "NotTrusted"
                 SignerCertificate = $null
             }
         }
 
-        Mock Start-Process {
-            [pscustomobject]@{ ExitCode = 0 }
-        }
+        Mock Start-Process { [pscustomobject]@{ ExitCode = 0 } }
 
         $result = Update-WinUtilPowerShellMSI
 
-        $result.State | Should -Be "Failed"
+        $result.Outcome | Should -Be "Failed"
         Should -Invoke Start-Process -Times 0
     }
 
-    It "rejects a trusted non-Microsoft certificate containing Microsoft in the subject" {
+    It "rejects a non-Microsoft certificate containing Microsoft" {
         Mock Get-AuthenticodeSignature {
             [pscustomobject]@{
                 Status = "Valid"
@@ -154,76 +123,119 @@ Describe "PowerShell MSI upgrade" {
             }
         }
 
-        Mock Start-Process {
-            [pscustomobject]@{ ExitCode = 0 }
+        Mock Start-Process { [pscustomobject]@{ ExitCode = 0 } }
+
+        $result = Update-WinUtilPowerShellMSI
+
+        $result.Outcome | Should -Be "Failed"
+        Should -Invoke Start-Process -Times 0
+    }
+
+    It "rejects a mismatched SHA256 digest" {
+        Mock Invoke-RestMethod {
+            [pscustomobject]@{
+                tag_name = "v7.5.3"
+                assets = @(
+                    [pscustomobject]@{
+                        name = "PowerShell-7.5.3-win-x64.msi"
+                        browser_download_url = "https://example.com/PowerShell.msi"
+                        digest = "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+                    }
+                )
+            }
+        }
+
+        Mock Get-FileHash {
+            [pscustomobject]@{
+                Hash = "1111111111111111111111111111111111111111111111111111111111111111"
+            }
+        }
+
+        Mock Start-Process { [pscustomobject]@{ ExitCode = 0 } }
+
+        $result = Update-WinUtilPowerShellMSI
+
+        $result.Outcome | Should -Be "Failed"
+        Should -Invoke Start-Process -Times 0
+    }
+
+    It "uses MSI for selected PowerShell Install and Upgrade" {
+        Mock Start-Process { [pscustomobject]@{ ExitCode = 0 } }
+
+        foreach ($action in @("Install", "Upgrade")) {
+            $result = Install-WinUtilProgramWinget `
+                -Action $action `
+                -Programs @("Microsoft.PowerShell")
+
+            $result.Package | Should -Be "Microsoft.PowerShell"
+            $result.Manager | Should -Be "msi"
+            $result.Outcome | Should -Be "Succeeded"
+        }
+
+        Should -Invoke Start-Process -Times 2
+    }
+
+    It "falls back to WinGet when PowerShell is not MSI-installed" {
+        Mock Get-ItemProperty { $null }
+        Mock Start-Process { [pscustomobject]@{ ExitCode = 0 } }
+
+        $result = Install-WinUtilProgramWinget `
+            -Action Upgrade `
+            -Programs @("Microsoft.PowerShell")
+
+        $result.Manager | Should -Be "winget"
+        $result.Outcome | Should -Be "Succeeded"
+        Should -Invoke Start-Process -Times 1
+    }
+
+    It "does not fall through to WinGet after MSI handling" {
+        Mock Start-Process { [pscustomobject]@{ ExitCode = 0 } }
+
+        $result = Install-WinUtilProgramWinget `
+            -Action Upgrade `
+            -Programs @("Microsoft.PowerShell")
+
+        $result.Manager | Should -Be "msi"
+        $result.Outcome | Should -Be "Succeeded"
+
+        Should -Invoke Start-Process -Times 1 -ParameterFilter {
+            $FilePath -eq "msiexec.exe"
+        }
+    }
+
+    It "does not use WinGet all when MSI PowerShell is detected" {
+        Mock Start-Process { [pscustomobject]@{ ExitCode = 0 } }
+
+        Install-WinUtilProgramWinget `
+            -Action Upgrade `
+            -Programs @("all")
+
+        Should -Invoke Start-Process -Times 0 -ParameterFilter {
+            $FilePath -eq "winget" -and
+            $ArgumentList -contains "--all"
+        }
+    }
+
+    It "ignores PowerShell preview installations" {
+        Mock Get-ItemProperty {
+            @(
+                [pscustomobject]@{
+                    WindowsInstaller = 1
+                    DisplayName = "PowerShell 7-preview"
+                    InstallLocation = "C:\PowerShell\preview"
+                    DisplayVersion = "7.6.0-preview"
+                },
+                [pscustomobject]@{
+                    WindowsInstaller = 1
+                    DisplayName = "PowerShell 7"
+                    InstallLocation = "C:\PowerShell\7"
+                    DisplayVersion = "7.5.2"
+                }
+            )
         }
 
         $result = Update-WinUtilPowerShellMSI
 
-        $result.State | Should -Be "Failed"
-        Should -Invoke Start-Process -Times 0
-    }
-
-    It "does not run WinGet after a successful MSI PowerShell upgrade" {
-        Mock Start-Process {
-            [pscustomobject]@{ ExitCode = 0 }
-        }
-
-        $result = Install-WinUtilProgramWinget `
-            -Action Upgrade `
-            -Programs @("Microsoft.PowerShell")
-
-        $result.Outcome | Should -Be "Succeeded"
-        $result.Manager | Should -Be "msi"
-        Should -Invoke Start-Process -Times 1
-    }
-
-    It "does not run WinGet after a failed MSI PowerShell upgrade" {
-        Mock Start-Process {
-            [pscustomobject]@{ ExitCode = 1603 }
-        }
-
-        $result = Install-WinUtilProgramWinget `
-            -Action Upgrade `
-            -Programs @("Microsoft.PowerShell")
-
-        $result.Outcome | Should -Be "Failed"
-        $result.Manager | Should -Be "msi"
-        Should -Invoke Start-Process -Times 1
-    }
-
-    It "falls back to WinGet when PowerShell is not MSI-installed" {
-        Mock Get-ItemProperty {
-            $null
-        }
-
-        Mock Start-Process {
-            [pscustomobject]@{ ExitCode = 0 }
-        }
-
-        $result = Install-WinUtilProgramWinget `
-            -Action Upgrade `
-            -Programs @("Microsoft.PowerShell")
-
-        $result.Outcome | Should -Be "Succeeded"
-        $result.Manager | Should -Be "winget"
-        Should -Invoke Invoke-RestMethod -Times 0
-        Should -Invoke Invoke-WebRequest -Times 0
-        Should -Invoke Get-AuthenticodeSignature -Times 0
-        Should -Invoke Start-Process -Times 1
-    }
-
-    It "checks MSI-installed PowerShell during Upgrade All" {
-        Mock Start-Process {
-            [pscustomobject]@{ ExitCode = 0 }
-        }
-
-        $result = Install-WinUtilProgramWinget `
-            -Action Upgrade `
-            -Programs @("all")
-
-        Should -Invoke Get-ItemProperty -Times 1
-        Should -Invoke Get-WinUtilPowerShellVersion -Times 1
-        Should -Invoke Invoke-RestMethod -Times 1
+        $result.Outcome | Should -Not -Be "NotInstalled"
     }
 }

--- a/pester/powershell-msi-upgrade.Tests.ps1
+++ b/pester/powershell-msi-upgrade.Tests.ps1
@@ -1,0 +1,184 @@
+Describe "PowerShell MSI upgrade" {
+    BeforeAll {
+        . "$PSScriptRoot/../functions/private/Install-WinUtilProgramWinget.ps1"
+
+        Mock Write-WinUtilLog {}
+
+        Mock Test-Path {
+            $true
+        }
+
+        Mock Remove-Item {}
+
+        Mock Get-ItemProperty {
+            [pscustomobject]@{
+                WindowsInstaller = 1
+                DisplayName = "PowerShell 7"
+                InstallLocation = "C:\Program Files\PowerShell\7"
+            }
+        }
+
+        Mock Get-WinUtilPowerShellVersion {
+            "7.5.2"
+        }
+
+        Mock Invoke-RestMethod {
+            [pscustomobject]@{
+                tag_name = "v7.5.3"
+                assets = @(
+                    [pscustomobject]@{
+                        name = "PowerShell-7.5.3-win-x64.msi"
+                        browser_download_url = "https://example.com/PowerShell.msi"
+                        digest = $null
+                    }
+                )
+            }
+        }
+
+        Mock Invoke-WebRequest {}
+
+        Mock Get-AuthenticodeSignature {
+            [pscustomobject]@{
+                Status = "Valid"
+                SignerCertificate = [pscustomobject]@{
+                    Subject = "CN=Microsoft Corporation"
+                }
+            }
+        }
+    }
+
+    It "upgrades MSI-installed PowerShell successfully" {
+        Mock Start-Process {
+            [pscustomobject]@{
+                ExitCode = 0
+            }
+        }
+
+        $result = Install-WinUtilProgramWinget `
+            -Action Upgrade `
+            -Programs @("Microsoft.PowerShell")
+
+        Should -Invoke Get-ItemProperty -Times 1
+        Should -Invoke Get-WinUtilPowerShellVersion -Times 1
+        Should -Invoke Invoke-RestMethod -Times 1
+        Should -Invoke Invoke-WebRequest -Times 1
+        Should -Invoke Get-AuthenticodeSignature -Times 1
+        Should -Invoke Start-Process -Times 2
+    }
+
+    It "treats MSI upgrade exit code 3010 as success" {
+        Mock Start-Process {
+            param($FilePath)
+
+            if ($FilePath -eq "msiexec.exe") {
+                [pscustomobject]@{
+                    ExitCode = 3010
+                }
+            }
+            else {
+                [pscustomobject]@{
+                    ExitCode = 0
+                }
+            }
+        }
+
+        Install-WinUtilProgramWinget `
+            -Action Upgrade `
+            -Programs @("Microsoft.PowerShell")
+
+        Should -Invoke Start-Process -Times 2
+    }
+
+    It "treats MSI upgrade exit code 1641 as success" {
+        Mock Start-Process {
+            param($FilePath)
+
+            if ($FilePath -eq "msiexec.exe") {
+                [pscustomobject]@{
+                    ExitCode = 1641
+                }
+            }
+            else {
+                [pscustomobject]@{
+                    ExitCode = 0
+                }
+            }
+        }
+
+        Install-WinUtilProgramWinget `
+            -Action Upgrade `
+            -Programs @("Microsoft.PowerShell")
+
+        Should -Invoke Start-Process -Times 2
+    }
+
+    It "logs an error when MSI installation fails" {
+        Mock Start-Process {
+            param($FilePath)
+
+            if ($FilePath -eq "msiexec.exe") {
+                [pscustomobject]@{
+                    ExitCode = 1603
+                }
+            }
+            else {
+                [pscustomobject]@{
+                    ExitCode = 0
+                }
+            }
+        }
+
+        Install-WinUtilProgramWinget `
+            -Action Upgrade `
+            -Programs @("Microsoft.PowerShell")
+
+        Should -Invoke Write-WinUtilLog -ParameterFilter {
+            $Level -eq "ERROR" -and
+            $Message -match "PowerShell MSI upgrade failed"
+        }
+    }
+
+    It "does not download when PowerShell is already current" {
+        Mock Get-WinUtilPowerShellVersion {
+            "7.5.3"
+        }
+
+        Install-WinUtilProgramWinget `
+            -Action Upgrade `
+            -Programs @("Microsoft.PowerShell")
+
+        Should -Invoke Invoke-RestMethod -Times 1
+        Should -Invoke Invoke-WebRequest -Times 0
+        Should -Invoke Get-AuthenticodeSignature -Times 0
+    }
+
+    It "checks MSI-installed PowerShell during Upgrade All" {
+        Install-WinUtilProgramWinget `
+            -Action Upgrade `
+            -Programs @("all")
+
+        Should -Invoke Get-ItemProperty -Times 1
+        Should -Invoke Get-WinUtilPowerShellVersion -Times 1
+        Should -Invoke Invoke-RestMethod -Times 1
+    }
+
+    It "falls back to WinGet when PowerShell is not MSI-installed" {
+        Mock Get-ItemProperty {
+            $null
+        }
+
+        Mock Start-Process {
+            [pscustomobject]@{
+                ExitCode = 0
+            }
+        }
+
+        $result = Install-WinUtilProgramWinget `
+            -Action Upgrade `
+            -Programs @("Microsoft.PowerShell")
+
+        Should -Invoke Invoke-RestMethod -Times 0
+        Should -Invoke Invoke-WebRequest -Times 0
+        Should -Invoke Start-Process -Times 1
+    }
+}

--- a/pester/powershell-msi-upgrade.Tests.ps1
+++ b/pester/powershell-msi-upgrade.Tests.ps1
@@ -37,7 +37,7 @@ Describe "PowerShell MSI upgrade" {
             [pscustomobject]@{
                 Status = "Valid"
                 SignerCertificate = [pscustomobject]@{
-                    Subject = "CN=Microsoft Corporation"
+                    Subject = "CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"
                 }
             }
         }
@@ -50,7 +50,7 @@ Describe "PowerShell MSI upgrade" {
 
         $result = Update-WinUtilPowerShellMSI
 
-        $result | Should -BeTrue
+        $result.State | Should -Be "Succeeded"
         Should -Invoke Get-ItemProperty -Times 1
         Should -Invoke Get-WinUtilPowerShellVersion -Times 1
         Should -Invoke Invoke-RestMethod -Times 1
@@ -66,7 +66,7 @@ Describe "PowerShell MSI upgrade" {
 
         $result = Update-WinUtilPowerShellMSI
 
-        $result | Should -BeTrue
+        $result.State | Should -Be "Succeeded"
         Should -Invoke Write-WinUtilLog -ParameterFilter {
             $Message -match "PowerShell MSI upgrade succeeded"
         }
@@ -79,7 +79,7 @@ Describe "PowerShell MSI upgrade" {
 
         $result = Update-WinUtilPowerShellMSI
 
-        $result | Should -BeTrue
+        $result.State | Should -Be "Succeeded"
         Should -Invoke Write-WinUtilLog -ParameterFilter {
             $Message -match "PowerShell MSI upgrade succeeded"
         }
@@ -92,7 +92,7 @@ Describe "PowerShell MSI upgrade" {
 
         $result = Update-WinUtilPowerShellMSI
 
-        $result | Should -BeFalse
+        $result.State | Should -Be "Failed"
         Should -Invoke Write-WinUtilLog -ParameterFilter {
             $Level -eq "ERROR" -and
             $Message -match "PowerShell MSI upgrade failed"
@@ -106,36 +106,90 @@ Describe "PowerShell MSI upgrade" {
 
         $result = Update-WinUtilPowerShellMSI
 
-        $result | Should -BeTrue
+        $result.State | Should -Be "Succeeded"
         Should -Invoke Invoke-RestMethod -Times 1
         Should -Invoke Invoke-WebRequest -Times 0
         Should -Invoke Get-AuthenticodeSignature -Times 0
         Should -Invoke Start-Process -Times 0
     }
 
-    It "returns false when PowerShell is not MSI-installed" {
+    It "returns NotInstalled when PowerShell is not MSI-installed" {
         Mock Get-ItemProperty {
             $null
         }
 
         $result = Update-WinUtilPowerShellMSI
 
-        $result | Should -BeFalse
+        $result.State | Should -Be "NotInstalled"
         Should -Invoke Invoke-RestMethod -Times 0
         Should -Invoke Invoke-WebRequest -Times 0
         Should -Invoke Start-Process -Times 0
     }
 
-    It "checks MSI-installed PowerShell during Upgrade All" {
+    It "rejects a missing signer certificate" {
+        Mock Get-AuthenticodeSignature {
+            [pscustomobject]@{
+                Status = "Valid"
+                SignerCertificate = $null
+            }
+        }
+
         Mock Start-Process {
             [pscustomobject]@{ ExitCode = 0 }
         }
 
-        Install-WinUtilProgramWinget -Action Upgrade -Programs @("all")
+        $result = Update-WinUtilPowerShellMSI
 
-        Should -Invoke Get-ItemProperty -Times 1
-        Should -Invoke Get-WinUtilPowerShellVersion -Times 1
-        Should -Invoke Invoke-RestMethod -Times 1
+        $result.State | Should -Be "Failed"
+        Should -Invoke Start-Process -Times 0
+    }
+
+    It "rejects a trusted non-Microsoft certificate containing Microsoft in the subject" {
+        Mock Get-AuthenticodeSignature {
+            [pscustomobject]@{
+                Status = "Valid"
+                SignerCertificate = [pscustomobject]@{
+                    Subject = "CN=Microsoft Malware Research"
+                }
+            }
+        }
+
+        Mock Start-Process {
+            [pscustomobject]@{ ExitCode = 0 }
+        }
+
+        $result = Update-WinUtilPowerShellMSI
+
+        $result.State | Should -Be "Failed"
+        Should -Invoke Start-Process -Times 0
+    }
+
+    It "does not run WinGet after a successful MSI PowerShell upgrade" {
+        Mock Start-Process {
+            [pscustomobject]@{ ExitCode = 0 }
+        }
+
+        $result = Install-WinUtilProgramWinget `
+            -Action Upgrade `
+            -Programs @("Microsoft.PowerShell")
+
+        $result.Outcome | Should -Be "Succeeded"
+        $result.Manager | Should -Be "msi"
+        Should -Invoke Start-Process -Times 1
+    }
+
+    It "does not run WinGet after a failed MSI PowerShell upgrade" {
+        Mock Start-Process {
+            [pscustomobject]@{ ExitCode = 1603 }
+        }
+
+        $result = Install-WinUtilProgramWinget `
+            -Action Upgrade `
+            -Programs @("Microsoft.PowerShell")
+
+        $result.Outcome | Should -Be "Failed"
+        $result.Manager | Should -Be "msi"
+        Should -Invoke Start-Process -Times 1
     }
 
     It "falls back to WinGet when PowerShell is not MSI-installed" {
@@ -151,9 +205,25 @@ Describe "PowerShell MSI upgrade" {
             -Action Upgrade `
             -Programs @("Microsoft.PowerShell")
 
+        $result.Outcome | Should -Be "Succeeded"
+        $result.Manager | Should -Be "winget"
         Should -Invoke Invoke-RestMethod -Times 0
         Should -Invoke Invoke-WebRequest -Times 0
         Should -Invoke Get-AuthenticodeSignature -Times 0
         Should -Invoke Start-Process -Times 1
+    }
+
+    It "checks MSI-installed PowerShell during Upgrade All" {
+        Mock Start-Process {
+            [pscustomobject]@{ ExitCode = 0 }
+        }
+
+        $result = Install-WinUtilProgramWinget `
+            -Action Upgrade `
+            -Programs @("all")
+
+        Should -Invoke Get-ItemProperty -Times 1
+        Should -Invoke Get-WinUtilPowerShellVersion -Times 1
+        Should -Invoke Invoke-RestMethod -Times 1
     }
 }


### PR DESCRIPTION
 Type of Change

* [ ] New feature
* [x] Bug fix
* [ ] Documentation update
* [ ] Refactor
* [ ] UI/UX improvement

## Description

Fixes PowerShell 7 upgrades when PowerShell was originally installed using the official MSI installer.

WinGet can fail to upgrade PowerShell when the installed version uses MSI but the WinGet package uses a different installation technology. This change detects MSI-installed PowerShell 7 and upgrades it using the official PowerShell MSI when an update is available.

### Changes

* Detects MSI-installed PowerShell 7 installations.
* Uses the latest PowerShell release from GitHub.
* Selects the MSI matching the system architecture.
* Checks the installed version before downloading.
* Supports the `Upgrade All` workflow.
* Verifies the downloaded MSI using its SHA-256 digest when available.
* Verifies the MSI Authenticode signature.
* Handles MSI success/reboot exit codes `0`, `3010`, and `1641`.
* Falls back to the existing WinGet behavior when PowerShell is not MSI-installed.
* Adds focused Pester tests for the new MSI upgrade path.

## Issue related to PR

* Resolves #4977
