### PR TITLE
feat(app): add PsTools to applications.json

### DIFF
--- a/config/applications.json
+++ b/config/applications.json
@@ -1384,6 +1384,15 @@
         "winget": "Microsoft.Sysinternals.ProcessMonitor",
         "foss": false
     },
+    "pstools": {
+        "category": "Microsoft Tools",
+        "choco": "pstools",
+        "content": "PsTools",
+        "description": "Microsoft Sysinternals PsTools allows administrators to execute command shells with SYSTEM privileges to access protected areas, monitor processes, and manage remote systems.",
+        "link": "https://learn.microsoft.com/en-us/sysinternals/downloads/pstools",
+        "winget": "Microsoft.Sysinternals.PsTools",
+        "foss": false
+    },
     "putty": {
         "category": "Pro Tools",
         "choco": "putty",


### PR DESCRIPTION
<!--Before you make this PR have you followed the docs here? - https://winutil.christitus.com/contributing/ -->
<!--Documentation is auto-generated from configs - no manual documentation updates needed -->

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactor
- [ ] UI/UX improvement

<!-- This automatically adds labels to your PR based on the selections above. -->

## Description
Accessing the `System Volume Information` folder, Windows recovery partition folders, and restricted Registry keys requires more than standard Administrator privileges due to native Windows protections.

PsTools allows the use of the `psexec.exe -i -s` command to elevate the execution of specific processes—such as `cmd.exe` or `explorer.exe`—to the `NT AUTHORITY\SYSTEM` level.

A few other functinalities include:
- PsList: Monitor threads and memory in detail.
- PsSuspend: Pause processes without losing current progress.
- PsFile: Identify and close locked network files.
- PsPing: Test latency for specific TCP ports.

## Issue related to PR
<!--[List any ISSUES this is related to as it AUTO-CLOSES Them!]-->
None.
